### PR TITLE
fix(agents): prevent ReleaseEngineer from destroying its own infrastructure

### DIFF
--- a/agents/openhands/release_engineer.py
+++ b/agents/openhands/release_engineer.py
@@ -79,6 +79,32 @@ This contains the CURRENT state of pods, events, logs, and rollout history.
 **USE THIS DATA** to understand the current state, but you still MUST run kubectl
 commands for any write operations (deploy, rollback, restart, scale).
 
+## ==========================================================================
+## CRITICAL SAFETY RULE: DO NOT DESTROY YOUR OWN INFRASTRUCTURE
+## ==========================================================================
+##
+## You (ReleaseEngineer) run INSIDE the vibeteam-gateway and openhands-svc pods.
+## If you restart, replace, or delete these pods, YOUR OWN REQUEST WILL DIE
+## and your response will NEVER reach Slack.
+##
+## FORBIDDEN COMMANDS (will kill your in-flight request):
+##   - kubectl apply -k k8s/overlays/dev  (replaces pod specs, triggers rollout)
+##   - kubectl apply -k k8s/base/         (same effect)
+##   - kubectl rollout restart deployment/vibeteam-gateway -n vibeteam
+##   - kubectl rollout restart deployment/openhands-svc -n vibeteam
+##   - kubectl delete pod <any vibeteam-gateway or openhands-svc pod>
+##   - kubectl delete deployment vibeteam-gateway or openhands-svc
+##   - Any command that modifies the deployment spec of vibeteam-gateway or openhands-svc
+##
+## SAFE ALTERNATIVES:
+##   - To update container images: use `kubectl set image` (rolling update, safe)
+##   - To check state: use `kubectl get`, `kubectl describe`, `kubectl logs` (read-only)
+##   - To rollback OTHER deployments: `kubectl rollout undo` is safe for non-self deployments
+##   - For vibeteam-gateway/openhands-svc rollback: report the need and recommend
+##     a human or CI/CD pipeline handles it (since you cannot survive the restart)
+##
+## ==========================================================================
+
 ## CRITICAL: TAKE ACTION, DON'T JUST INVESTIGATE
 
 SupportEngineer has already investigated. When you receive a handoff:
@@ -88,48 +114,51 @@ SupportEngineer has already investigated. When you receive a handoff:
 
 ## ACTIONS YOU MUST TAKE (not just recommend)
 
-### Deploy New Code (PR merged, deploy to staging/production)
+### Deploy New Code (update container images)
 ```bash
-# Step 1: Verify current state BEFORE deployment
+# Step 1: Check current deployment state
 kubectl get pods -n vibeteam -o wide
-kubectl get deployments -n vibeteam
+kubectl get deployments -n vibeteam -o wide
 
-# Step 2: Apply the latest manifests
-kubectl apply -k k8s/overlays/dev
+# Step 2: Check what image tag is currently running
+kubectl get deployment vibeteam-gateway -n vibeteam -o jsonpath='{.spec.template.spec.containers[0].image}'
+kubectl get deployment openhands-svc -n vibeteam -o jsonpath='{.spec.template.spec.containers[0].image}'
 
-# Step 3: Wait for rollout to complete
+# Step 3: Update image tag (replace <NEW_TAG> with actual commit SHA or version)
+# This triggers a safe rolling update that does NOT immediately kill your pod.
+kubectl set image deployment/vibeteam-gateway gateway=ghcr.io/vibetechnologies/vibeteam:<NEW_TAG> -n vibeteam
+kubectl set image deployment/openhands-svc openhands=ghcr.io/vibetechnologies/vibeteam-openhands:<NEW_TAG> -n vibeteam
+
+# Step 4: Monitor rollout (non-destructive, just watches)
 kubectl rollout status deployment/vibeteam-gateway -n vibeteam --timeout=120s
 kubectl rollout status deployment/openhands-svc -n vibeteam --timeout=120s
 
-# Step 4: Verify pods are healthy AFTER deployment
+# Step 5: Verify pods are healthy AFTER deployment
 kubectl get pods -n vibeteam
 kubectl get events -n vibeteam --sort-by='.lastTimestamp' | tail -10
 ```
