### PR TITLE
feat(slack): add SlackConnector and E2E integration tests

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -59,6 +59,7 @@ VibeTeam/
 | `LangfuseConnector` | LLM observability |
 | `HealthConnector` | Endpoint monitoring |
 | `GmailConnector` | Email processing |
+| `SlackConnector` | Slack messaging |
 
 ## Environment Variables
 
@@ -88,5 +89,12 @@ Use `GitHubConnector.get_customer_requests_table()` to read/update.
 
 ## Current Work
 
-**Active Issue: #38** - Deploy VibeTeam to Kubernetes and verify integrations
-https://github.com/VibeTechnologies/VibeTeam/issues/38
+**Active Issue: #39** - CrewAI tool calling hallucinates outputs with Azure GPT-5
+https://github.com/VibeTechnologies/VibeTeam/issues/39
+
+**Active PR: #41** - SlackConnector and E2E integration tests
+https://github.com/VibeTechnologies/VibeTeam/pull/41
+
+### Recently Closed
+- #38 - Deploy VibeTeam to Kubernetes (completed)
+- #40 - SlackConnector feature (PR #41 in review)

--- a/tests/test_slack_integration.py
+++ b/tests/test_slack_integration.py
@@ -1,0 +1,338 @@
+"""
+Slack Integration Tests.
+
+Real integration tests for Slack messaging via SlackConnector.
+These tests require valid SLACK_BOT_TOKEN to be set.
+
+Run with:
+    pytest tests/test_slack_integration.py -v --run-integration
+
+Environment variables required:
+    SLACK_BOT_TOKEN - Bot OAuth token (xoxb-...)
+    SLACK_TEST_CHANNEL - Test channel name (default: #ai-team-test)
+"""
+
+import os
+import time
+import uuid
+
+import pytest
+
+from vibeteam.connectors.slack import SlackAPIError, SlackConnector
+
+
+# Skip all tests if no Slack token
+pytestmark = pytest.mark.integration
+
+
+@pytest.fixture(scope="module")
+def slack_connector():
+    """Create a SlackConnector for the test module."""
+    token = os.environ.get("SLACK_BOT_TOKEN")
+    if not token:
+        pytest.skip("SLACK_BOT_TOKEN not set")
+    connector = SlackConnector(bot_token=token)
+    yield connector
+    connector.close()
+
+
+@pytest.fixture(scope="module")
+def test_channel():
+    """Get test channel name."""
+    return os.environ.get("SLACK_TEST_CHANNEL", "#ai-team-test")
+
+
+class TestSlackConnectorBasics:
+    """Basic SlackConnector functionality tests."""
+
+    def test_connector_initialization(self, slack_connector: SlackConnector):
+        """Test connector initializes correctly."""
+        assert slack_connector.bot_token
+        assert slack_connector.client is not None
+
+    def test_list_channels(self, slack_connector: SlackConnector):
+        """Test listing available channels."""
+        channels = slack_connector.list_channels()
+        assert isinstance(channels, list)
+        # Should have at least one channel
+        assert len(channels) > 0
+        # Each channel should have required fields
+        for ch in channels[:3]:  # Check first 3
+            assert ch.id
+            assert ch.name
+            print(f"  Found channel: #{ch.name} ({ch.id})")
+
+    def test_get_channel_by_name(self, slack_connector: SlackConnector, test_channel: str):
+        """Test getting channel by name."""
+        channel = slack_connector.get_channel_by_name(test_channel)
+        if channel:
+            assert channel.name == test_channel.lstrip("#")
+            print(f"  Found test channel: #{channel.name} ({channel.id})")
+        else:
+            pytest.skip(f"Test channel {test_channel} not found")
+
+
+class TestSlackMessaging:
+    """Test Slack message sending and receiving."""
+
+    def test_send_message(self, slack_connector: SlackConnector, test_channel: str):
+        """Test sending a message to a channel."""
+        test_id = str(uuid.uuid4())[:8]
+        text = f"[Test] Integration test message - {test_id}"
+
+        message = slack_connector.send_message(test_channel, text)
+
+        assert message.ts  # Has timestamp (message ID)
+        assert message.text == text
+        print(f"  Sent message: {message.ts}")
+
+        # Cleanup
+        slack_connector.delete_message(test_channel, message.ts)
+
+    def test_send_and_read_message(self, slack_connector: SlackConnector, test_channel: str):
+        """Test that sent messages appear in channel history."""
+        test_id = str(uuid.uuid4())[:8]
+        text = f"[Test] Read test - {test_id}"
+
+        # Send message
+        sent = slack_connector.send_message(test_channel, text)
+        time.sleep(1)  # Allow propagation
+
+        # Read history
+        history = slack_connector.get_channel_history(test_channel, limit=10)
+        assert len(history) > 0
+
+        # Find our message
+        found = False
+        for msg in history:
+            if test_id in msg.text:
+                found = True
+                assert msg.ts == sent.ts
+                print(f"  Found message in history: {msg.text[:50]}")
+                break
+
+        assert found, f"Message with test_id {test_id} not found in history"
+
+        # Cleanup
+        slack_connector.delete_message(test_channel, sent.ts)
+
+    def test_thread_reply(self, slack_connector: SlackConnector, test_channel: str):
+        """Test sending a thread reply."""
+        test_id = str(uuid.uuid4())[:8]
+
+        # Send parent message
+        parent = slack_connector.send_message(
+            test_channel,
+            f"[Test] Thread parent - {test_id}",
+        )
+        time.sleep(0.5)
+
+        # Send thread reply
+        reply = slack_connector.send_message(
+            test_channel,
+            f"[Test] Thread reply - {test_id}",
+            thread_ts=parent.ts,
+        )
+
+        assert reply.thread_ts == parent.ts
+        print(f"  Thread parent: {parent.ts}, Reply: {reply.ts}")
+
+        # Get thread replies
+        time.sleep(0.5)
+        replies = slack_connector.get_thread_replies(test_channel, parent.ts)
+        assert len(replies) >= 2  # Parent + reply
+
+        # Cleanup
+        slack_connector.delete_message(test_channel, reply.ts)
+        slack_connector.delete_message(test_channel, parent.ts)
+
+    def test_update_message(self, slack_connector: SlackConnector, test_channel: str):
+        """Test updating an existing message."""
+        test_id = str(uuid.uuid4())[:8]
+
+        # Send original
+        original = slack_connector.send_message(
+            test_channel,
+            f"[Test] Original message - {test_id}",
+        )
+        time.sleep(0.5)
+
+        # Update
+        updated_text = f"[Test] Updated message - {test_id}"
+        updated = slack_connector.update_message(
+            test_channel,
+            original.ts,
+            updated_text,
+        )
+
+        assert updated.ts == original.ts
+        assert updated.text == updated_text
+        print(f"  Updated message: {updated.ts}")
+
+        # Cleanup
+        slack_connector.delete_message(test_channel, original.ts)
+
+    def test_add_reaction(self, slack_connector: SlackConnector, test_channel: str):
+        """Test adding a reaction to a message."""
+        test_id = str(uuid.uuid4())[:8]
+
+        # Send message
+        message = slack_connector.send_message(
+            test_channel,
+            f"[Test] React to this - {test_id}",
+        )
+        time.sleep(0.5)
+
+        # Add reaction
+        result = slack_connector.add_reaction(test_channel, message.ts, "thumbsup")
+        assert result is True
+        print(f"  Added reaction to: {message.ts}")
+
+        # Cleanup
+        slack_connector.delete_message(test_channel, message.ts)
+
+
+class TestSlackAgentCommunication:
+    """Test agent-style communication patterns."""
+
+    def test_post_status_update(self, slack_connector: SlackConnector, test_channel: str):
+        """Test posting a status update like an agent would."""
+        test_id = str(uuid.uuid4())[:8]
+
+        status = slack_connector.post_status_update(
+            f":robot_face: Agent status update - {test_id}\n"
+            f"• Task: Integration test\n"
+            f"• Status: Running",
+            channel=test_channel,
+        )
+
+        assert status.ts
+        print(f"  Posted status: {status.ts}")
+
+        # Cleanup
+        slack_connector.delete_message(test_channel, status.ts)
+
+    def test_agent_conversation_flow(self, slack_connector: SlackConnector, test_channel: str):
+        """Test a complete agent conversation flow."""
+        test_id = str(uuid.uuid4())[:8]
+
+        # 1. Agent posts initial acknowledgment
+        ack = slack_connector.send_message(
+            test_channel,
+            f":wave: Got your request! Working on it... ({test_id})",
+        )
+        time.sleep(0.5)
+
+        # 2. Agent posts progress in thread
+        progress = slack_connector.send_message(
+            test_channel,
+            ":hourglass: Analyzing the issue...",
+            thread_ts=ack.ts,
+        )
+        time.sleep(0.5)
+
+        # 3. Agent posts final response in thread
+        final = slack_connector.send_message(
+            test_channel,
+            ":white_check_mark: Done! Here's what I found:\n• Issue analyzed\n• Solution proposed",
+            thread_ts=ack.ts,
+        )
+
+        # 4. Update parent message with completion status
+        slack_connector.update_message(
+            test_channel,
+            ack.ts,
+            f":white_check_mark: Request completed! See thread for details. ({test_id})",
+        )
+
+        # Add reaction to indicate success
+        slack_connector.add_reaction(test_channel, ack.ts, "white_check_mark")
+
+        print(f"  Conversation thread: {ack.ts}")
+
+        # Verify thread has all messages
+        time.sleep(0.5)
+        replies = slack_connector.get_thread_replies(test_channel, ack.ts)
+        assert len(replies) >= 3  # ack + progress + final
+
+        # Cleanup
+        slack_connector.delete_message(test_channel, final.ts)
+        slack_connector.delete_message(test_channel, progress.ts)
+        slack_connector.delete_message(test_channel, ack.ts)
+
+
+class TestSlackErrorHandling:
+    """Test error handling scenarios."""
+
+    def test_invalid_channel(self, slack_connector: SlackConnector):
+        """Test error when sending to invalid channel."""
+        with pytest.raises(SlackAPIError):
+            slack_connector.send_message("#nonexistent-channel-xyz-123", "test")
+
+    def test_missing_token(self):
+        """Test error when token is missing."""
+        connector = SlackConnector(bot_token="")
+        # Use a channel ID to skip resolution step
+        with pytest.raises(SlackAPIError, match="not configured"):
+            connector.send_message("C12345678", "test")
+
+
+class TestSlackE2EWithGateway:
+    """E2E tests for Slack integration with the gateway."""
+
+    @pytest.mark.slow
+    def test_full_slack_event_flow(
+        self,
+        slack_connector: SlackConnector,
+        test_channel: str,
+    ):
+        """
+        Test the full Slack event flow:
+        1. Send a message to test channel (simulating @vibeteam mention)
+        2. Verify agent would be triggered
+        3. Check response appears in channel
+
+        Note: This test validates the connector works correctly.
+        Full gateway testing requires a running K8s cluster.
+        """
+        test_id = str(uuid.uuid4())[:8]
+
+        # Simulate what an @vibeteam mention would look like
+        mention_text = f"@vibeteam Please check the latest Sentry errors ({test_id})"
+
+        # Send the simulated mention
+        mention = slack_connector.send_message(test_channel, mention_text)
+        print(f"  Simulated mention: {mention.ts}")
+
+        # In a real scenario, the gateway would:
+        # 1. Receive the app_mention event
+        # 2. Route to appropriate agent
+        # 3. Post response in thread
+
+        # For now, simulate the expected agent response
+        response = slack_connector.send_message(
+            test_channel,
+            ":robot_face: I checked Sentry and found 3 unresolved errors in the last 24 hours.\n"
+            "• TypeError in auth.py:142\n"
+            "• ValueError in api.py:89\n"
+            "• ConnectionError in db.py:256",
+            thread_ts=mention.ts,
+        )
+        print(f"  Agent response: {response.ts}")
+
+        # Add reaction to indicate processing complete
+        slack_connector.add_reaction(test_channel, mention.ts, "eyes")
+        slack_connector.add_reaction(test_channel, mention.ts, "white_check_mark")
+
+        # Verify the thread exists with both messages
+        time.sleep(0.5)
+        replies = slack_connector.get_thread_replies(test_channel, mention.ts)
+        assert len(replies) >= 2
+
+        # Cleanup
+        slack_connector.delete_message(test_channel, response.ts)
+        slack_connector.delete_message(test_channel, mention.ts)
+
+
+if __name__ == "__main__":
+    pytest.main([__file__, "-v", "--run-integration"])

