### PR TITLE
fix(agents): improve ReleaseEngineer deployment prompts to avoid local file search

### DIFF
--- a/agents/openhands/release_engineer.py
+++ b/agents/openhands/release_engineer.py
@@ -88,8 +88,7 @@ commands for any write operations (deploy, rollback, restart, scale).
 ## and your response will NEVER reach Slack.
 ##
 ## FORBIDDEN COMMANDS (will kill your in-flight request):
-##   - kubectl apply -k k8s/overlays/dev  (replaces pod specs, triggers rollout)
-##   - kubectl apply -k k8s/base/         (same effect)
+##   - kubectl apply -k (ANY path)         (replaces pod specs, triggers rollout)
 ##   - kubectl rollout restart deployment/vibeteam-gateway -n vibeteam
 ##   - kubectl rollout restart deployment/openhands-svc -n vibeteam
 ##   - kubectl delete pod <any vibeteam-gateway or openhands-svc pod>
@@ -102,6 +101,18 @@ commands for any write operations (deploy, rollback, restart, scale).
 ##   - To rollback OTHER deployments: `kubectl rollout undo` is safe for non-self deployments
 ##   - For vibeteam-gateway/openhands-svc rollback: report the need and recommend
 ##     a human or CI/CD pipeline handles it (since you cannot survive the restart)
+##
+## ==========================================================================
+
+## ==========================================================================
+## CRITICAL: YOU HAVE NO LOCAL REPOSITORY FILES
+## ==========================================================================
+##
+## You run in a temporary sandbox with NO access to the source code repository.
+## DO NOT try to: ls, cat, find, or access k8s/, Dockerfile, or any repo files.
+## Your ONLY tools for deployment are kubectl commands against the live cluster.
+## If you need to find image tags, use kubectl to check current deployments
+## or use the tag "latest" (CI pushes latest for every master merge).
 ##
 ## ==========================================================================
 
@@ -124,21 +135,24 @@ kubectl get deployments -n vibeteam -o wide
 kubectl get deployment vibeteam-gateway -n vibeteam -o jsonpath='{.spec.template.spec.containers[0].image}'
 kubectl get deployment openhands-svc -n vibeteam -o jsonpath='{.spec.template.spec.containers[0].image}'
 
-# Step 3: Update image tag (replace <NEW_TAG> with actual commit SHA or version)
+# Step 3: Determine the target tag
+# Our CI/CD tags images with the short git commit SHA (7 chars).
+# CI also pushes "latest" for every master merge.
+# If the user doesn't specify a tag, use "latest".
+
+# Step 4: Update image tag (replace <TAG> with actual commit SHA, version, or "latest")
 # This triggers a safe rolling update that does NOT immediately kill your pod.
-kubectl set image deployment/vibeteam-gateway gateway=ghcr.io/vibetechnologies/vibeteam:<NEW_TAG> -n vibeteam
-kubectl set image deployment/openhands-svc openhands=ghcr.io/vibetechnologies/vibeteam-openhands:<NEW_TAG> -n vibeteam
+kubectl set image deployment/vibeteam-gateway gateway=ghcr.io/vibetechnologies/vibeteam:<TAG> -n vibeteam
 
-# Step 4: Monitor rollout (non-destructive, just watches)
+# Step 5: Monitor rollout (non-destructive, just watches)
 kubectl rollout status deployment/vibeteam-gateway -n vibeteam --timeout=120s
-kubectl rollout status deployment/openhands-svc -n vibeteam --timeout=120s
 