+**NOTE:** If no specific image tag is provided in the request, check the latest available
+tag from the GitHub Container Registry or ask the user which tag/commit to deploy.
+Do NOT blindly apply kustomize overlays — they modify pod specs and kill in-flight requests.
 
-### Rollback a Deployment
+### Rollback a Deployment (non-self deployments)
 ```bash
 # Check rollout history
-kubectl rollout history deployment/vibeteam-gateway -n vibeteam
+kubectl rollout history deployment/<DEPLOYMENT_NAME> -n vibeteam
 
 # Rollback to previous version
-kubectl rollout undo deployment/vibeteam-gateway -n vibeteam
+kubectl rollout undo deployment/<DEPLOYMENT_NAME> -n vibeteam
 
 # Verify rollback succeeded
-kubectl rollout status deployment/vibeteam-gateway -n vibeteam --timeout=120s
+kubectl rollout status deployment/<DEPLOYMENT_NAME> -n vibeteam --timeout=120s
 ```
-
-### Restart Pods (for transient issues)
-```bash
-# Rolling restart
-kubectl rollout restart deployment/vibeteam-gateway -n vibeteam
-
-# Wait for restart to complete
-kubectl rollout status deployment/vibeteam-gateway -n vibeteam --timeout=120s
-```
+**WARNING:** For vibeteam-gateway and openhands-svc rollbacks, the rollout will terminate
+your in-flight request. Report the rollback as needed and state it should be triggered
+externally (CI/CD or human operator) so the response can still reach Slack.
 
 ### Scale for Load Issues
 ```bash
-# Scale up
+# Scale up (safe — adds pods, does not replace existing ones)
 kubectl scale deployment/vibeteam-gateway -n vibeteam --replicas=3
 
 # Verify scaling
@@ -157,11 +186,15 @@ kubectl get deployments -n vibeteam
 ## OWNERSHIP MATRIX
 
 **YOU ARE RESPONSIBLE FOR:**
-- Rollbacks (kubectl rollout undo)
-- Restarts (kubectl rollout restart)
+- Image updates (kubectl set image)
+- Rollbacks for non-self deployments (kubectl rollout undo)
 - Scaling (kubectl scale)
-- Deployments (kubectl apply)
-- Any production cluster modifications
+- Any production cluster modifications (except self-destructive ones)
+
+**SELF-DESTRUCTIVE ACTIONS (report but do NOT execute):**
+- Rollback/restart of vibeteam-gateway or openhands-svc
+- Applying kustomize overlays that change gateway/openhands pod specs
+- These must be triggered by CI/CD pipeline or human operator
 
 **YOU HAND OFF TO:**
 - @SoftwareEngineer - if root cause is a code bug that needs fixing
@@ -173,9 +206,10 @@ kubectl get deployments -n vibeteam
 ### For Deployments:
 ```
 **Deployment Executed:**
-- Ran: `kubectl apply -k k8s/overlays/dev`
-- Rollout: `kubectl rollout status deployment/vibeteam-gateway -n vibeteam` → Complete
-- Rollout: `kubectl rollout status deployment/openhands-svc -n vibeteam` → Complete
+- Current image: `ghcr.io/vibetechnologies/vibeteam:<old_tag>`
+- Updated to: `ghcr.io/vibetechnologies/vibeteam:<new_tag>`
+- Ran: `kubectl set image deployment/vibeteam-gateway gateway=ghcr.io/vibetechnologies/vibeteam:<new_tag> -n vibeteam`
+- Rollout: `kubectl rollout status deployment/vibeteam-gateway -n vibeteam` -> Complete
 
 **Verification:**
 - Pods: All Running (kubectl get pods output)
@@ -190,7 +224,7 @@ Deployment to staging complete. Team notified.
 Received handoff about [issue].
 
 **Action Taken:**
-- Ran: `kubectl rollout undo deployment/vibeteam-gateway -n vibeteam`
+- Ran: `kubectl rollout undo deployment/<DEPLOYMENT_NAME> -n vibeteam`
 - Result: Rolled back to revision 5
 - Verified: All pods now Running, no errors in events
 

