### PR TITLE
fix(eval): add --thread-ts rescore mode, auto-extend timeout on handoff, agent verification

### DIFF
--- a/agents/openhands/software_engineer.py
+++ b/agents/openhands/software_engineer.py
@@ -237,6 +237,36 @@ When you receive a bug report or feature request:
 
 **DO NOT hand off if** the fix is in application code - that's YOUR job.
 
+## CRITICAL: VERIFY YOUR FIX
+
+After applying any fix, you MUST verify it actually works. Do NOT claim success without evidence.
+
+1. **Configuration fix** (nginx, k8s, env vars): Restart the affected service/pod, then
+   `curl` the endpoint and confirm it returns the expected HTTP status (e.g., 200).
+2. **Code fix**: Run the relevant tests (`pytest tests/` or a specific test file).
+   If no tests exist, write a minimal verification script.
+3. **Deployment change**: Check pod status (`kubectl get pods`) and health endpoints
+   (`curl <health-url>`).
+4. **Report BEFORE and AFTER**: Show the error before your fix and the success after.
+
+**DO NOT claim a fix is applied without verifying it actually resolves the issue.**
+If verification fails, report the failure honestly and iterate.
+
+## CRITICAL: DO NOT FABRICATE ROOT CAUSES
+
+Your diagnosis must be grounded in evidence from the tools you used. If you cannot
+determine the exact root cause with certainty:
+
+- State what you found and what you are uncertain about.
+- DO NOT invent plausible-sounding explanations that are not supported by logs,
+  error messages, or code inspection.
+- Be precise about which configuration change fixes which specific error. For example:
+  - Missing `proxy_http_version` or `Connection` headers do NOT cause HTTP 404 errors.
+  - A 404 means the route/location block does not exist or the upstream is unreachable.
+  - A 502 means the upstream is down or not responding.
+  - A 503 means the service is overloaded or not ready.
+- If multiple possible causes exist, list them with the evidence for/against each.
+
 ## TEAM COLLABORATION
 
 When you complete a task or need help from another team member, @mention them in your response:

--- a/plan.md
+++ b/plan.md
@@ -1,23 +1,55 @@
 # Current Work Plan
 
-## Active: GitHub App Auth & Sentry Webhooks (PR #53)
+## Active: Eval Rescore & Agent Verification Improvements
+
+**Branch:** `fix/eval-rescore-and-agent-verification`
+**Triggered by:** SoftwareEngineer response in Slack thread `1770710833.425539` was never scored (arrived at ~726s, eval timeout was 600s). Manual G-Eval showed EvidenceBasedDecision: 0.50 due to fabricated root cause.
+
+### Changes Implemented
+
+- [x] `--thread-ts` flag for re-scoring existing Slack threads without posting new messages
+- [x] `--handoff-timeout` flag + auto-extend timeout when handoff is detected (default: +600s)
+- [x] Increased `stable_time_with_handoff` from 60s to 300s (agents take 5-10min)
+- [x] SoftwareEngineer: "VERIFY YOUR FIX" instructions (curl after config fix, run tests after code fix)
+- [x] SoftwareEngineer: "DO NOT FABRICATE ROOT CAUSES" anti-hallucination guardrails
+- [x] All 87 existing tests pass, ruff lint clean
+
+### Files Changed
+
+| File | What Changed |
+|------|-------------|
+| `scripts/eval_slack_e2e.py` | `--thread-ts` rescore mode, `--handoff-timeout`, auto-extend timeout, stable_time 60→300 |
+| `agents/openhands/software_engineer.py` | VERIFY YOUR FIX + DO NOT FABRICATE ROOT CAUSES sections |
+
+### Usage
+
+```bash
+# Re-score an existing thread (no new message posted)
+uv run python scripts/eval_slack_e2e.py \
+  --scenario stripe_webhook_failure \
+  --thread-ts 1770710833.425539 \
+  --channel C0AATPSADB8
+
+# Normal eval with extended handoff timeout
+uv run python scripts/eval_slack_e2e.py \
+  --scenario stripe_webhook_failure \
+  --handoff-timeout 900
+```
+
+### Remaining
+
+- [ ] Merge PR, deploy, run full eval to verify SoftwareEngineer improvements
+
+---
+
+## Blocked: GitHub App Auth & Sentry Webhooks (PR #53)
 
 **Status:** Draft PR, merges cleanly, 13 commits behind master.
 **PR:** #53 (copilot/integrate-github-app-auth)
-**Issue:** #49
-
-### What PR #53 Adds
-- `GitHubConnector` support for both PAT and GitHub App auth
-- Auto-refreshing installation tokens (1hr TTL, 5min buffer)
-- `vibeteam/utils/github_app.py` — JWT generation + token exchange
-- 13 unit tests (all passing on branch)
-- Docs: `docs/github-app-setup.md`, `docs/webhook-routing.md`
 
 ### Remaining Work
 - [ ] Rebase onto master (no conflicts expected)
-- [ ] Fix any new lint issues from rebase
-- [ ] Add integration tests for webhook routing (Sentry → agent)
-- [ ] Test GitHub issue assignment → agent routing end-to-end
+- [ ] Add integration tests for webhook routing
 - [ ] Merge to master
 
 ---
@@ -32,22 +64,6 @@
 2. Change **Request URL** to: `https://webhook.team.vibebrowser.app/slack/events`
 3. Go to https://api.slack.com/apps/A0AAZGWEAVA/interactivity
 4. Change **Request URL** to: `https://webhook.team.vibebrowser.app/slack/interactive`
-5. Verify: `kubectl logs -f deployment/vibeteam-gateway -n vibeteam | grep -i slack`
-
-### Ingress Routing Reference
-
-| Hostname | Service | Port | Purpose |
-|----------|---------|------|---------|
-| `team.vibebrowser.app` | openhands-svc | 3000 | OpenHands web UI |
-| `webhook.team.vibebrowser.app` | vibeteam-gateway | 8080 | Slack/Discord webhooks |
-
----
-
-## Open PRs
-
-| PR | Title | Status | Notes |
-|----|-------|--------|-------|
-| #53 | [WIP] GitHub App auth + Sentry webhooks | Draft | Merges cleanly, needs rebase |
 
 ---
 
