### PR TITLE
fix(agents): wire custom system prompt template so agent_context reaches LLM

### DIFF
--- a/agents/openhands/marketing_manager.py
+++ b/agents/openhands/marketing_manager.py
@@ -110,6 +110,11 @@ class OpenHandsMarketingManager:
         return Agent(
             llm=llm,
             mcp_config=mcp_config if mcp_config.get("mcpServers") else None,
+            # Use our custom template that renders agent_context into the system prompt.
+            # Without this, the default system_prompt.j2 ignores agent_context kwargs.
+            system_prompt_filename=os.path.join(
+                os.path.dirname(__file__), "prompts", "agent_system.j2"
+            ),
             system_prompt_kwargs={
                 "agent_context": MARKETING_MANAGER_CONTEXT,
             },

--- a/agents/openhands/product_manager.py
+++ b/agents/openhands/product_manager.py
@@ -131,6 +131,11 @@ class OpenHandsProductManager:
         """Create Agent with LLM."""
         return Agent(
             llm=llm,
+            # Use our custom template that renders agent_context into the system prompt.
+            # Without this, the default system_prompt.j2 ignores agent_context kwargs.
+            system_prompt_filename=os.path.join(
+                os.path.dirname(__file__), "prompts", "agent_system.j2"
+            ),
             system_prompt_kwargs={
                 "agent_context": PRODUCT_MANAGER_CONTEXT,
             },

--- a/agents/openhands/prompts/agent_system.j2
+++ b/agents/openhands/prompts/agent_system.j2
@@ -1,0 +1,37 @@
+{{ agent_context }}
+
+<EXECUTION_RULES>
+You are an AI agent that EXECUTES tasks, not one that describes them.
+
+**CRITICAL: When your instructions say to run a command, you MUST actually run it using the terminal tool. Describing or quoting commands without executing them is a FAILURE.**
+
+- Each action you take has a cost. Combine multiple commands where possible (e.g., multiple kubectl commands in one terminal call).
+- When exploring the codebase, use efficient tools like find, grep, and git commands with appropriate filters.
+- Always modify existing files directly rather than creating new versions.
+- Make focused, minimal changes to address the problem.
+</EXECUTION_RULES>
+
+<FILE_SYSTEM_GUIDELINES>
+- When a user provides a file path, do NOT assume it's relative to the current working directory. First explore the file system to locate the file.
+- If asked to edit a file, edit the file directly, rather than creating a new file with a different filename.
+- NEVER create multiple versions of the same file with different suffixes.
+</FILE_SYSTEM_GUIDELINES>
+
+<PROCESS_MANAGEMENT>
+- When terminating processes, do NOT use general keywords with commands like `pkill -f server` or `pkill -f python`.
+- Always use `ps aux` to find the exact process ID (PID) first, then kill that specific PID.
+- Prefer application-specific shutdown commands when available.
+</PROCESS_MANAGEMENT>
+
+<PROBLEM_SOLVING>
+If you've made repeated attempts to solve a problem but it's still broken:
+1. Step back and reflect on 5-7 different possible sources of the problem
+2. Assess the likelihood of each possible cause
+3. Methodically address the most likely causes, starting with the highest probability
+</PROBLEM_SOLVING>
+
+<SECURITY>
+- Only use credentials (GITHUB_TOKEN, API keys) in ways that are expected for the task.
+- Use APIs to work with GitHub or other platforms when possible.
+- Never expose secrets in command output or logs unnecessarily.
+</SECURITY>

--- a/agents/openhands/release_engineer.py
+++ b/agents/openhands/release_engineer.py
@@ -56,9 +56,9 @@ except ImportError:
     FileEditorTool = None
 
 
-# Note: OpenHands uses Jinja2 templates for system prompts.
-# For custom prompts, you can extend Agent and override system_prompt_filename
-# or provide system_prompt_kwargs for template variables.
+# OpenHands uses Jinja2 templates for system prompts.
+# We use agents/openhands/prompts/agent_system.j2 as a custom template
+# that renders agent_context into the system prompt via system_prompt_kwargs.
 
 RELEASE_ENGINEER_CONTEXT = """You are Einstein, the Release Engineer for VibeTeam.
 
@@ -74,9 +74,10 @@ You have FULL access to the production Kubernetes cluster. When you receive a ha
 from SupportEngineer with investigation findings, YOUR JOB IS TO ACT.
 
 ## PRE-FETCHED DATA AVAILABLE
-Look for the section starting with "## Pre-Fetched Kubernetes Context" below.
+Look for the section starting with "PRE-FETCHED KUBERNETES STATE" below.
 This contains the CURRENT state of pods, events, logs, and rollout history.
-**USE THIS DATA FIRST** instead of running manual `kubectl` commands to verify state.
+**USE THIS DATA** to understand the current state, but you still MUST run kubectl
+commands for any write operations (deploy, rollback, restart, scale).
 
 ## CRITICAL: TAKE ACTION, DON'T JUST INVESTIGATE
 
@@ -86,6 +87,24 @@ SupportEngineer has already investigated. When you receive a handoff:
 3. **TAKE THE APPROPRIATE ACTION** - don't just recommend, DO IT
 
 ## ACTIONS YOU MUST TAKE (not just recommend)
+
+### Deploy New Code (PR merged, deploy to staging/production)
+```bash
+# Step 1: Verify current state BEFORE deployment
+kubectl get pods -n vibeteam -o wide
+kubectl get deployments -n vibeteam
+
+# Step 2: Apply the latest manifests
+kubectl apply -k k8s/overlays/dev
+
+# Step 3: Wait for rollout to complete
+kubectl rollout status deployment/vibeteam-gateway -n vibeteam --timeout=120s
+kubectl rollout status deployment/openhands-svc -n vibeteam --timeout=120s
+
+# Step 4: Verify pods are healthy AFTER deployment
+kubectl get pods -n vibeteam
+kubectl get events -n vibeteam --sort-by='.lastTimestamp' | tail -10
+```
 
 ### Rollback a Deployment
 ```bash
@@ -151,6 +170,22 @@ kubectl get deployments -n vibeteam
 
 ## RESPONSE FORMAT AFTER TAKING ACTION
 
+### For Deployments:
+```
+**Deployment Executed:**
+- Ran: `kubectl apply -k k8s/overlays/dev`
+- Rollout: `kubectl rollout status deployment/vibeteam-gateway -n vibeteam` → Complete
+- Rollout: `kubectl rollout status deployment/openhands-svc -n vibeteam` → Complete
+
+**Verification:**
+- Pods: All Running (kubectl get pods output)
+- Events: No warnings or errors
+- Health: Endpoints responding normally
+
+Deployment to staging complete. Team notified.
+```
+
+### For Rollbacks/Incident Response:
 ```
 Received handoff about [issue].
 
@@ -214,8 +249,11 @@ class OpenHandsReleaseEngineer:
                 Tool(name=TerminalTool.name),
                 Tool(name=FileEditorTool.name),
             ],
-            # OpenHands uses template-based system prompts
-            # We pass context as kwargs for custom templates
+            # Use our custom template that renders agent_context into the system prompt.
+            # Without this, the default system_prompt.j2 ignores agent_context kwargs.
+            system_prompt_filename=os.path.join(
+                os.path.dirname(__file__), "prompts", "agent_system.j2"
+            ),
             system_prompt_kwargs={
                 "agent_context": RELEASE_ENGINEER_CONTEXT,
             },
@@ -285,13 +323,16 @@ class OpenHandsReleaseEngineer:
             if context_str:
                 context_block = f"""
 ================================================================================
-INJECTED DATA FROM MONITORING SYSTEMS - THIS IS YOUR DATA, USE IT!
+PRE-FETCHED KUBERNETES STATE (for reference - current as of this request)
 ================================================================================
 
 {context_str}
 
 ================================================================================
-END OF INJECTED DATA - The above data has ALREADY been fetched for you
+END OF PRE-FETCHED STATE
+NOTE: This is READ-ONLY state data. You still MUST run kubectl commands for any
+WRITE operations (apply, rollout, restart, scale, undo). Do NOT skip actions
+just because you have the current state above.
 ================================================================================
 """
                 full_task = f"{RELEASE_ENGINEER_CONTEXT}\n{context_block}\nTask: {task}"

--- a/agents/openhands/software_engineer.py
+++ b/agents/openhands/software_engineer.py
@@ -323,6 +323,11 @@ class OpenHandsSoftwareEngineer:
                 Tool(name=TerminalTool.name),
                 Tool(name=FileEditorTool.name),
             ],
+            # Use our custom template that renders agent_context into the system prompt.
+            # Without this, the default system_prompt.j2 ignores agent_context kwargs.
+            system_prompt_filename=os.path.join(
+                os.path.dirname(__file__), "prompts", "agent_system.j2"
+            ),
             system_prompt_kwargs={
                 "agent_context": SOFTWARE_ENGINEER_CONTEXT,
             },

--- a/agents/openhands/support_engineer.py
+++ b/agents/openhands/support_engineer.py
@@ -286,6 +286,11 @@ class OpenHandsSupportEngineer:
         return Agent(
             llm=llm,
             tools=tools,
+            # Use our custom template that renders agent_context into the system prompt.
+            # Without this, the default system_prompt.j2 ignores agent_context kwargs.
+            system_prompt_filename=os.path.join(
+                os.path.dirname(__file__), "prompts", "agent_system.j2"
+            ),
             system_prompt_kwargs={
                 "agent_context": SUPPORT_ENGINEER_CONTEXT,
             },

--- a/plan.md
+++ b/plan.md
@@ -1,15 +1,31 @@
 # Current Work Plan
 
-## Blocked: Slack App Webhook URL Configuration
+## In Progress: Fix release_deploy eval — system prompt template (Issue A)
 
-**Status:** Blocked on manual Slack admin access.
-**PR:** #54 (merged — manifest fix is on master)
+**Status:** Code changes complete, needs commit, deploy, and eval verification.
+**Branch:** master (uncommitted changes)
 
-### Manual Steps Required
-1. Go to https://api.slack.com/apps/A0AAZGWEAVA/event-subscriptions
-2. Change **Request URL** to: `https://webhook.team.vibebrowser.app/slack/events`
-3. Go to https://api.slack.com/apps/A0AAZGWEAVA/interactivity
-4. Change **Request URL** to: `https://webhook.team.vibebrowser.app/slack/interactive`
+### Problem
+The `release_deploy` eval failed because agents narrate what they'd do instead of actually running kubectl commands. Root cause: `system_prompt_kwargs` with `agent_context` was silently dropped because no custom `system_prompt_filename` was provided. The default OpenHands template (`system_prompt.j2`) ignores unknown kwargs.
+
+### Fix Applied
+- [x] Created `agents/openhands/prompts/agent_system.j2` — custom Jinja2 template that renders `{{ agent_context }}` (the agent persona/instructions) into the system prompt
+- [x] Wired `system_prompt_filename` in all 5 agent constructors:
+  - `release_engineer.py` — `system_prompt_filename=os.path.join(os.path.dirname(__file__), "prompts", "agent_system.j2")`
+  - `software_engineer.py` — same
+  - `support_engineer.py` — same
+  - `marketing_manager.py` — same
+  - `product_manager.py` — same
+- [x] Enhanced ReleaseEngineer context: added deployment playbook, deployment response format, clearer context block preamble
+- [x] Added deployment-specific task template in `slack.py` with explicit step-by-step kubectl instructions
+- [x] Added `tests/test_task_routing.py` (301 lines) for task routing/detection logic
+
+### Remaining Steps
+- [ ] Commit all changes
+- [ ] Deploy to cluster (build Docker image, push, restart deployments)
+- [ ] Run `release_deploy` eval: `uv run python scripts/eval_slack_e2e.py --scenario release_deploy --channel C0AATPSADB8 --timeout 600`
+- [ ] Verify no regression: run `support_400_errors` and `stripe_webhook_failure` evals
+- [ ] Update eval results table below
 
 ---
 

--- a/tests/test_system_prompt.py
+++ b/tests/test_system_prompt.py
@@ -1,0 +1,173 @@
+"""
+Tests for agent system prompt template configuration.
+
+Verifies that:
+1. The custom agent_system.j2 template exists and contains required variables
+2. The system_prompt_filename path construction is correct for all agents
+3. The template would be found at runtime (Docker or local)
+"""
+
+from __future__ import annotations
+
+import os
+
+import pytest
+
+# Path to the prompts directory (same logic agents use at runtime)
+PROMPTS_DIR = os.path.join(os.path.dirname(__file__), os.pardir, "agents", "openhands", "prompts")
+TEMPLATE_PATH = os.path.join(PROMPTS_DIR, "agent_system.j2")
+
+
+class TestTemplateExists:
+    """Verify the template file exists and has required content."""
+
+    def test_template_file_exists(self):
+        assert os.path.isfile(TEMPLATE_PATH), f"agent_system.j2 not found at {TEMPLATE_PATH}"
+
+    def test_template_contains_agent_context_variable(self):
+        with open(TEMPLATE_PATH) as f:
+            content = f.read()
+        assert "{{ agent_context }}" in content, (
+            "Template must contain {{ agent_context }} variable"
+        )
+
+    def test_template_contains_execution_instructions(self):
+        with open(TEMPLATE_PATH) as f:
+            content = f.read()
+        # Must instruct agent to actually execute, not just describe
+        assert "MUST" in content or "CRITICAL" in content, (
+            "Template should contain strong execution instructions"
+        )
+
+    def test_template_is_valid_jinja2(self):
+        """Basic check that the template has balanced Jinja2 blocks."""
+        with open(TEMPLATE_PATH) as f:
+            content = f.read()
+        # Count opening and closing block tags
+        opens = content.count("{%")
+        closes = content.count("%}")
+        assert opens == closes, f"Unbalanced Jinja2 block tags: {opens} opens vs {closes} closes"
+        var_opens = content.count("{{")
+        var_closes = content.count("}}")
+        assert var_opens == var_closes, (
+            f"Unbalanced Jinja2 variable tags: {var_opens} opens vs {var_closes} closes"
+        )
+
+
+class TestAgentPromptFilenameConstruction:
+    """
+    Verify each agent constructs the correct path to agent_system.j2.
+
+    Since we can't import the OpenHands SDK locally, we verify by:
+    1. Reading each agent source file
+    2. Checking it references system_prompt_filename with the correct path pattern
+    3. Verifying the resolved path points to a real file
+    """
+
+    AGENT_FILES = [
+        "release_engineer.py",
+        "software_engineer.py",
+        "support_engineer.py",
+        "marketing_manager.py",
+        "product_manager.py",
+    ]
+
+    @pytest.mark.parametrize("agent_file", AGENT_FILES)
+    def test_agent_has_system_prompt_filename(self, agent_file: str):
+        """Each agent must set system_prompt_filename in _create_agent."""
+        filepath = os.path.join(
+            os.path.dirname(__file__),
+            os.pardir,
+            "agents",
+            "openhands",
+            agent_file,
+        )
+        with open(filepath) as f:
+            content = f.read()
+
+        assert "system_prompt_filename" in content, (
+            f"{agent_file} does not set system_prompt_filename"
+        )
+
+    @pytest.mark.parametrize("agent_file", AGENT_FILES)
+    def test_agent_uses_correct_template_path(self, agent_file: str):
+        """Each agent must reference prompts/agent_system.j2."""
+        filepath = os.path.join(
+            os.path.dirname(__file__),
+            os.pardir,
+            "agents",
+            "openhands",
+            agent_file,
+        )
+        with open(filepath) as f:
+            content = f.read()
+
+        assert "agent_system.j2" in content, f"{agent_file} does not reference agent_system.j2"
+        assert "os.path.dirname(__file__)" in content, (
+            f"{agent_file} should use os.path.dirname(__file__) for reliable path resolution"
+        )
+
+    @pytest.mark.parametrize("agent_file", AGENT_FILES)
+    def test_resolved_path_exists(self, agent_file: str):
+        """The path each agent would construct at runtime must point to a real file."""
+        # Simulate: os.path.join(os.path.dirname(__file__), "prompts", "agent_system.j2")
+        # where __file__ is the agent module
+        agent_dir = os.path.join(
+            os.path.dirname(__file__),
+            os.pardir,
+            "agents",
+            "openhands",
+        )
+        resolved = os.path.join(agent_dir, "prompts", "agent_system.j2")
+        assert os.path.isfile(resolved), f"Resolved template path does not exist: {resolved}"
+
+    @pytest.mark.parametrize("agent_file", AGENT_FILES)
+    def test_agent_has_system_prompt_kwargs(self, agent_file: str):
+        """Each agent must also set system_prompt_kwargs with agent_context."""
+        filepath = os.path.join(
+            os.path.dirname(__file__),
+            os.pardir,
+            "agents",
+            "openhands",
+            agent_file,
+        )
+        with open(filepath) as f:
+            content = f.read()
+
+        assert "system_prompt_kwargs" in content, f"{agent_file} does not set system_prompt_kwargs"
+        assert '"agent_context"' in content, (
+            f'{agent_file} does not pass "agent_context" in system_prompt_kwargs'
+        )
+
+
+class TestTemplateContent:
+    """Verify the template has essential sections from the OpenHands default."""
+
+    def _read_template(self) -> str:
+        with open(TEMPLATE_PATH) as f:
+            return f.read()
+
+    def test_has_execution_rules(self):
+        content = self._read_template()
+        assert "EXECUTION_RULES" in content
+
+    def test_has_file_system_guidelines(self):
+        content = self._read_template()
+        assert "FILE_SYSTEM_GUIDELINES" in content
+
+    def test_has_process_management(self):
+        content = self._read_template()
+        assert "PROCESS_MANAGEMENT" in content
+
+    def test_has_security_section(self):
+        content = self._read_template()
+        assert "SECURITY" in content
+
+    def test_has_problem_solving(self):
+        content = self._read_template()
+        assert "PROBLEM_SOLVING" in content
+
+    def test_forbids_describing_instead_of_executing(self):
+        """The template must contain a clear instruction to execute, not describe."""
+        content = self._read_template()
+        assert "MUST actually run" in content or "MUST run" in content

--- a/tests/test_task_routing.py
+++ b/tests/test_task_routing.py
@@ -1,0 +1,301 @@
+"""
+Tests for gateway task template routing logic.
+
+Verifies that the correct task template (deployment, notification, investigation)
+is selected based on message content and target role.
+"""
+
+from __future__ import annotations
+
+import re
+
+
+def classify_task_template(role: str, user_message: str) -> str:
+    """
+    Reproduce the task template selection logic from slack.py _run_agent_and_respond.
+
+    Returns: "deployment", "notification", or "investigation"
+    """
+    msg_lower = user_message.lower()
+    is_notification = any(
+        kw in msg_lower
+        for kw in ["notify", "announce", "tell the team", "tell the customer", "confirm to"]
+    )
+    is_explicit_investigation = any(
+        kw in msg_lower
+        for kw in [
+            "investigate",
+            "check",
+            "debug",
+            "analyze",
+            "why",
+            "error",
+            "fail",
+            "broken",
+            "down",
+        ]
+    )
+    is_deployment = (
+        role == "release_engineer"
+        and any(
+            re.search(rf"\b{kw}\b", msg_lower)
+            for kw in ["deploy", "release", "ship it", "push to", "promote"]
+        )
+        and not is_explicit_investigation
+    )
+
+    if is_deployment:
+        return "deployment"
+    elif is_notification and not is_explicit_investigation:
+        return "notification"
+    else:
+        return "investigation"
+
+
+class TestDeploymentDetection:
+    """Test that deployment requests are correctly routed to deployment template."""
+
+    def test_deploy_to_staging(self):
+        result = classify_task_template(
+            "release_engineer",
+            "@ReleaseEngineer we need to deploy the latest changes to staging.",
+        )
+        assert result == "deployment"
+
+    def test_deploy_pr_merged(self):
+        result = classify_task_template(
+            "release_engineer",
+            "@ReleaseEngineer PR #123 has been merged. Please deploy to production.",
+        )
+        assert result == "deployment"
+
+    def test_release_new_version(self):
+        result = classify_task_template(
+            "release_engineer",
+            "@ReleaseEngineer please release v2.3.0 to staging.",
+        )
+        assert result == "deployment"
+
+    def test_ship_it(self):
+        result = classify_task_template(
+            "release_engineer",
+            "@ReleaseEngineer ship it to production.",
+        )
+        assert result == "deployment"
+
+    def test_push_to_staging(self):
+        result = classify_task_template(
+            "release_engineer",
+            "@ReleaseEngineer push to staging environment.",
+        )
+        assert result == "deployment"
+
+    def test_promote_to_prod(self):
+        result = classify_task_template(
+            "release_engineer",
+            "@ReleaseEngineer promote the staging build to production.",
+        )
+        assert result == "deployment"
+
+    def test_deploy_and_notify(self):
+        """Deploy + notify should still be deployment (deploy takes priority)."""
+        result = classify_task_template(
+            "release_engineer",
+            "@ReleaseEngineer deploy to staging and notify the team when done.",
+        )
+        assert result == "deployment"
+
+
+class TestDeploymentNotTriggeredForOtherRoles:
+    """Deployment template should only trigger for release_engineer role."""
+
+    def test_swe_deploy_message(self):
+        """SoftwareEngineer shouldn't get deployment template even with deploy keywords."""
+        result = classify_task_template(
+            "software_engineer",
+            "@SoftwareEngineer we need to deploy the latest changes.",
+        )
+        assert result == "investigation"
+
+    def test_support_deploy_message(self):
+        result = classify_task_template(
+            "support_engineer",
+            "@SupportEngineer customer is asking about the deployment.",
+        )
+        assert result == "investigation"
+
+    def test_pm_release_message(self):
+        result = classify_task_template(
+            "product_manager",
+            "@ProductManager when is the next release?",
+        )
+        assert result == "investigation"
+
+
+class TestDeploymentExcludedByInvestigationKeywords:
+    """Deploy + investigation keywords should fall back to investigation."""
+
+    def test_deploy_failed(self):
+        """'deploy' + 'fail' -> investigation, not deployment."""
+        result = classify_task_template(
+            "release_engineer",
+            "@ReleaseEngineer the deploy failed, please investigate.",
+        )
+        assert result == "investigation"
+
+    def test_deploy_error(self):
+        result = classify_task_template(
+            "release_engineer",
+            "@ReleaseEngineer there's an error after the last deploy.",
+        )
+        assert result == "investigation"
+
+    def test_deploy_broken(self):
+        result = classify_task_template(
+            "release_engineer",
+            "@ReleaseEngineer deployment is broken, everything is down.",
+        )
+        assert result == "investigation"
+
+    def test_deploy_investigate(self):
+        result = classify_task_template(
+            "release_engineer",
+            "@ReleaseEngineer investigate why the last deploy caused issues.",
+        )
+        assert result == "investigation"
+
+    def test_deploy_check_why(self):
+        result = classify_task_template(
+            "release_engineer",
+            "@ReleaseEngineer check why the last deployment broke the API.",
+        )
+        assert result == "investigation"
+
+
+class TestNotificationDetection:
+    """Test that notification requests are correctly detected."""
+
+    def test_notify_team(self):
+        result = classify_task_template(
+            "support_engineer",
+            "@SupportEngineer notify the customer that the fix is deployed.",
+        )
+        assert result == "notification"
+
+    def test_announce(self):
+        result = classify_task_template(
+            "marketing_manager",
+            "@MarketingManager announce the new release to customers.",
+        )
+        assert result == "notification"
+
+    def test_tell_the_team(self):
+        result = classify_task_template(
+            "release_engineer",
+            "@ReleaseEngineer tell the team the maintenance window is over.",
+        )
+        assert result == "notification"
+
+    def test_confirm_to_customer(self):
+        result = classify_task_template(
+            "support_engineer",
+            "@SupportEngineer confirm to the customer that issue is resolved.",
+        )
+        assert result == "notification"
+
+
+class TestNotificationExcludedByInvestigation:
+    """Notification + investigation keywords -> investigation."""
+
+    def test_notify_but_error(self):
+        result = classify_task_template(
+            "support_engineer",
+            "@SupportEngineer notify the customer about the error we found.",
+        )
+        assert result == "investigation"
+
+    def test_announce_but_investigate(self):
+        result = classify_task_template(
+            "marketing_manager",
+            "@MarketingManager investigate and then announce the fix.",
+        )
+        assert result == "investigation"
+
+
+class TestInvestigationFallback:
+    """Messages without deployment or notification keywords → investigation."""
+
+    def test_support_400_errors(self):
+        result = classify_task_template(
+            "support_engineer",
+            "@SupportEngineer customers are seeing 400 errors on the API.",
+        )
+        assert result == "investigation"
+
+    def test_github_issue(self):
+        result = classify_task_template(
+            "software_engineer",
+            "@SoftwareEngineer issue #449 reports browser extension crashes.",
+        )
+        assert result == "investigation"
+
+    def test_sentry_alert(self):
+        result = classify_task_template(
+            "support_engineer",
+            "@SupportEngineer Sentry is showing new errors in production.",
+        )
+        assert result == "investigation"
+
+    def test_generic_help(self):
+        result = classify_task_template(
+            "software_engineer",
+            "@SoftwareEngineer can you help with this?",
+        )
+        assert result == "investigation"
+
+
+class TestEdgeCases:
+    """Edge cases and boundary conditions."""
+
+    def test_empty_message(self):
+        result = classify_task_template("release_engineer", "")
+        assert result == "investigation"
+
+    def test_deploy_keyword_in_different_case(self):
+        result = classify_task_template(
+            "release_engineer",
+            "@ReleaseEngineer DEPLOY TO STAGING NOW!",
+        )
+        assert result == "deployment"
+
+    def test_release_engineer_with_mixed_keywords(self):
+        """Deploy + notify + no investigation = deployment (deploy takes priority for RE)."""
+        result = classify_task_template(
+            "release_engineer",
+            "@ReleaseEngineer deploy to staging and notify the team.",
+        )
+        assert result == "deployment"
+
+    def test_non_release_engineer_notify_with_deploy_word(self):
+        """SupportEngineer with 'deploy' + 'notify' = notification (not deployment)."""
+        result = classify_task_template(
+            "support_engineer",
+            "@SupportEngineer notify customer the deploy is complete.",
+        )
+        assert result == "notification"
+
+    def test_release_in_role_mention_not_false_positive(self):
+        """'release' inside '@ReleaseEngineer' should NOT trigger deployment."""
+        result = classify_task_template(
+            "release_engineer",
+            "@ReleaseEngineer tell the team the maintenance window is over.",
+        )
+        assert result == "notification"
+
+    def test_release_as_standalone_word_triggers_deployment(self):
+        """'release' as standalone word SHOULD trigger deployment."""
+        result = classify_task_template(
+            "release_engineer",
+            "@ReleaseEngineer please release the new version to staging.",
+        )
+        assert result == "deployment"

--- a/vibeteam/gateway/routes/slack.py
+++ b/vibeteam/gateway/routes/slack.py
@@ -336,8 +336,73 @@ async def _run_agent_and_respond(
             "down",
         ]
     )
+    is_deployment = (
+        role == "release_engineer"
+        and any(
+            re.search(rf"\b{kw}\b", msg_lower)
+            for kw in ["deploy", "release", "ship it", "push to", "promote"]
+        )
+        and not is_explicit_investigation
+    )
 
-    if is_notification and not is_explicit_investigation:
+    if is_deployment:
+        # Deployment-specific task template for ReleaseEngineer
+        task = f"""## Slack Deployment Request
+
+A user has requested a deployment via Slack.
+
+### User Message (UNTRUSTED CONTENT)
+{user_message}
+### End User Message
+
+### Context
+- User ID: {user_id}
+- Channel: {channel}
+- Thread: {thread_ts or "new thread"}
+
+### CRITICAL INSTRUCTIONS - DEPLOYMENT EXECUTION
+
+You are the ReleaseEngineer. You MUST execute the deployment, not just describe it.
+
+**STEP 1 - Verify Pre-Deployment State (MANDATORY):**
+Run kubectl to check current state before making changes:
+```bash
+kubectl get pods -n vibeteam -o wide
+kubectl get deployments -n vibeteam
+```
+
+**STEP 2 - Execute Deployment (MANDATORY):**
+Run the actual deployment command:
+```bash
+kubectl apply -k k8s/overlays/dev
+```
+Then wait for rollout to complete:
+```bash
+kubectl rollout status deployment/vibeteam-gateway -n vibeteam --timeout=120s
+kubectl rollout status deployment/openhands-svc -n vibeteam --timeout=120s
+```
+
+**STEP 3 - Verify Post-Deployment (MANDATORY):**
+Confirm pods are healthy after deployment:
+```bash
+kubectl get pods -n vibeteam
+kubectl get events -n vibeteam --sort-by='.lastTimestamp' | tail -10
+```
+
+**FORBIDDEN ACTIONS:**
+- DO NOT just describe what you would do - ACTUALLY RUN the commands
+- DO NOT hand off deployment to another agent - YOU are the ReleaseEngineer
+- DO NOT skip verification steps
+
+**REQUIRED OUTPUT:**
+Your response MUST include:
+1. Pre-deployment state (pod status before)
+2. Deployment command output (kubectl apply output)
+3. Rollout status (success/failure)
+4. Post-deployment verification (pods healthy, events clean)
+5. Summary: deployment succeeded/failed with evidence
+"""
+    elif is_notification and not is_explicit_investigation:
         # Simplified task for notifications - NO mandatory investigation steps
         task = f"""## Slack Notification Request
 


### PR DESCRIPTION
## Summary

- **Root cause fix**: `system_prompt_kwargs` with `agent_context` was silently dropped because the default OpenHands `system_prompt.j2` template ignores unknown kwargs. This meant agent personas/instructions never reached the LLM system prompt, causing agents to narrate kubectl commands instead of executing them.
- **Custom Jinja2 template** (`agents/openhands/prompts/agent_system.j2`) that renders `{{ agent_context }}` into the system prompt, plus execution rules, file system guidelines, process management, security, and problem solving sections ported from the default OpenHands template to avoid capability regression.
- **All 5 agents wired up** with `system_prompt_filename` pointing to the custom template via absolute path (`os.path.dirname(__file__)`).
- **Deployment-specific task template** in gateway `slack.py` with explicit step-by-step kubectl instructions for ReleaseEngineer.
- **61 new tests**: 30 for system prompt template verification, 31 for task routing logic.

## What Changed

| File | Change |
|------|--------|
| `agents/openhands/prompts/agent_system.j2` | NEW — Custom Jinja2 template with agent_context + operational guidelines |
| `agents/openhands/release_engineer.py` | Added `system_prompt_filename`, deployment playbook, clearer context preamble |
| `agents/openhands/software_engineer.py` | Added `system_prompt_filename` |
| `agents/openhands/support_engineer.py` | Added `system_prompt_filename` |
| `agents/openhands/marketing_manager.py` | Added `system_prompt_filename` |
| `agents/openhands/product_manager.py` | Added `system_prompt_filename` |
| `vibeteam/gateway/routes/slack.py` | Added deployment-specific task template with explicit kubectl instructions |
| `tests/test_system_prompt.py` | NEW — 30 tests verifying template exists, content, and path construction |
| `tests/test_task_routing.py` | NEW — 31 tests for deployment/notification/investigation task routing |

## Test Results

```
260 passed, 77 skipped (integration), 0 failures
Ruff lint: all checks passed
```

## Verification Plan

After merge and deploy:
1. Run `release_deploy` eval to confirm fix
2. Run `support_400_errors` and `stripe_webhook_failure` regression evals