--- a/plan.md
+++ b/plan.md
@@ -180,21 +180,28 @@ Last updated: 2026-02-10
 
 ## In-Progress Work
 
-### Branch: `fix/release-deploy-eval`
+### Branch: `fix/release-deploy-self-destruct`
 
-**Goals:**
-1. Fix `release_deploy` eval failure (DeploymentExecution: 0.40 → target ≥0.60)
-2. Fix `github_issue` eval timeout (agent ReadTimeout at 600s)
+**Root Cause:** ReleaseEngineer agent kills its own infrastructure when executing deployment
+commands (`kubectl apply -k k8s/overlays/dev` and `kubectl rollout restart`) which replace
+the vibeteam-gateway/openhands-svc pods that are processing the agent's own request.
+The in-flight request dies and the response never reaches Slack, causing eval timeouts.
+
+**Fix:** Replace destructive commands with safe `kubectl set image` approach and add
+critical safety guardrails to prevent self-infrastructure destruction.
 
 **Changes:**
-- [x] ReleaseEngineer prompt: Added deployment playbook (kubectl apply -k, rollout status, verification)
-- [x] ReleaseEngineer prompt: Updated response format with deployment-specific template
-- [x] ReleaseEngineer: Changed pre-fetched data preamble to not discourage write operations
-- [x] Gateway `slack.py`: Added deployment task template (detects deploy/release/ship/promote for RE role)
-- [x] Gateway `slack.py`: Word-boundary regex for deployment keywords (avoids false-positive on @ReleaseEngineer)
-- [x] Gateway `server.py`: Increased agent HTTP timeout from 600s to 900s (15 min)
-- [x] Gateway `server.py`: No retry on ReadTimeout (agent is processing, not down)
-- [x] SWE prompt: Updated time limit from 60s to 10 minutes, added prioritize-analysis-first guidance
-- [x] 31 new unit tests for task routing logic (deployment, notification, investigation classification)
+- [x] `release_engineer.py`: Added CRITICAL SAFETY RULE section forbidding self-destructive commands
+- [x] `release_engineer.py`: Replaced `kubectl apply -k` with `kubectl set image` in deploy playbook
+- [x] `release_engineer.py`: Removed "Restart Pods" section (was: `kubectl rollout restart deployment/vibeteam-gateway`)
+- [x] `release_engineer.py`: Added SELF-DESTRUCTIVE ACTIONS section documenting unsafe operations
+- [x] `release_engineer.py`: Updated response format to use `kubectl set image` output
+- [x] `slack.py`: Added CRITICAL SAFETY RULE block to deployment task template
+- [x] `slack.py`: Replaced `kubectl apply -k` with `kubectl set image` in deployment steps
+- [x] `slack.py`: Added Step 2 for checking current image tags before deployment
+- [x] `slack.py`: Updated FORBIDDEN ACTIONS and REQUIRED OUTPUT sections
+- [x] `test_system_prompt.py`: Added 12 new tests for safety guardrails (RE context + deployment template)
+- [x] All 357 tests pass (77 skipped integration tests)
 - [ ] Deploy and run release_deploy eval to verify fix
+- [ ] Run regression evals (support_400_errors, stripe_webhook_failure)
 - [ ] Deploy and run github_issue eval to verify fix

--- a/tests/test_system_prompt.py
+++ b/tests/test_system_prompt.py
@@ -171,3 +171,146 @@ class TestTemplateContent:
         """The template must contain a clear instruction to execute, not describe."""
         content = self._read_template()
         assert "MUST actually run" in content or "MUST run" in content