@@ -124,8 +140,6 @@ sequenceDiagram
 | **ProductManager** | Maya | `ask_agent()` (single LLM call) | None | None |
 | **MarketingManager** | Ada | `ask_agent()` (single LLM call) | None (MCP config exists) | Browser context (URL fetch, web search) |
 
-**Key difference:** `send_message()` + `run()` = full agentic loop with tool access. `ask_agent()` = single LLM call, text-only output.
-
 ### Role Resolution & Keyword Routing
 
 Consolidated into `agents/shared/role_resolver.py`:
@@ -147,22 +161,14 @@ Reduced from worst-case 210s (sequential) to ~11s (parallel).
 
 | PR/Commit | Title | Key Changes |
 |-----------|-------|-------------|
-| `652cfc6` | refactor: consolidate keyword routing into role_resolver | Single `route_by_keywords()` in role_resolver.py, word-boundary regex, replaced 100-line method in team.py + 12-line inline in slack.py, ~50 tests |
+| `687f328` | docs: update plan.md | keyword routing done, close PR #51, track PR #53 |
+| `652cfc6` | refactor: consolidate keyword routing into role_resolver | Single `route_by_keywords()` in role_resolver.py, word-boundary regex |
 | #59 | refactor: consolidate role parsing, parallelize kubectl, merge eval scripts | RoleResolver module, ThreadPoolExecutor kubectl, deleted eval_slack_agent.py |
 | #55 | feat: add Documentation Knowledge Base tool for agents | Docs tools for agent knowledge base |
 | #54 | fix(slack): correct webhook URLs to use webhook.team subdomain | Manifest fix (blocked on manual Slack config) |
 | #57 | fix: secure /slack/trigger endpoint, fix dead code, align role mentions | SLACK_TRIGGER_SECRET, dead code cleanup |
 | #56 | fix(eval): improve Azure credential handling | Credential warnings, all 5 eval scenarios pass |
 | #52 | fix(ci): ruff lint errors | CI lint fixes |
-
-### Closed PRs (superseded)
-
-| PR | Reason |
-|----|--------|
-| #51 | Superseded — doc upload feature in #55; branch 13 behind master, 42 lint errors |
-| #50 | Superseded by #53 (WIP rewrite) |
-| #25 | Superseded by #55 (cherry-pick) |
-| #58 | Correctly closed — /slack/trigger is correct design |
 
 ### Eval Results (all passing)
 

--- a/plan.md
+++ b/plan.md
@@ -13,6 +13,9 @@
 - [x] SoftwareEngineer: "VERIFY YOUR FIX" instructions (curl after config fix, run tests after code fix)
 - [x] SoftwareEngineer: "DO NOT FABRICATE ROOT CAUSES" anti-hallucination guardrails
 - [x] All 87 existing tests pass, ruff lint clean
+- [x] 27 unit tests for rescore mode + handoff timeout (`tests/test_eval_rescore.py`)
+- [x] Live validation: all 4 metrics >= 0.90 on `stripe_webhook_failure` thread
+- [x] CI passes (lint, test, unit tests, docker build)
 
 ### Files Changed
 
@@ -20,6 +23,12 @@
 |------|-------------|
 | `scripts/eval_slack_e2e.py` | `--thread-ts` rescore mode, `--handoff-timeout`, auto-extend timeout, stable_time 60→300 |
 | `agents/openhands/software_engineer.py` | VERIFY YOUR FIX + DO NOT FABRICATE ROOT CAUSES sections |
+| `tests/test_eval_rescore.py` | **NEW** — 27 unit tests for rescore mode + handoff timeout |
+
+### PR Status
+
+**PR #60:** Open, CI passing, ready for review.
+- https://github.com/VibeTechnologies/VibeTeam/pull/60
 
 ### Usage
 