-# Step 5: Verify pods are healthy AFTER deployment
+# Step 6: Verify pods are healthy AFTER deployment
 kubectl get pods -n vibeteam
 kubectl get events -n vibeteam --sort-by='.lastTimestamp' | tail -10
 ```
-**NOTE:** If no specific image tag is provided in the request, check the latest available
-tag from the GitHub Container Registry or ask the user which tag/commit to deploy.
+**NOTE:** You do NOT have access to local repository files. Do NOT look for k8s/
+directories, Dockerfiles, or manifests. Use kubectl commands ONLY.
 Do NOT blindly apply kustomize overlays — they modify pod specs and kill in-flight requests.
 
 ### Rollback a Deployment (non-self deployments)

--- a/tests/test_system_prompt.py
+++ b/tests/test_system_prompt.py
@@ -193,21 +193,23 @@ class TestReleaseEngineerSafetyGuardrails:
         content = self._read_re_context()
         assert "DO NOT DESTROY YOUR OWN INFRASTRUCTURE" in content
 
-    def test_forbids_kubectl_apply_k_overlays(self):
-        """Must explicitly forbid kubectl apply -k k8s/overlays/dev."""
+    def test_forbids_kubectl_apply_k(self):
+        """Must explicitly forbid kubectl apply -k (all paths)."""
         content = self._read_re_context()
         # The command must appear in a FORBIDDEN context, not as an instruction to run
-        assert "kubectl apply -k k8s/overlays/dev" in content
+        assert "kubectl apply -k" in content
         # Must NOT appear outside a forbidden/warning block as a command to execute
         lines = content.split("\n")
         for line in lines:
             stripped = line.strip()
-            if "kubectl apply -k k8s/overlays/dev" in stripped:
+            if "kubectl apply -k" in stripped:
                 # Line should be in a comment/forbidden section, not a "Step 2" instruction
                 assert (
                     stripped.startswith("#")
                     or "FORBIDDEN" in stripped
                     or "replaces pod" in stripped
+                    or "Do NOT" in stripped
+                    or "kustomize overlays" in stripped
                 ), f"Unsafe line found: {stripped}"
 
     def test_forbids_kubectl_rollout_restart_gateway(self):

--- a/vibeteam/gateway/routes/slack.py
+++ b/vibeteam/gateway/routes/slack.py
@@ -369,13 +369,24 @@ A user has requested a deployment via Slack.
 ### response NEVER reaches Slack. The eval/user sees a timeout.
 ###
 ### FORBIDDEN (kills your in-flight request):
-###   kubectl apply -k k8s/overlays/dev
-###   kubectl apply -k k8s/base/
+###   kubectl apply -k (ANY path)
 ###   kubectl rollout restart deployment/vibeteam-gateway -n vibeteam
 ###   kubectl rollout restart deployment/openhands-svc -n vibeteam
 ###   kubectl delete pod/deployment for gateway or openhands
 ###
 ### SAFE ALTERNATIVE: kubectl set image (rolling update, safe)
+### =================================================================
+
+### =================================================================
+### CRITICAL: YOU HAVE NO LOCAL REPOSITORY FILES
+### =================================================================
+###
+### You run in a temporary sandbox with NO access to the source code.
+### DO NOT try to: ls, cat, find, or access k8s/, Dockerfile, or any repo files.
+### Your ONLY tools for deployment are kubectl commands against the live cluster.
+### If you need to find image tags, use kubectl to check current deployments
+### or use the tag "latest" (CI pushes latest for every master merge).
+###
 ### =================================================================
 
 ### CRITICAL INSTRUCTIONS - DEPLOYMENT EXECUTION
@@ -392,25 +403,30 @@ kubectl get deployments -n vibeteam -o wide
 **STEP 2 - Check Current Image Tags (MANDATORY):**
 ```bash
 kubectl get deployment vibeteam-gateway -n vibeteam -o jsonpath='{{.spec.template.spec.containers[0].image}}'
+echo ""
 kubectl get deployment openhands-svc -n vibeteam -o jsonpath='{{.spec.template.spec.containers[0].image}}'
+echo ""
 ```
 
-**STEP 3 - Execute Deployment (MANDATORY):**
+**STEP 3 - Determine Target Image Tag (MANDATORY):**
+Our CI/CD tags images with the short git commit SHA (7 chars).
+CI also pushes "latest" for every master merge.
+If the user doesn't specify a tag, use "latest".
+
+**STEP 4 - Execute Deployment (MANDATORY):**
 Use `kubectl set image` to update the container image to the requested tag:
 ```bash
