### PR TITLE
fix(slack): correct webhook URLs to use webhook.team subdomain

### DIFF
--- a/templates/slack-app/manifest.yaml
+++ b/templates/slack-app/manifest.yaml
@@ -30,14 +30,14 @@ oauth_config:
 
 settings:
   event_subscriptions:
-    # Update this URL after deploying the webhook server
-    request_url: https://team.vibebrowser.app/slack/events
+    # IMPORTANT: Use webhook.team subdomain - team.vibebrowser.app routes to OpenHands
+    request_url: https://webhook.team.vibebrowser.app/slack/events
     bot_events:
       - app_mention
       - message.im
   interactivity:
     is_enabled: true
-    request_url: https://team.vibebrowser.app/slack/interactive
+    request_url: https://webhook.team.vibebrowser.app/slack/interactive
   org_deploy_enabled: false
   socket_mode_enabled: false
   token_rotation_enabled: false


### PR DESCRIPTION
## Summary

- Fixes Slack webhook URL misconfiguration that prevented messages from reaching the gateway
- Changes URLs from `team.vibebrowser.app` to `webhook.team.vibebrowser.app`

## Problem

Slack app was configured to send events to `https://team.vibebrowser.app/slack/events` which routes to OpenHands (port 3000), not the vibeteam-gateway (port 8080) that handles Slack events.

## Solution

Updated `templates/slack-app/manifest.yaml` to use the correct subdomain:
- `https://webhook.team.vibebrowser.app/slack/events`
- `https://webhook.team.vibebrowser.app/slack/interactive`

## Manual Action Required

After merging, update the Slack app configuration at:
https://api.slack.com/apps/A0AAZGWEAVA/event-subscriptions

Change Request URL to: `https://webhook.team.vibebrowser.app/slack/events`

## Testing

Verified the endpoint responds correctly:
```bash
curl -s "https://webhook.team.vibebrowser.app/slack/events" -X POST \
  -H "Content-Type: application/json" \
  -d '{"type":"url_verification","challenge":"test"}' 
# Returns: {"challenge":"test"}
```