+
+
+class TestReleaseEngineerSafetyGuardrails:
+    """Verify the ReleaseEngineer context has self-infrastructure safety guardrails."""
+
+    @staticmethod
+    def _read_re_context() -> str:
+        filepath = os.path.join(
+            os.path.dirname(__file__),
+            os.pardir,
+            "agents",
+            "openhands",
+            "release_engineer.py",
+        )
+        with open(filepath) as f:
+            return f.read()
+
+    def test_has_safety_rule_header(self):
+        """Must have the critical safety rule about self-infrastructure."""
+        content = self._read_re_context()
+        assert "DO NOT DESTROY YOUR OWN INFRASTRUCTURE" in content
+
+    def test_forbids_kubectl_apply_k_overlays(self):
+        """Must explicitly forbid kubectl apply -k k8s/overlays/dev."""
+        content = self._read_re_context()
+        # The command must appear in a FORBIDDEN context, not as an instruction to run
+        assert "kubectl apply -k k8s/overlays/dev" in content
+        # Must NOT appear outside a forbidden/warning block as a command to execute
+        lines = content.split("\n")
+        for line in lines:
+            stripped = line.strip()
+            if "kubectl apply -k k8s/overlays/dev" in stripped:
+                # Line should be in a comment/forbidden section, not a "Step 2" instruction
+                assert (
+                    stripped.startswith("#")
+                    or "FORBIDDEN" in stripped
+                    or "replaces pod" in stripped
+                ), f"Unsafe line found: {stripped}"
+
+    def test_forbids_kubectl_rollout_restart_gateway(self):
+        """Must explicitly forbid kubectl rollout restart on gateway."""
+        content = self._read_re_context()
+        assert "kubectl rollout restart deployment/vibeteam-gateway" in content
+        # Verify it's in the forbidden section
+        lines = content.split("\n")
+        for line in lines:
+            stripped = line.strip()
+            if "kubectl rollout restart deployment/vibeteam-gateway" in stripped:
+                assert stripped.startswith("#"), f"Unsafe line found: {stripped}"
+
+    def test_forbids_kubectl_rollout_restart_openhands(self):
+        """Must explicitly forbid kubectl rollout restart on openhands-svc."""
+        content = self._read_re_context()
+        assert "kubectl rollout restart deployment/openhands-svc" in content
+
+    def test_recommends_kubectl_set_image(self):
+        """Must recommend kubectl set image as the safe alternative."""
+        content = self._read_re_context()
+        assert "kubectl set image" in content
+
+    def test_no_restart_pods_section(self):
+        """The 'Restart Pods' section that told agents to restart gateway must be gone."""
+        content = self._read_re_context()
+        # Should NOT have a section header like "### Restart Pods"
+        assert "### Restart Pods" not in content
+
+    def test_deploy_section_uses_set_image(self):
+        """The 'Deploy New Code' section must use kubectl set image, not kubectl apply."""
+        content = self._read_re_context()
+        # Find the deploy section
+        deploy_start = content.find("### Deploy New Code")
+        assert deploy_start != -1, "Deploy section not found"
+        # Find the next section header
+        next_section = content.find("###", deploy_start + 1)
+        deploy_section = (
+            content[deploy_start:next_section] if next_section != -1 else content[deploy_start:]
+        )
+        assert "kubectl set image" in deploy_section
+        # Must NOT contain kubectl apply -k as an instruction
+        for line in deploy_section.split("\n"):
+            stripped = line.strip()
+            if "kubectl apply -k" in stripped and not stripped.startswith("#"):
+                pytest.fail(f"Deploy section contains unsafe kubectl apply: {stripped}")
+
+    def test_has_self_destructive_actions_section(self):
+        """Must document which actions are self-destructive."""
+        content = self._read_re_context()
+        assert "SELF-DESTRUCTIVE ACTIONS" in content
+
+
+class TestDeploymentTaskTemplateSafety:
+    """Verify the deployment task template in slack.py has safety guardrails."""
+
+    @staticmethod
+    def _read_slack_py() -> str:
+        filepath = os.path.join(
+            os.path.dirname(__file__),
+            os.pardir,
+            "vibeteam",
+            "gateway",
+            "routes",
+            "slack.py",
+        )
+        with open(filepath) as f:
+            return f.read()
+
+    def test_has_safety_rule_in_deployment_template(self):
+        """Deployment task template must warn about self-infrastructure destruction."""
+        content = self._read_slack_py()
+        assert "DO NOT DESTROY YOUR OWN INFRASTRUCTURE" in content
+
+    def test_deployment_template_forbids_kubectl_apply_k(self):
+        """Deployment template must list kubectl apply -k as forbidden."""
+        content = self._read_slack_py()
+        # Find the deployment template section
+        deploy_start = content.find("## Slack Deployment Request")
+        assert deploy_start != -1, "Deployment template not found"
+        deploy_end = content.find("elif is_notification", deploy_start)
+        deploy_section = content[deploy_start:deploy_end]
+
+        # kubectl apply -k must be in FORBIDDEN section, not as instruction
+        assert "kubectl apply -k" in deploy_section
+        # The STEP 3 should use kubectl set image, not kubectl apply
+        step3_start = deploy_section.find("STEP 3")
+        assert step3_start != -1
+        step3_section = deploy_section[step3_start:]
+        assert "kubectl set image" in step3_section
+
+    def test_deployment_template_uses_set_image(self):
+        """Deployment template must instruct agent to use kubectl set image."""
+        content = self._read_slack_py()
+        deploy_start = content.find("## Slack Deployment Request")
+        deploy_end = content.find("elif is_notification", deploy_start)
+        deploy_section = content[deploy_start:deploy_end]
+        assert "kubectl set image" in deploy_section
+
+    def test_deployment_template_has_image_check_step(self):
+        """Deployment template must include a step to check current image tags."""
+        content = self._read_slack_py()
+        deploy_start = content.find("## Slack Deployment Request")
+        deploy_end = content.find("elif is_notification", deploy_start)
+        deploy_section = content[deploy_start:deploy_end]
+        assert "Check Current Image Tags" in deploy_section or "jsonpath" in deploy_section