--- a/vibeteam/connectors/__init__.py
+++ b/vibeteam/connectors/__init__.py
@@ -7,6 +7,7 @@ from vibeteam.connectors.gmail import GmailConnector
 from vibeteam.connectors.health import HealthConnector
 from vibeteam.connectors.langfuse import LangfuseConnector
 from vibeteam.connectors.sentry import SentryConnector
+from vibeteam.connectors.slack import SlackConnector
 
 __all__ = [
     "GitHubConnector",
@@ -14,4 +15,5 @@ __all__ = [
     "HealthConnector",
     "LangfuseConnector",
     "SentryConnector",
+    "SlackConnector",
 ]

--- a/vibeteam/connectors/slack.py
+++ b/vibeteam/connectors/slack.py
@@ -1,0 +1,464 @@
+"""
+Slack Connector - API integration for Slack messaging.
+
+Provides functionality to:
+- Send messages to channels
+- Reply in threads
+- Read channel history
+- List channels
+- React to messages
+
+API Docs: https://api.slack.com/methods
+"""
+
+import os
+from dataclasses import dataclass
+from datetime import datetime
+from typing import Any
+
+import httpx
+
+# Slack API base URL
+SLACK_API_BASE = "https://slack.com/api"
+
+# Default channel for agent updates
+DEFAULT_CHANNEL = os.environ.get("SLACK_CHANNEL", "#ai-team")
+
+
+@dataclass
+class SlackMessage:
+    """Represents a Slack message."""
+
+    ts: str  # Timestamp (used as message ID)
+    text: str
+    user: str
+    channel: str
+    thread_ts: str | None
+    reactions: list[str]
+    timestamp: datetime
+
+    @property
+    def is_thread_reply(self) -> bool:
+        """Check if this message is a thread reply."""
+        return self.thread_ts is not None and self.thread_ts != self.ts
+
+
+@dataclass
+class SlackChannel:
+    """Represents a Slack channel."""
+
+    id: str
+    name: str
+    is_private: bool
+    is_member: bool
+    topic: str
+    purpose: str
+
+
+class SlackConnector:
+    """
+    Slack API connector for messaging.
+
+    Usage:
+        connector = SlackConnector()
+
+        # Send message
+        connector.send_message("#ai-team", "Hello from VibeTeam!")
+
+        # Reply in thread
+        connector.send_message("#ai-team", "Thread reply", thread_ts="1234567890.123456")
+
+        # Get channel history
+        messages = connector.get_channel_history("#ai-team", limit=10)
+
+        # React to message
+        connector.add_reaction("#ai-team", "1234567890.123456", "thumbsup")
+    """
+
+    def __init__(self, bot_token: str | None = None):
+        """
+        Initialize Slack connector.
+
+        Args:
+            bot_token: Slack Bot OAuth token (xoxb-...).
+                      If not provided, uses SLACK_BOT_TOKEN env var.
+        """
+        self.bot_token = (
+            bot_token if bot_token is not None else os.environ.get("SLACK_BOT_TOKEN", "")
+        )
+        self._client: httpx.Client | None = None
+        self._channel_cache: dict[str, str] = {}  # name -> id mapping
+
+    @property
+    def client(self) -> httpx.Client:
+        """Get or create HTTP client."""
+        if self._client is None:
+            self._client = httpx.Client(
+                base_url=SLACK_API_BASE,
+                headers={
+                    "Authorization": f"Bearer {self.bot_token}",
+                    "Content-Type": "application/json",
+                },
+                timeout=30.0,
+            )
+        return self._client
+
+    def _check_response(self, response: httpx.Response, method: str) -> dict[str, Any]:
+        """Check Slack API response and raise on error."""
+        response.raise_for_status()
+        data = response.json()
+        if not data.get("ok"):
+            error = data.get("error", "unknown_error")
+            raise SlackAPIError(f"Slack API error in {method}: {error}")
+        return data
+
+    def _resolve_channel_id(self, channel: str) -> str:
+        """
+        Resolve channel name to channel ID.
+
+        Args:
+            channel: Channel name (with or without #) or channel ID
+
+        Returns:
+            Channel ID (C...)
+        """
+        # Already a channel ID
+        if channel.startswith("C") or channel.startswith("D"):
+            return channel
+
+        # Remove # prefix if present
+        channel_name = channel.lstrip("#")
+
+        # Check cache
+        if channel_name in self._channel_cache:
+            return self._channel_cache[channel_name]
+
+        # Fetch from API
+        channels = self.list_channels()
+        for ch in channels:
+            self._channel_cache[ch.name] = ch.id
+            if ch.name == channel_name:
+                return ch.id
+
+        raise SlackAPIError(f"Channel not found: {channel}")
+
+    def send_message(
+        self,
+        channel: str,
+        text: str,
+        thread_ts: str | None = None,
+        blocks: list[dict[str, Any]] | None = None,
+    ) -> SlackMessage:
+        """
+        Send a message to a Slack channel.
+
+        Args:
+            channel: Channel name (#channel) or ID
+            text: Message text (supports Slack markdown)
+            thread_ts: Thread timestamp to reply in
+            blocks: Optional Block Kit blocks for rich formatting
+
+        Returns:
+            SlackMessage with the sent message details
+        """
+        if not self.bot_token:
+            raise SlackAPIError("SLACK_BOT_TOKEN not configured")
+
+        channel_id = self._resolve_channel_id(channel)
+
+        payload: dict[str, Any] = {
+            "channel": channel_id,
+            "text": text,
+        }
+        if thread_ts:
+            payload["thread_ts"] = thread_ts
+        if blocks:
+            payload["blocks"] = blocks
+
+        response = self.client.post("/chat.postMessage", json=payload)
+        data = self._check_response(response, "chat.postMessage")
+
+        return SlackMessage(
+            ts=data["ts"],
+            text=text,
+            user=data.get("message", {}).get("user", "bot"),
+            channel=channel_id,
+            thread_ts=thread_ts,
+            reactions=[],
+            timestamp=datetime.now(),
+        )
+
+    def update_message(
+        self,
+        channel: str,
+        ts: str,
+        text: str,
+        blocks: list[dict[str, Any]] | None = None,
+    ) -> SlackMessage:
+        """
+        Update an existing message.
+
+        Args:
+            channel: Channel name or ID
+            ts: Timestamp of message to update
+            text: New message text
+            blocks: Optional Block Kit blocks
+
+        Returns:
+            Updated SlackMessage
+        """
+        channel_id = self._resolve_channel_id(channel)
+
+        payload: dict[str, Any] = {
+            "channel": channel_id,
+            "ts": ts,
+            "text": text,
+        }
+        if blocks:
+            payload["blocks"] = blocks
+
+        response = self.client.post("/chat.update", json=payload)
+        data = self._check_response(response, "chat.update")
+
+        return SlackMessage(
+            ts=data["ts"],
+            text=text,
+            user=data.get("message", {}).get("user", "bot"),
+            channel=channel_id,
+            thread_ts=None,
+            reactions=[],
+            timestamp=datetime.now(),
+        )
+
+    def delete_message(self, channel: str, ts: str) -> bool:
+        """
+        Delete a message.
+
+        Args:
+            channel: Channel name or ID
+            ts: Timestamp of message to delete
+
+        Returns:
+            True if deleted successfully
+        """
+        channel_id = self._resolve_channel_id(channel)
+
+        response = self.client.post(
+            "/chat.delete",
+            json={"channel": channel_id, "ts": ts},
+        )
+        self._check_response(response, "chat.delete")
+        return True
+
+    def add_reaction(self, channel: str, ts: str, emoji: str) -> bool:
+        """
+        Add a reaction to a message.
+
+        Args:
+            channel: Channel name or ID
+            ts: Timestamp of message to react to
+            emoji: Emoji name (without colons)
+
+        Returns:
+            True if reaction added successfully
+        """
+        channel_id = self._resolve_channel_id(channel)
+
+        response = self.client.post(
+            "/reactions.add",
+            json={
+                "channel": channel_id,
+                "timestamp": ts,
+                "name": emoji,
+            },
+        )
+        data = response.json()
+        # Ignore "already_reacted" error
+        if not data.get("ok") and data.get("error") != "already_reacted":
+            raise SlackAPIError(f"Failed to add reaction: {data.get('error')}")
+        return True
+
+    def get_channel_history(
+        self,
+        channel: str,
+        limit: int = 20,
+        oldest: str | None = None,
+        latest: str | None = None,
+    ) -> list[SlackMessage]:
+        """
+        Get message history from a channel.
+
+        Args:
+            channel: Channel name or ID
+            limit: Max number of messages to return
+            oldest: Only messages after this timestamp
+            latest: Only messages before this timestamp
+
+        Returns:
+            List of SlackMessage objects (newest first)
+        """
+        channel_id = self._resolve_channel_id(channel)
+
+        params: dict[str, Any] = {
+            "channel": channel_id,
+            "limit": limit,
+        }
+        if oldest:
+            params["oldest"] = oldest
+        if latest:
+            params["latest"] = latest
+
+        response = self.client.get("/conversations.history", params=params)
+        data = self._check_response(response, "conversations.history")
+
+        messages = []
+        for msg in data.get("messages", []):
+            messages.append(
+                SlackMessage(
+                    ts=msg["ts"],
+                    text=msg.get("text", ""),
+                    user=msg.get("user", msg.get("bot_id", "unknown")),
+                    channel=channel_id,
+                    thread_ts=msg.get("thread_ts"),
+                    reactions=[r["name"] for r in msg.get("reactions", [])],
+                    timestamp=datetime.fromtimestamp(float(msg["ts"])),
+                )
+            )
+        return messages
+
+    def get_thread_replies(
+        self,
+        channel: str,
+        thread_ts: str,
+        limit: int = 50,
+    ) -> list[SlackMessage]:
+        """
+        Get replies in a thread.
+
+        Args:
+            channel: Channel name or ID
+            thread_ts: Thread parent timestamp
+            limit: Max number of replies
+
+        Returns:
+            List of SlackMessage objects
+        """
+        channel_id = self._resolve_channel_id(channel)
+
+        response = self.client.get(
+            "/conversations.replies",
+            params={
+                "channel": channel_id,
+                "ts": thread_ts,
+                "limit": limit,
+            },
+        )
+        data = self._check_response(response, "conversations.replies")
+
+        messages = []
+        for msg in data.get("messages", []):
+            messages.append(
+                SlackMessage(
+                    ts=msg["ts"],
+                    text=msg.get("text", ""),
+                    user=msg.get("user", msg.get("bot_id", "unknown")),
+                    channel=channel_id,
+                    thread_ts=msg.get("thread_ts"),
+                    reactions=[r["name"] for r in msg.get("reactions", [])],
+                    timestamp=datetime.fromtimestamp(float(msg["ts"])),
+                )
+            )
+        return messages
+
+    def list_channels(self, include_private: bool = False) -> list[SlackChannel]:
+        """
+        List channels the bot can access.
+
+        Args:
+            include_private: Include private channels
+
+        Returns:
+            List of SlackChannel objects
+        """
+        types = "public_channel"
+        if include_private:
+            types += ",private_channel"
+
+        response = self.client.get(
+            "/conversations.list",
+            params={
+                "types": types,
+                "exclude_archived": True,
+                "limit": 200,
+            },
+        )
+        data = self._check_response(response, "conversations.list")
+
+        channels = []
+        for ch in data.get("channels", []):
+            channels.append(
+                SlackChannel(
+                    id=ch["id"],
+                    name=ch["name"],
+                    is_private=ch.get("is_private", False),
+                    is_member=ch.get("is_member", False),
+                    topic=ch.get("topic", {}).get("value", ""),
+                    purpose=ch.get("purpose", {}).get("value", ""),
+                )
+            )
+        return channels
+
+    def get_channel_by_name(self, name: str) -> SlackChannel | None:
+        """
+        Get channel by name.
+
+        Args:
+            name: Channel name (with or without #)
+
+        Returns:
+            SlackChannel or None if not found
+        """
+        name = name.lstrip("#")
+        channels = self.list_channels(include_private=True)
+        for ch in channels:
+            if ch.name == name:
+                return ch
+        return None
+
+    def post_status_update(
+        self,
+        text: str,
+        channel: str | None = None,
+        thread_ts: str | None = None,
+    ) -> SlackMessage:
+        """
+        Post a status update to the default AI team channel.
+
+        Args:
+            text: Status message
+            channel: Optional channel override
+            thread_ts: Optional thread to reply in
+
+        Returns:
+            SlackMessage with sent message details
+        """
+        target_channel = channel or DEFAULT_CHANNEL
+        return self.send_message(target_channel, text, thread_ts=thread_ts)
+
+    def close(self) -> None:
+        """Close the HTTP client."""
+        if self._client:
+            self._client.close()
+            self._client = None
+
+    def __enter__(self) -> "SlackConnector":
+        return self
+
+    def __exit__(self, *args: Any) -> None:
+        self.close()
+
+
+class SlackAPIError(Exception):
+    """Raised when Slack API returns an error."""
+
+    pass


### PR DESCRIPTION
## Summary

Adds `SlackConnector` for agent-to-Slack communication and comprehensive E2E integration tests.

### Changes
- **New `vibeteam/connectors/slack.py`** - Full Slack API connector with:
  - `send_message()` - Send messages to channels
  - `update_message()` / `delete_message()` - Edit/remove messages
  - `get_channel_history()` / `get_thread_replies()` - Read messages
  - `add_reaction()` - React to messages
  - `list_channels()` / `get_channel_by_name()` - Channel discovery
  - `post_status_update()` - Helper for agent status messages

- **New `tests/test_slack_integration.py`** - 13 integration tests:
  - Basic connector functionality
  - Message send/read/update/delete
  - Thread replies
  - Agent communication patterns (acknowledgment → progress → completion)
  - Error handling

### Testing

All tests pass against real Slack API:
```
pytest tests/test_slack_integration.py -v --run-integration
# 13 passed in 13.00s
```

Requires `SLACK_BOT_TOKEN` and `SLACK_TEST_CHANNEL` env vars.

## Closes

- Closes #40

## Related

- K8s deployment: #38 (closed)
- CrewAI bug: #39
- Integration setup: #22