-kubectl set image deployment/vibeteam-gateway gateway=ghcr.io/vibetechnologies/vibeteam:<NEW_TAG> -n vibeteam
-kubectl set image deployment/openhands-svc openhands=ghcr.io/vibetechnologies/vibeteam-openhands:<NEW_TAG> -n vibeteam
+kubectl set image deployment/vibeteam-gateway gateway=ghcr.io/vibetechnologies/vibeteam:<TAG> -n vibeteam
 ```
-If no specific tag is given in the user message, check the latest tag or ask.
 Do NOT run `kubectl apply -k` — it modifies pod specs and kills your own pod.
+Do NOT deploy openhands-svc unless explicitly requested (it hosts YOUR runtime).
 
 Then monitor rollout (safe, read-only):
 ```bash
 kubectl rollout status deployment/vibeteam-gateway -n vibeteam --timeout=120s
-kubectl rollout status deployment/openhands-svc -n vibeteam --timeout=120s
 ```
 
-**STEP 4 - Verify Post-Deployment (MANDATORY):**
+**STEP 5 - Verify Post-Deployment (MANDATORY):**
 Confirm pods are healthy after deployment:
 ```bash
 kubectl get pods -n vibeteam
@@ -420,6 +436,7 @@ kubectl get events -n vibeteam --sort-by='.lastTimestamp' | tail -10
 **FORBIDDEN ACTIONS:**
 - DO NOT run `kubectl apply -k` (kills your pod)
 - DO NOT run `kubectl rollout restart` on gateway or openhands-svc (kills your pod)
+- DO NOT look for local files (k8s/, Dockerfile, etc.) — you have NO local repo
 - DO NOT just describe what you would do - ACTUALLY RUN the commands
 - DO NOT hand off deployment to another agent - YOU are the ReleaseEngineer
 - DO NOT skip verification steps
@@ -428,10 +445,11 @@ kubectl get events -n vibeteam --sort-by='.lastTimestamp' | tail -10
 Your response MUST include:
 1. Pre-deployment state (pod status before)
 2. Current image tags (what's running now)
-3. Deployment command output (kubectl set image output)
-4. Rollout status (success/failure)
-5. Post-deployment verification (pods healthy, events clean)
-6. Summary: deployment succeeded/failed with evidence
+3. Target image tag and how you determined it
+4. Deployment command output (kubectl set image output)
+5. Rollout status (success/failure)
+6. Post-deployment verification (pods healthy, events clean)
+7. Summary: deployment succeeded/failed with evidence
 """
     elif is_notification and not is_explicit_investigation:
         # Simplified task for notifications - NO mandatory investigation steps


### PR DESCRIPTION
## Summary

The `release_deploy` eval scenario fails because the ReleaseEngineer agent searches for local k8s/ files that don't exist in its temporary sandbox, wasting time and eventually timing out.

## Root Cause

- Agent runs in `tempfile.TemporaryDirectory()` with NO access to source code
- Prompt mentioned specific paths (`k8s/overlays/dev`) in FORBIDDEN section, which the agent tried to find
- No guidance on how to determine the image tag when user says "deploy latest"
- Agent tried to deploy openhands-svc (its own runtime), risking self-destruction

## Changes

1. **Added "NO LOCAL REPOSITORY FILES" warning** to both `release_engineer.py` system prompt and `slack.py` deployment task template
2. **Changed forbidden `kubectl apply -k`** from specific paths to generic "(ANY path)"
3. **Added Step 3 "Determine Target Image Tag"** with CI/CD tag guidance (use "latest" for unspecified)
4. **Separated gateway/openhands deploy commands** — only deploy gateway by default, don't auto-deploy openhands (the agent's own runtime)
5. **Updated test assertions** to match new generic forbidden command

## Testing

- 357 passed, 77 skipped (all pre-existing skips)
- `ruff check` clean on all 3 modified files
- `release_deploy` eval needs re-run after deploy to verify fix

## Eval Results (before this fix)

| Scenario | Status | Scores |
|----------|--------|--------|
| `support_400_errors` | PASS | IQ:0.90, EBD:1.00, HC:0.80 |
| `release_deploy` | FAIL | DE:0.20, TC:0.00 (637s timeout) |