--- a/vibeteam/gateway/routes/slack.py
+++ b/vibeteam/gateway/routes/slack.py
@@ -360,6 +360,24 @@ A user has requested a deployment via Slack.
 - Channel: {channel}
 - Thread: {thread_ts or "new thread"}
 
+### =================================================================
+### CRITICAL SAFETY RULE: DO NOT DESTROY YOUR OWN INFRASTRUCTURE
+### =================================================================
+###
+### You (ReleaseEngineer) run INSIDE vibeteam-gateway and openhands-svc.
+### If you restart or replace these pods, YOUR REQUEST DIES and the
+### response NEVER reaches Slack. The eval/user sees a timeout.
+###
+### FORBIDDEN (kills your in-flight request):
+###   kubectl apply -k k8s/overlays/dev
+###   kubectl apply -k k8s/base/
+###   kubectl rollout restart deployment/vibeteam-gateway -n vibeteam
+###   kubectl rollout restart deployment/openhands-svc -n vibeteam
+###   kubectl delete pod/deployment for gateway or openhands
+###
+### SAFE ALTERNATIVE: kubectl set image (rolling update, safe)
+### =================================================================
+
 ### CRITICAL INSTRUCTIONS - DEPLOYMENT EXECUTION
 
 You are the ReleaseEngineer. You MUST execute the deployment, not just describe it.
@@ -368,21 +386,31 @@ You are the ReleaseEngineer. You MUST execute the deployment, not just describe 
 Run kubectl to check current state before making changes:
 ```bash
 kubectl get pods -n vibeteam -o wide
-kubectl get deployments -n vibeteam
+kubectl get deployments -n vibeteam -o wide
 ```
 
-**STEP 2 - Execute Deployment (MANDATORY):**
-Run the actual deployment command:
+**STEP 2 - Check Current Image Tags (MANDATORY):**
 ```bash
-kubectl apply -k k8s/overlays/dev
+kubectl get deployment vibeteam-gateway -n vibeteam -o jsonpath='{{.spec.template.spec.containers[0].image}}'
+kubectl get deployment openhands-svc -n vibeteam -o jsonpath='{{.spec.template.spec.containers[0].image}}'
 ```
-Then wait for rollout to complete:
+
+**STEP 3 - Execute Deployment (MANDATORY):**
+Use `kubectl set image` to update the container image to the requested tag:
+```bash
+kubectl set image deployment/vibeteam-gateway gateway=ghcr.io/vibetechnologies/vibeteam:<NEW_TAG> -n vibeteam
+kubectl set image deployment/openhands-svc openhands=ghcr.io/vibetechnologies/vibeteam-openhands:<NEW_TAG> -n vibeteam
+```
+If no specific tag is given in the user message, check the latest tag or ask.
+Do NOT run `kubectl apply -k` — it modifies pod specs and kills your own pod.
+
+Then monitor rollout (safe, read-only):
 ```bash
 kubectl rollout status deployment/vibeteam-gateway -n vibeteam --timeout=120s
 kubectl rollout status deployment/openhands-svc -n vibeteam --timeout=120s
 ```
 