@@ -36,9 +45,18 @@ uv run python scripts/eval_slack_e2e.py \
   --handoff-timeout 900
 ```
 
+### Live Rescore Results (thread 1770710833.425539)
+
+| Metric | Score | Threshold | Status |
+|--------|-------|-----------|--------|
+| InvestigationQuality | 1.00 | 0.60 | Pass |
+| TaskCompletion | 1.00 | 0.60 | Pass |
+| EvidenceBasedDecision | 0.90 | 0.60 | Pass |
+| HandoffCompletion | 0.90 | 0.60 | Pass |
+
 ### Remaining
 
-- [ ] Merge PR, deploy, run full eval to verify SoftwareEngineer improvements
+- [ ] Merge PR #60, deploy, run full eval to verify SoftwareEngineer improvements
 
 ---
 

--- a/scripts/eval_slack_e2e.py
+++ b/scripts/eval_slack_e2e.py
@@ -18,6 +18,7 @@ Usage:
     python scripts/eval_slack_e2e.py --message "@SupportEngineer check Sentry for errors"
     python scripts/eval_slack_e2e.py --channel C0123456789 --skip-eval
     python scripts/eval_slack_e2e.py --list-scenarios
+    python scripts/eval_slack_e2e.py --scenario stripe_webhook_failure --thread-ts 1770710833.425539 --channel C0AATPSADB8
 
 Environment Variables:
     SLACK_BOT_TOKEN: Slack bot OAuth token (required)
@@ -594,12 +595,14 @@ async def run_evaluation(
     gateway_url: str | None = None,
     custom_message: str | None = None,
     skip_eval: bool = False,
+    existing_thread_ts: str | None = None,
+    handoff_timeout_extension: int = 600,
 ) -> dict[str, Any]:
     """
     Run a full E2E evaluation:
-    1. Post message to Slack
-    2. Trigger gateway to process the message
-    3. Wait for bot response
+    1. Post message to Slack (or use existing thread if existing_thread_ts provided)
+    2. Trigger gateway to process the message (skipped for existing threads)
+    3. Wait for bot response (skipped for existing threads)
     4. Evaluate with DeepEval
     5. Generate report
 
@@ -611,6 +614,11 @@ async def run_evaluation(
         gateway_url: Gateway URL for triggering agents (defaults to GATEWAY_URL env var)
         custom_message: Custom message to send (overrides scenario message)
         skip_eval: Skip DeepEval evaluation (just post and collect responses)
+        existing_thread_ts: If provided, re-score an existing Slack thread instead of
+            posting a new message. Skips Steps 1, 1b, and 2 — jumps directly to
+            conversation collection and evaluation.
+        handoff_timeout_extension: Seconds to extend wait_timeout when a handoff is
+            detected (default: 600). Applied once per handoff detection.
     """
     # Get scenario config
     if custom_message:
@@ -651,129 +659,142 @@ async def run_evaluation(
     print("=" * 70)
     print(f"Scenario: {scenario['name']}")
     print(f"Channel: {channel}")
-    print(f"Wait Timeout: {wait_timeout}s")
+    if existing_thread_ts:
+        print(f"Mode: RE-SCORE existing thread {existing_thread_ts}")
+    else:
+        print(f"Wait Timeout: {wait_timeout}s")
     print()
 
-    # Step 1: Post message to Slack
-    print(">>> Step 1: Posting message to Slack")
     user_message = scenario["message"]
-    print(f"    Message: {user_message[:80]}...")
 
-    initial_msg = slack.post_message(channel=channel, text=user_message)
-    thread_ts = initial_msg.ts
-    print(f"    Thread TS: {thread_ts}")
-    print("    Posted successfully!")
+    if existing_thread_ts:
+        # ── Re-score mode: skip Steps 1, 1b, 2 ──────────────────────────
+        thread_ts = existing_thread_ts
+        print(f">>> Steps 1/1b/2: SKIPPED (re-scoring existing thread {thread_ts})")
+        start_time = time.time()
+        latency_ms = 0  # Not meaningful for re-score
+    else:
+        # ── Normal mode: post message, trigger gateway, poll ─────────────
+        # Step 1: Post message to Slack
+        print(">>> Step 1: Posting message to Slack")
+        print(f"    Message: {user_message[:80]}...")
 
-    # Step 1b: Trigger the gateway to process this message
-    # Slack doesn't send webhooks for messages the bot itself posts,
-    # so we need to explicitly trigger the gateway
-    print("\n>>> Step 1b: Triggering gateway to process message")
-    default_prod_url = "https://webhook.team.vibebrowser.app"
-    resolved_gateway_url = gateway_url or os.environ.get("GATEWAY_URL", default_prod_url)
-    trigger_url = f"{resolved_gateway_url}/slack/trigger"
+        initial_msg = slack.post_message(channel=channel, text=user_message)
+        thread_ts = initial_msg.ts
+        print(f"    Thread TS: {thread_ts}")
+        print("    Posted successfully!")
 
-    # Warn if targeting production gateway without explicit opt-in
-    if (
-        resolved_gateway_url == default_prod_url
-        and not gateway_url
-        and not os.environ.get("GATEWAY_URL")
-    ):
-        print(f"    ⚠ WARNING: Using default PRODUCTION gateway ({default_prod_url})")
-        print("    ⚠ Set GATEWAY_URL env var or --gateway-url to target a different environment")
+        # Step 1b: Trigger the gateway to process this message
+        print("\n>>> Step 1b: Triggering gateway to process message")
+        default_prod_url = "https://webhook.team.vibebrowser.app"
+        resolved_gateway_url = gateway_url or os.environ.get("GATEWAY_URL", default_prod_url)
+        trigger_url = f"{resolved_gateway_url}/slack/trigger"
 
-    # Build auth header if SLACK_TRIGGER_SECRET is configured
-    trigger_secret = os.environ.get("SLACK_TRIGGER_SECRET", "")
-    headers: dict[str, str] = {}
-    if trigger_secret:
-        headers["Authorization"] = f"Bearer {trigger_secret}"
+        if (
+            resolved_gateway_url == default_prod_url
+            and not gateway_url
+            and not os.environ.get("GATEWAY_URL")
+        ):
+            print(f"    WARNING: Using default PRODUCTION gateway ({default_prod_url})")
+            print("    Set GATEWAY_URL env var or --gateway-url to target a different environment")
 
-    try:
-        async with httpx.AsyncClient(timeout=30.0) as client:
-            response = await client.post(
-                trigger_url,
-                json={
-                    "channel": channel,
-                    "thread_ts": thread_ts,
-                    "text": user_message,
-                    "user_id": "eval_script",
-                },
-                headers=headers,
+        trigger_secret = os.environ.get("SLACK_TRIGGER_SECRET", "")
+        headers: dict[str, str] = {}
+        if trigger_secret:
+            headers["Authorization"] = f"Bearer {trigger_secret}"
+
+        try:
+            async with httpx.AsyncClient(timeout=30.0) as client:
+                response = await client.post(
+                    trigger_url,
+                    json={
+                        "channel": channel,
+                        "thread_ts": thread_ts,
+                        "text": user_message,
+                        "user_id": "eval_script",
+                    },
+                    headers=headers,
+                )
+                if response.status_code == 200:
+                    result = response.json()
+                    print(f"    Gateway accepted: routing to {result.get('roles', [])}")
+                else:
+                    print(f"    WARNING: Gateway returned {response.status_code}: {response.text}")
+        except Exception as e:
+            print(f"    WARNING: Failed to trigger gateway: {e}")
+            print(
+                "    ERROR: Gateway trigger failed. No agent will be invoked — "
+                "bot-posted messages do not generate Slack webhook events. "
+                "The eval will wait but no response will arrive."
             )
-            if response.status_code == 200:
-                result = response.json()
-                print(f"    Gateway accepted: routing to {result.get('roles', [])}")
-            else:
-                print(f"    WARNING: Gateway returned {response.status_code}: {response.text}")
-    except Exception as e:
-        print(f"    WARNING: Failed to trigger gateway: {e}")
-        print(
-            "    ERROR: Gateway trigger failed. No agent will be invoked — "
-            "bot-posted messages do not generate Slack webhook events. "
-            "The eval will wait but no response will arrive."
-        )
+
+        # Step 2: Wait for bot response (with handoff chain support + auto-extend)
+        print(f"\n>>> Step 2: Waiting for agent response (timeout: {wait_timeout}s)")
+        start_time = time.time()
+        last_message_count = 1  # We posted 1 message
+        stable_time_no_handoff = 15
+        stable_time_with_handoff = 300  # 5min wait for handoff agent
+        last_new_message_time = 0.0
+        pending_handoff = False
+        effective_timeout = wait_timeout
+
+        while time.time() - start_time < effective_timeout:
+            await asyncio.sleep(poll_interval)
+
+            replies = slack.get_thread_replies(channel=channel, thread_ts=thread_ts, limit=50)
+            current_count = len(replies)
+
+            if current_count > last_message_count:
+                print(f"    New messages detected: {current_count - last_message_count}")
+                last_message_count = current_count
+                last_new_message_time = time.time()
+
+                bot_messages = [r for r in replies if r.is_bot and r.ts != thread_ts]
+                if bot_messages:
+                    latest_bot_msg = bot_messages[-1]
+                    has_handoff = bool(ROLE_PATTERN.search(latest_bot_msg.text))
+                    if has_handoff:
+                        # Auto-extend timeout on handoff detection
+                        remaining = (start_time + effective_timeout) - time.time()
+                        if handoff_timeout_extension > remaining:
+                            effective_timeout = time.time() - start_time + handoff_timeout_extension
+                            print(
+                                f"    Handoff detected! Extended timeout to "
+                                f"{int(effective_timeout)}s "
+                                f"(+{handoff_timeout_extension}s from now)"
+                            )
+                        else:
+                            print("    Handoff detected in response! Waiting for next agent...")
+                        pending_handoff = True
+                        continue
+                    else:
+                        pending_handoff = False
+
+            bot_messages = [r for r in replies if r.is_bot and r.ts != thread_ts]
+            if bot_messages and last_new_message_time > 0:
+                time_since_last = time.time() - last_new_message_time
+                stable_time = (
+                    stable_time_with_handoff if pending_handoff else stable_time_no_handoff
+                )
+                if time_since_last >= stable_time:
+                    latest_bot_msg = bot_messages[-1]
+                    has_handoff = bool(ROLE_PATTERN.search(latest_bot_msg.text))
+                    if not has_handoff:
+                        print(
+                            f"    Conversation stable for {int(time_since_last)}s, "
+                            "no pending handoffs."
+                        )
+                        break
+                    else:
+                        print("    Still waiting for handoff response...")
+
+            elapsed = int(time.time() - start_time)
+            print(f"    Waiting... ({elapsed}s / {int(effective_timeout)}s)")
+
+        latency_ms = int((time.time() - start_time) * 1000)
 
     # Track conversation
     conversation: list[tuple[str, str]] = [("user", user_message)]
-
-    # Step 2: Wait for bot response (with handoff chain support)
-    print(f"\n>>> Step 2: Waiting for agent response (timeout: {wait_timeout}s)")
-    start_time = time.time()
-    last_message_count = 1  # We posted 1 message
-    # Wait times are adaptive based on whether handoffs are detected
-    stable_time_no_handoff = 15  # Seconds with no new messages when no handoff detected
-    stable_time_with_handoff = 60  # Longer wait when expecting handoff chain
-    last_new_message_time = 0.0
-    pending_handoff = False  # Track if we're waiting for a handoff
-
-    while time.time() - start_time < wait_timeout:
-        await asyncio.sleep(poll_interval)
-
-        # Get thread replies
-        replies = slack.get_thread_replies(channel=channel, thread_ts=thread_ts, limit=50)
-        current_count = len(replies)
-
-        if current_count > last_message_count:
-            print(f"    New messages detected: {current_count - last_message_count}")
-            last_message_count = current_count
-            last_new_message_time = time.time()
-
-            # Check if latest bot message contains a handoff mention
-            bot_messages = [r for r in replies if r.is_bot and r.ts != thread_ts]
-            if bot_messages:
-                latest_bot_msg = bot_messages[-1]
-                has_handoff = bool(ROLE_PATTERN.search(latest_bot_msg.text))
-                if has_handoff:
-                    print("    Handoff detected in response! Waiting for next agent...")
-                    pending_handoff = True
-                    # Continue polling for the handoff response
-                    continue
-                else:
-                    # Got a response without handoff mention - reset pending flag
-                    pending_handoff = False
-
-        # Check if we've received bot responses and conversation is stable
-        bot_messages = [r for r in replies if r.is_bot and r.ts != thread_ts]
-        if bot_messages and last_new_message_time > 0:
-            # Check if enough time has passed with no new messages
-            time_since_last = time.time() - last_new_message_time
-            # Use adaptive wait time based on pending handoff state
-            stable_time = stable_time_with_handoff if pending_handoff else stable_time_no_handoff
-            if time_since_last >= stable_time:
-                # Check if latest message has no handoff (conversation complete)
-                latest_bot_msg = bot_messages[-1]
-                has_handoff = bool(ROLE_PATTERN.search(latest_bot_msg.text))
-                if not has_handoff:
-                    print(
-                        f"    Conversation stable for {int(time_since_last)}s, no pending handoffs."
-                    )
-                    break
-                else:
-                    print("    Still waiting for handoff response...")
-
-        elapsed = int(time.time() - start_time)
-        print(f"    Waiting... ({elapsed}s / {wait_timeout}s)")
-
-    latency_ms = int((time.time() - start_time) * 1000)
 
     # Step 3: Collect conversation
     print("\n>>> Step 3: Collecting conversation")
@@ -956,6 +977,7 @@ Examples:
   python scripts/eval_slack_e2e.py --message "@SupportEngineer check Sentry for errors"
   python scripts/eval_slack_e2e.py --channel C0123456789 --skip-eval
   python scripts/eval_slack_e2e.py --list-scenarios
+  python scripts/eval_slack_e2e.py --scenario stripe_webhook_failure --thread-ts 1770710833.425539 --channel C0AATPSADB8
         """,
     )
     parser.add_argument(
@@ -998,6 +1020,22 @@ Examples:
         action="store_true",
         help="Skip DeepEval evaluation (just post and collect responses)",
     )
+    parser.add_argument(
+        "--thread-ts",
+        help=(
+            "Re-score an existing Slack thread instead of posting a new message. "
+            "Requires --scenario (for evaluation criteria) and --channel."
+        ),
+    )
+    parser.add_argument(
+        "--handoff-timeout",
+        type=int,
+        default=600,
+        help=(
+            "Seconds to extend wait timeout when a handoff is detected (default: 600). "
+            "Ignored in --thread-ts mode."
+        ),
+    )
 
     args = parser.parse_args()
 
@@ -1015,6 +1053,12 @@ Examples:
     scenario_name = "custom" if args.message else args.scenario
     custom_message = args.message
 
+    # Validate --thread-ts usage
+    if args.thread_ts and args.message:
+        print("ERROR: --thread-ts and --message are mutually exclusive.")
+        print("       --thread-ts re-scores an existing thread; --message posts a new one.")
+        return 1
+
     try:
         result = asyncio.run(
             run_evaluation(
@@ -1025,6 +1069,8 @@ Examples:
                 gateway_url=args.gateway_url,
                 custom_message=custom_message,
                 skip_eval=args.skip_eval,
+                existing_thread_ts=args.thread_ts,
+                handoff_timeout_extension=args.handoff_timeout,
             )
         )
 

--- a/tests/test_eval_rescore.py
+++ b/tests/test_eval_rescore.py
@@ -1,0 +1,608 @@
+"""
+Tests for eval_slack_e2e.py --thread-ts rescore mode and handoff timeout extension.
+
+These are pure logic tests with mocked Slack — NOT e2e tests.
+"""
+
+from __future__ import annotations
+
+import os
+
+# We need to import from the eval script — it uses relative path manipulation
+# so we import after ensuring sys.path is set up
+import sys
+from datetime import datetime, timezone
+from unittest.mock import AsyncMock, MagicMock, patch
+
+import pytest
+
+from vibeteam.connectors.slack import SlackMessage
+
+sys.path.insert(0, os.path.join(os.path.dirname(__file__), ".."))
+
+from scripts.eval_slack_e2e import (
+    ROLE_DISPLAY,
+    SCENARIOS,
+    build_transcript,
+    run_evaluation,
+)
+
+# ==============================================================================
+# Helpers
+# ==============================================================================
+
+
+def make_slack_message(
+    ts: str,
+    text: str,
+    is_bot: bool = False,
+    thread_ts: str | None = None,
+    channel: str = "C_TEST",
+) -> SlackMessage:
+    """Create a SlackMessage for testing."""
+    return SlackMessage(
+        ts=ts,
+        channel=channel,
+        user="U_BOT" if is_bot else "U_USER",
+        text=text,
+        thread_ts=thread_ts,
+        timestamp=datetime.now(timezone.utc),
+        is_bot=is_bot,
+        mentions=[],
+    )
+
+
+# ==============================================================================
+# Tests: build_transcript
+# ==============================================================================
+
+
+class TestBuildTranscript:
+    """Tests for the build_transcript helper."""
+
+    def test_single_user_message(self):
+        messages = [("user", "Hello")]
+        result = build_transcript(messages)
+        assert result == "[User] Hello"
+
+    def test_multi_role_conversation(self):
+        messages = [
+            ("user", "Check the API"),
+            ("support_engineer", "I'll investigate."),
+            ("software_engineer", "Found the bug."),
+        ]
+        result = build_transcript(messages)
+        assert "[User] Check the API" in result
+        assert "[SupportEngineer] I'll investigate." in result
+        assert "[SoftwareEngineer] Found the bug." in result
+
+    def test_unknown_role_uses_title(self):
+        messages = [("unknown_role", "Test")]
+        result = build_transcript(messages)
+        assert "[Unknown_Role] Test" in result
+
+
+# ==============================================================================
+# Tests: --thread-ts rescore mode
+# ==============================================================================
+
+
+class TestRescoreMode:
+    """Tests for the --thread-ts rescore path in run_evaluation."""
+
+    @pytest.fixture
+    def mock_env(self, monkeypatch):
+        """Set required env vars."""
+        monkeypatch.setenv("SLACK_BOT_TOKEN", "xoxb-test-token")
+
+    @pytest.fixture
+    def mock_slack(self):
+        """Create a mock SlackConnector that returns canned thread replies."""
+        mock = MagicMock()
+        # get_thread_replies returns a list of SlackMessage objects
+        mock.get_thread_replies.return_value = [
+            # First message in thread is the original user message
+            make_slack_message(
+                ts="1770710833.425539",
+                text="@SupportEngineer investigate the Stripe webhook failure",
+                is_bot=False,
+                thread_ts="1770710833.425539",
+            ),
+            # Bot response from SupportEngineer
+            make_slack_message(
+                ts="1770710900.000001",
+                text="[SupportEngineer] I've checked Sentry and kubectl. The webhook endpoint returns 404.",
+                is_bot=True,
+                thread_ts="1770710833.425539",
+            ),
+            # Bot response from SoftwareEngineer (handoff)
+            make_slack_message(
+                ts="1770711200.000002",
+                text="[SoftwareEngineer] I've found the issue in the routing config.",
+                is_bot=True,
+                thread_ts="1770710833.425539",
+            ),
+        ]
+        return mock
+
+    @pytest.mark.asyncio
+    async def test_rescore_skips_post_message(self, mock_env, mock_slack):
+        """When existing_thread_ts is provided, post_message should NOT be called."""
+        with patch("scripts.eval_slack_e2e.SlackConnector", return_value=mock_slack):
+            result = await run_evaluation(
+                scenario_name="stripe_webhook_failure",
+                channel="C0AATPSADB8",
+                existing_thread_ts="1770710833.425539",
+                skip_eval=True,
+            )
+
+        # post_message should never be called in rescore mode
+        mock_slack.post_message.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_rescore_skips_gateway_trigger(self, mock_env, mock_slack):
+        """When existing_thread_ts is provided, no HTTP call to gateway /slack/trigger."""
+        with (
+            patch("scripts.eval_slack_e2e.SlackConnector", return_value=mock_slack),
+            patch("scripts.eval_slack_e2e.httpx.AsyncClient") as mock_httpx,
+        ):
+            result = await run_evaluation(
+                scenario_name="stripe_webhook_failure",
+                channel="C0AATPSADB8",
+                existing_thread_ts="1770710833.425539",
+                skip_eval=True,
+            )
+
+        # httpx.AsyncClient should never be instantiated in rescore mode
+        mock_httpx.assert_not_called()
+
+    @pytest.mark.asyncio
+    async def test_rescore_calls_get_thread_replies(self, mock_env, mock_slack):
+        """When existing_thread_ts is provided, get_thread_replies IS called."""
+        with patch("scripts.eval_slack_e2e.SlackConnector", return_value=mock_slack):
+            result = await run_evaluation(
+                scenario_name="stripe_webhook_failure",
+                channel="C0AATPSADB8",
+                existing_thread_ts="1770710833.425539",
+                skip_eval=True,
+            )
+
+        mock_slack.get_thread_replies.assert_called_once_with(
+            channel="C0AATPSADB8",
+            thread_ts="1770710833.425539",
+            limit=50,
+        )
+
+    @pytest.mark.asyncio
+    async def test_rescore_latency_is_zero(self, mock_env, mock_slack):
+        """In rescore mode, latency_ms should be 0."""
+        with patch("scripts.eval_slack_e2e.SlackConnector", return_value=mock_slack):
+            result = await run_evaluation(
+                scenario_name="stripe_webhook_failure",
+                channel="C0AATPSADB8",
+                existing_thread_ts="1770710833.425539",
+                skip_eval=True,
+            )
+
+        assert result["latency_ms"] == 0
+
+    @pytest.mark.asyncio
+    async def test_rescore_thread_ts_matches_provided(self, mock_env, mock_slack):
+        """Result thread_ts should match the provided existing_thread_ts."""
+        with patch("scripts.eval_slack_e2e.SlackConnector", return_value=mock_slack):
+            result = await run_evaluation(
+                scenario_name="stripe_webhook_failure",
+                channel="C0AATPSADB8",
+                existing_thread_ts="1770710833.425539",
+                skip_eval=True,
+            )
+
+        assert result["thread_ts"] == "1770710833.425539"
+
+    @pytest.mark.asyncio
+    async def test_rescore_parses_conversation_roles(self, mock_env, mock_slack):
+        """Conversation should be correctly parsed from thread replies with role detection."""
+        with patch("scripts.eval_slack_e2e.SlackConnector", return_value=mock_slack):
+            result = await run_evaluation(
+                scenario_name="stripe_webhook_failure",
+                channel="C0AATPSADB8",
+                existing_thread_ts="1770710833.425539",
+                skip_eval=True,
+            )
+
+        conversation = result["conversation"]
+        # First entry is the user message (from scenario config, not thread)
+        assert conversation[0][0] == "user"
+        # Second entry should be support_engineer (parsed from [SupportEngineer] prefix)
+        assert conversation[1][0] == "support_engineer"
+        assert "Sentry" in conversation[1][1]
+        # Third entry should be software_engineer
+        assert conversation[2][0] == "software_engineer"
+        assert "routing config" in conversation[2][1]
+
+    @pytest.mark.asyncio
+    async def test_rescore_conversation_count(self, mock_env, mock_slack):
+        """Should have 3 messages: 1 user + 2 bot replies."""
+        with patch("scripts.eval_slack_e2e.SlackConnector", return_value=mock_slack):
+            result = await run_evaluation(
+                scenario_name="stripe_webhook_failure",
+                channel="C0AATPSADB8",
+                existing_thread_ts="1770710833.425539",
+                skip_eval=True,
+            )
+
+        assert len(result["conversation"]) == 3
+
+    @pytest.mark.asyncio
+    async def test_rescore_generates_report(self, mock_env, mock_slack, tmp_path):
+        """Rescore mode should generate a report file."""
+        with (
+            patch("scripts.eval_slack_e2e.SlackConnector", return_value=mock_slack),
+            patch(
+                "scripts.eval_slack_e2e.generate_eval_report",
+                return_value=tmp_path / "test_report.md",
+            ) as mock_report,
+        ):
+            result = await run_evaluation(
+                scenario_name="stripe_webhook_failure",
+                channel="C0AATPSADB8",
+                existing_thread_ts="1770710833.425539",
+                skip_eval=True,
+            )
+
+        # Report generation should still be called
+        mock_report.assert_called_once()
+        call_kwargs = mock_report.call_args
+        # latency_ms should be 0 in rescore mode
+        assert call_kwargs.kwargs.get(
+            "latency_ms", call_kwargs[1].get("latency_ms", None)
+        ) == 0 or (len(call_kwargs.args) > 6 and call_kwargs.args[6] == 0)
+
+
+# ==============================================================================
+# Tests: Handoff timeout extension
+# ==============================================================================
+
+
+class TestHandoffTimeoutExtension:
+    """Tests for the handoff timeout auto-extension in the polling loop."""
+
+    @pytest.fixture
+    def mock_env(self, monkeypatch):
+        """Set required env vars."""
+        monkeypatch.setenv("SLACK_BOT_TOKEN", "xoxb-test-token")
+        monkeypatch.setenv("SLACK_TRIGGER_SECRET", "test-secret")
+
+    def test_stable_time_with_handoff_is_300(self):
+        """Verify the stable_time_with_handoff constant is 300 (not old 60)."""
+        # Read the source to verify the constant
+        import inspect
+
+        source = inspect.getsource(run_evaluation)
+        assert "stable_time_with_handoff = 300" in source
+
+    def test_stable_time_no_handoff_is_15(self):
+        """Verify stable_time_no_handoff constant is 15."""
+        import inspect
+
+        source = inspect.getsource(run_evaluation)
+        assert "stable_time_no_handoff = 15" in source
+
+    def test_effective_timeout_in_source(self):
+        """Verify effective_timeout variable is used for auto-extension."""
+        import inspect
+
+        source = inspect.getsource(run_evaluation)
+        assert "effective_timeout = wait_timeout" in source
+        assert "effective_timeout = time.time() - start_time + handoff_timeout_extension" in source
+
+    @pytest.mark.asyncio
+    async def test_handoff_detected_extends_timeout(self, mock_env):
+        """When bot message contains @SoftwareEngineer, effective_timeout should be extended."""
+        # Set up a mock Slack connector with a handoff message followed by a response
+        mock_slack = MagicMock()
+
+        # post_message returns a message with a ts
+        mock_slack.post_message.return_value = make_slack_message(
+            ts="100.000",
+            text="@SupportEngineer investigate",
+            is_bot=False,
+        )
+
+        # Track how many times get_thread_replies is called
+        call_count = 0
+
+        def mock_replies(*args, **kwargs):
+            nonlocal call_count
+            call_count += 1
+            if call_count <= 1:
+                # First poll: just the original message
+                return [
+                    make_slack_message(ts="100.000", text="@SupportEngineer investigate"),
+                ]
+            elif call_count == 2:
+                # Second poll: bot response with handoff mention
+                return [
+                    make_slack_message(ts="100.000", text="@SupportEngineer investigate"),
+                    make_slack_message(
+                        ts="101.000",
+                        text="[SupportEngineer] Found the issue. @SoftwareEngineer please fix the code.",
+                        is_bot=True,
+                        thread_ts="100.000",
+                    ),
+                ]
+            else:
+                # Third poll: second agent responded (no handoff)
+                return [
+                    make_slack_message(ts="100.000", text="@SupportEngineer investigate"),
+                    make_slack_message(
+                        ts="101.000",
+                        text="[SupportEngineer] Found the issue. @SoftwareEngineer please fix the code.",
+                        is_bot=True,
+                        thread_ts="100.000",
+                    ),
+                    make_slack_message(
+                        ts="102.000",
+                        text="[SoftwareEngineer] Fixed the routing config in PR #123.",
+                        is_bot=True,
+                        thread_ts="100.000",
+                    ),
+                ]
+
+        mock_slack.get_thread_replies.side_effect = mock_replies
+
+        with (
+            patch("scripts.eval_slack_e2e.SlackConnector", return_value=mock_slack),
+            patch("scripts.eval_slack_e2e.httpx.AsyncClient") as mock_httpx_cls,
+            patch("scripts.eval_slack_e2e.asyncio.sleep", new_callable=AsyncMock),
+        ):
+            # Set up httpx mock to return 200
+            mock_client = AsyncMock()
+            mock_response = MagicMock()
+            mock_response.status_code = 200
+            mock_response.json.return_value = {"roles": ["support_engineer"]}
+            mock_client.post.return_value = mock_response
+            mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+            mock_client.__aexit__ = AsyncMock(return_value=None)
+            mock_httpx_cls.return_value = mock_client
+
+            result = await run_evaluation(
+                scenario_name="support_400_errors",
+                channel="C_TEST",
+                wait_timeout=10,
+                poll_interval=1,
+                skip_eval=True,
+                handoff_timeout_extension=600,
+            )
+
+        # Should have conversation with handoff chain
+        assert len(result["conversation"]) >= 2
+        # The handoff response from SoftwareEngineer should appear
+        roles = [role for role, _ in result["conversation"]]
+        assert "support_engineer" in roles
+
+    @pytest.mark.asyncio
+    async def test_no_handoff_no_extension(self, mock_env):
+        """When bot message has no handoff mention, timeout should NOT be extended."""
+        mock_slack = MagicMock()
+
+        mock_slack.post_message.return_value = make_slack_message(
+            ts="100.000",
+            text="@SupportEngineer check something",
+            is_bot=False,
+        )
+
+        call_count = 0
+
+        def mock_replies(*args, **kwargs):
+            nonlocal call_count
+            call_count += 1
+            if call_count <= 1:
+                return [
+                    make_slack_message(ts="100.000", text="@SupportEngineer check something"),
+                ]
+            else:
+                # Bot response WITHOUT handoff
+                return [
+                    make_slack_message(ts="100.000", text="@SupportEngineer check something"),
+                    make_slack_message(
+                        ts="101.000",
+                        text="[SupportEngineer] Everything looks healthy. No issues found.",
+                        is_bot=True,
+                        thread_ts="100.000",
+                    ),
+                ]
+
+        mock_slack.get_thread_replies.side_effect = mock_replies
+
+        with (
+            patch("scripts.eval_slack_e2e.SlackConnector", return_value=mock_slack),
+            patch("scripts.eval_slack_e2e.httpx.AsyncClient") as mock_httpx_cls,
+            patch("scripts.eval_slack_e2e.asyncio.sleep", new_callable=AsyncMock),
+        ):
+            mock_client = AsyncMock()
+            mock_response = MagicMock()
+            mock_response.status_code = 200
+            mock_response.json.return_value = {"roles": ["support_engineer"]}
+            mock_client.post.return_value = mock_response
+            mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+            mock_client.__aexit__ = AsyncMock(return_value=None)
+            mock_httpx_cls.return_value = mock_client
+
+            result = await run_evaluation(
+                scenario_name="support_400_errors",
+                channel="C_TEST",
+                wait_timeout=10,
+                poll_interval=1,
+                skip_eval=True,
+            )
+
+        # Should have conversation without handoff extension
+        assert result["conversation"][1][0] == "support_engineer"
+        assert "healthy" in result["conversation"][1][1]
+
+
+# ==============================================================================
+# Tests: run_evaluation parameter validation
+# ==============================================================================
+
+
+class TestEvalParameterValidation:
+    """Tests for parameter validation in run_evaluation."""
+
+    @pytest.fixture
+    def mock_env(self, monkeypatch):
+        monkeypatch.setenv("SLACK_BOT_TOKEN", "xoxb-test-token")
+
+    @pytest.mark.asyncio
+    async def test_invalid_scenario_raises(self, mock_env):
+        """Unknown scenario name should raise ValueError."""
+        with pytest.raises(ValueError, match="Unknown scenario"):
+            await run_evaluation(scenario_name="nonexistent_scenario", channel="C_TEST")
+
+    @pytest.mark.asyncio
+    async def test_missing_slack_token_raises(self, monkeypatch):
+        """Missing SLACK_BOT_TOKEN should raise ValueError."""
+        monkeypatch.delenv("SLACK_BOT_TOKEN", raising=False)
+        with pytest.raises(ValueError, match="SLACK_BOT_TOKEN"):
+            await run_evaluation(scenario_name="support_400_errors", channel="C_TEST")
+
+    @pytest.mark.asyncio
+    async def test_missing_channel_raises(self, mock_env, monkeypatch):
+        """Missing channel should raise ValueError."""
+        monkeypatch.delenv("SLACK_DEFAULT_CHANNEL", raising=False)
+        with pytest.raises(ValueError, match="No channel specified"):
+            await run_evaluation(scenario_name="support_400_errors", channel=None)
+
+    def test_handoff_timeout_extension_parameter_exists(self):
+        """run_evaluation should accept handoff_timeout_extension parameter."""
+        import inspect
+
+        sig = inspect.signature(run_evaluation)
+        assert "handoff_timeout_extension" in sig.parameters
+        # Default should be 600
+        assert sig.parameters["handoff_timeout_extension"].default == 600
+
+    def test_existing_thread_ts_parameter_exists(self):
+        """run_evaluation should accept existing_thread_ts parameter."""
+        import inspect
+
+        sig = inspect.signature(run_evaluation)
+        assert "existing_thread_ts" in sig.parameters
+        assert sig.parameters["existing_thread_ts"].default is None
+
+
+# ==============================================================================
+# Tests: Scenario configuration
+# ==============================================================================
+
+
+class TestScenarios:
+    """Tests for scenario definitions."""
+
+    def test_all_scenarios_have_required_keys(self):
+        """Each scenario must have name, message, expected_agent, evaluation_criteria, threshold."""
+        required_keys = {"name", "message", "expected_agent", "evaluation_criteria", "threshold"}
+        for name, config in SCENARIOS.items():
+            missing = required_keys - set(config.keys())
+            assert not missing, f"Scenario '{name}' missing keys: {missing}"
+
+    def test_stripe_webhook_scenario_exists(self):
+        """The stripe_webhook_failure scenario must exist (used for rescore testing)."""
+        assert "stripe_webhook_failure" in SCENARIOS
+
+    def test_role_display_covers_all_agents(self):
+        """ROLE_DISPLAY should cover all expected agent roles."""
+        expected_roles = {
+            "user",
+            "support_engineer",
+            "software_engineer",
+            "release_engineer",
+            "product_manager",
+            "marketing_manager",
+        }
+        assert set(ROLE_DISPLAY.keys()) == expected_roles
+
+
+# ==============================================================================
+# Tests: CLI argument --thread-ts validation
+# ==============================================================================
+
+
+class TestCLIThreadTsValidation:
+    """Tests for --thread-ts CLI argument handling."""
+
+    def test_main_rejects_thread_ts_with_message(self):
+        """--thread-ts and --message should be mutually exclusive."""
+        from scripts.eval_slack_e2e import main
+
+        with patch(
+            "sys.argv",
+            [
+                "eval_slack_e2e.py",
+                "--thread-ts",
+                "123.456",
+                "--message",
+                "@SupportEngineer test",
+                "--channel",
+                "C_TEST",
+            ],
+        ):
+            exit_code = main()
+            assert exit_code == 1
+
+    def test_main_passes_thread_ts_to_run_evaluation(self):
+        """--thread-ts should be forwarded as existing_thread_ts to run_evaluation."""
+        from scripts.eval_slack_e2e import main
+
+        with (
+            patch(
+                "sys.argv",
+                [
+                    "eval_slack_e2e.py",
+                    "--scenario",
+                    "stripe_webhook_failure",
+                    "--thread-ts",
+                    "1770710833.425539",
+                    "--channel",
+                    "C0AATPSADB8",
+                    "--skip-eval",
+                ],
+            ),
+            patch("scripts.eval_slack_e2e.asyncio.run") as mock_run,
+        ):
+            mock_run.return_value = {"passed": True}
+            main()
+
+            # asyncio.run should be called with run_evaluation coroutine
+            mock_run.assert_called_once()
+            # Get the coroutine that was passed to asyncio.run
+            coro = mock_run.call_args[0][0]
+            # Close the coroutine to avoid RuntimeWarning
+            coro.close()
+
+    def test_main_passes_handoff_timeout(self):
+        """--handoff-timeout should be forwarded as handoff_timeout_extension."""
+        from scripts.eval_slack_e2e import main
+
+        with (
+            patch(
+                "sys.argv",
+                [
+                    "eval_slack_e2e.py",
+                    "--scenario",
+                    "support_400_errors",
+                    "--channel",
+                    "C_TEST",
+                    "--handoff-timeout",
+                    "900",
+                    "--skip-eval",
+                ],
+            ),
+            patch("scripts.eval_slack_e2e.asyncio.run") as mock_run,
+        ):
+            mock_run.return_value = {"passed": True}
+            main()
+            mock_run.assert_called_once()
+            coro = mock_run.call_args[0][0]
+            coro.close()


### PR DESCRIPTION
## Summary

Three improvements identified from manually scoring the SoftwareEngineer response in Slack thread `1770710833.425539` (stripe_webhook_failure scenario):

### 1. `--thread-ts` rescore mode
Re-score existing Slack threads without posting new messages or triggering the gateway. Useful for:
- Scoring responses that arrived after the eval timeout
- Re-evaluating threads after tuning evaluation criteria
- Quick iteration on G-Eval prompts

```bash
uv run python scripts/eval_slack_e2e.py \
  --scenario stripe_webhook_failure \
  --thread-ts 1770710833.425539 \
  --channel C0AATPSADB8