-**STEP 3 - Verify Post-Deployment (MANDATORY):**
+**STEP 4 - Verify Post-Deployment (MANDATORY):**
 Confirm pods are healthy after deployment:
 ```bash
 kubectl get pods -n vibeteam
@@ -390,6 +418,8 @@ kubectl get events -n vibeteam --sort-by='.lastTimestamp' | tail -10
 ```
 
 **FORBIDDEN ACTIONS:**
+- DO NOT run `kubectl apply -k` (kills your pod)
+- DO NOT run `kubectl rollout restart` on gateway or openhands-svc (kills your pod)
 - DO NOT just describe what you would do - ACTUALLY RUN the commands
 - DO NOT hand off deployment to another agent - YOU are the ReleaseEngineer
 - DO NOT skip verification steps
@@ -397,10 +427,11 @@ kubectl get events -n vibeteam --sort-by='.lastTimestamp' | tail -10
 **REQUIRED OUTPUT:**
 Your response MUST include:
 1. Pre-deployment state (pod status before)
-2. Deployment command output (kubectl apply output)
-3. Rollout status (success/failure)
-4. Post-deployment verification (pods healthy, events clean)
-5. Summary: deployment succeeded/failed with evidence
+2. Current image tags (what's running now)
+3. Deployment command output (kubectl set image output)
+4. Rollout status (success/failure)
+5. Post-deployment verification (pods healthy, events clean)
+6. Summary: deployment succeeded/failed with evidence
 """
     elif is_notification and not is_explicit_investigation:
         # Simplified task for notifications - NO mandatory investigation steps


### PR DESCRIPTION
## Summary

- Add critical safety guardrails to prevent the ReleaseEngineer agent from killing its own vibeteam-gateway and openhands-svc pods mid-request
- Replace destructive `kubectl apply -k` and `kubectl rollout restart` commands with safe `kubectl set image` approach

## Root Cause

When the ReleaseEngineer receives a deployment request, it executes `kubectl apply -k k8s/overlays/dev` which changes the deployment spec (adds git-sync sidecars, changes image tags to `:dev`), triggering a full pod replacement. Since the agent runs **inside** these pods, its own request dies and the response never reaches Slack. The eval times out at 600s with "NOT EVALUATED".

Evidence from 4 consecutive eval runs: every time the agent runs `kubectl apply`, the `restartedAt` annotation changes ~3 minutes later, both pods get replaced, and the in-flight request is lost.

## Changes

### `agents/openhands/release_engineer.py`
- Added **CRITICAL SAFETY RULE** section listing all forbidden self-destructive commands
- Replaced `kubectl apply -k k8s/overlays/dev` with `kubectl set image` in the deployment playbook
- Removed the "Restart Pods" section (which told agents to `kubectl rollout restart deployment/vibeteam-gateway`)
- Added **SELF-DESTRUCTIVE ACTIONS** section documenting operations that must be handled externally
- Updated response format template to use `kubectl set image` output

### `vibeteam/gateway/routes/slack.py`
- Added **CRITICAL SAFETY RULE** block to the deployment task template
- Replaced `kubectl apply -k` instruction with `kubectl set image` in deployment steps
- Added Step 2 for checking current image tags before deployment
- Updated FORBIDDEN ACTIONS and REQUIRED OUTPUT sections

### `tests/test_system_prompt.py`
- Added 12 new tests verifying safety guardrails exist in both the RE context and deployment task template
- Tests verify forbidden commands only appear in warning contexts, not as executable instructions
- Tests verify `kubectl set image` is the recommended approach

## Test Results

357 passed, 77 skipped (integration tests requiring `--run-integration`), 0 failures.

## Next Steps

After merge and deploy:
1. Pause rollouts, run `release_deploy` eval scenario
2. Run regression evals (support_400_errors, stripe_webhook_failure)