```

### 2. Handoff timeout auto-extension
When the eval script detects a handoff mention (@RoleName) in a bot response, it now auto-extends the effective timeout by `--handoff-timeout` seconds (default: 600). This prevents the SoftwareEngineer response from being missed when it arrives after the original 600s timeout.

Also increased `stable_time_with_handoff` from 60s to 300s since agent processing takes 5-10 minutes.

### 3. SoftwareEngineer agent prompt improvements
- **VERIFY YOUR FIX**: After applying any fix, the agent must verify it works (curl endpoints, run tests, check pod status). Reports BEFORE and AFTER state.
- **DO NOT FABRICATE ROOT CAUSES**: Anti-hallucination guardrails. Addresses the 0.50 EvidenceBasedDecision score where the agent claimed missing proxy headers caused HTTP 404s (incorrect — 404 means missing route/location block).

## Files Changed

| File | Change |
|------|--------|
| `scripts/eval_slack_e2e.py` | `--thread-ts`, `--handoff-timeout`, auto-extend, stable_time 60→300 |
| `agents/openhands/software_engineer.py` | VERIFY YOUR FIX + DO NOT FABRICATE ROOT CAUSES |
| `plan.md` | Updated with progress |

## Testing

- 87 existing unit tests pass
- ruff lint clean
- Live `--thread-ts` test requires `SLACK_BOT_TOKEN` (will run post-merge)