### PR TITLE
fix(agents): add namespace awareness so ReleaseEngineer deploys VibeBrowser to correct namespace

### DIFF
--- a/agents/openhands/release_engineer.py
+++ b/agents/openhands/release_engineer.py
@@ -105,14 +105,16 @@ commands for any write operations (deploy, rollback, restart, scale).
 ## ==========================================================================
 
 ## ==========================================================================
-## CRITICAL: YOU HAVE NO LOCAL REPOSITORY FILES
+## YOUR TOOLS: kubectl commands and `gh` CLI (GitHub CLI, pre-authenticated)
 ## ==========================================================================
 ##
 ## You run in a temporary sandbox with NO access to the source code repository.
 ## DO NOT try to: ls, cat, find, or access k8s/, Dockerfile, or any repo files.
-## Your ONLY tools for deployment are kubectl commands against the live cluster.
-## If you need to find image tags, use kubectl to check current deployments
-## or use the tag "latest" (CI pushes latest for every master merge).
+##
+## To find image tags from PRs, use `gh pr view` to get the merge commit SHA.
+## Example: gh pr view 123 --repo VibeTechnologies/VibeWebAgent --json mergeCommit -q .mergeCommit.oid
+##
+## NEVER use `:latest` — always use a specific commit SHA for traceability.
 ##
 ## ==========================================================================
 
@@ -127,33 +129,39 @@ SupportEngineer has already investigated. When you receive a handoff:
 
 ### Deploy New Code (update container images)
 ```bash
-# Step 1: Check current deployment state
-kubectl get pods -n vibeteam -o wide
-kubectl get deployments -n vibeteam -o wide
+# Step 1: Identify the TARGET NAMESPACE from the request
+# "staging" / "dev" → namespace: vibe-dev
+# "production" / "prod" → namespace: vibe
+# "agents" / "vibeteam" → namespace: vibeteam
+# DEFAULT: If the request mentions a PR on VibeTechnologies/VibeWebAgent, use vibe-dev (staging)
 
-# Step 2: Check what image tag is currently running
-kubectl get deployment vibeteam-gateway -n vibeteam -o jsonpath='{.spec.template.spec.containers[0].image}'
-kubectl get deployment openhands-svc -n vibeteam -o jsonpath='{.spec.template.spec.containers[0].image}'
+# Step 2: Get the merge commit SHA from the PR (using gh CLI)
+gh pr view <PR_NUMBER> --repo VibeTechnologies/VibeWebAgent --json mergeCommit -q .mergeCommit.oid
+# This returns the full 40-char SHA — use it as the image tag
 
-# Step 3: Determine the target tag
-# Our CI/CD tags images with the short git commit SHA (7 chars).
-# CI also pushes "latest" for every master merge.
-# If the user doesn't specify a tag, use "latest".
+# Step 3: Check current deployment state in the TARGET namespace
+kubectl get pods -n <NAMESPACE> -o wide
+kubectl get deployments -n <NAMESPACE> -o wide
 
-# Step 4: Update image tag (replace <TAG> with actual commit SHA, version, or "latest")
-# This triggers a safe rolling update that does NOT immediately kill your pod.
-kubectl set image deployment/vibeteam-gateway gateway=ghcr.io/vibetechnologies/vibeteam:<TAG> -n vibeteam
-kubectl set image deployment/openhands-svc openhands=ghcr.io/vibetechnologies/vibeteam-openhands:<TAG> -n vibeteam
+# Step 4: Check current image tags
+kubectl get deployment user-portal -n <NAMESPACE> -o jsonpath='{.spec.template.spec.containers[0].image}'
+kubectl get deployment stripe-service -n <NAMESPACE> -o jsonpath='{.spec.template.spec.containers[0].image}'
 
-# Step 5: Monitor rollout (non-destructive, just watches)
-kubectl rollout status deployment/vibeteam-gateway -n vibeteam --timeout=120s
+# Step 5: Update image tags (VibeBrowser product deployments)
+kubectl set image deployment/user-portal user-portal=ghcr.io/vibetechnologies/vibe-user-portal:<SHA> -n <NAMESPACE>
+kubectl set image deployment/stripe-service stripe-service=ghcr.io/vibetechnologies/vibe-stripe-service:<SHA> -n <NAMESPACE>
 
-# Step 6: Verify pods are healthy AFTER deployment
-kubectl get pods -n vibeteam
-kubectl get events -n vibeteam --sort-by='.lastTimestamp' | tail -10
+# Step 6: Monitor rollout
+kubectl rollout status deployment/user-portal -n <NAMESPACE> --timeout=120s
+kubectl rollout status deployment/stripe-service -n <NAMESPACE> --timeout=120s
+
+# Step 7: Verify pods are healthy AFTER deployment
+kubectl get pods -n <NAMESPACE>
+kubectl get events -n <NAMESPACE> --sort-by='.lastTimestamp' | tail -10
 ```
 **NOTE:** You do NOT have access to local repository files. Do NOT look for k8s/
-directories, Dockerfiles, or manifests. Use kubectl commands ONLY.
+directories, Dockerfiles, or manifests. Use kubectl and gh commands ONLY.
+NEVER use `:latest` — always use a specific commit SHA from `gh pr view`.
 Do NOT blindly apply kustomize overlays — they modify pod specs and kill in-flight requests.
 
 ### Rollback a Deployment (non-self deployments)
@@ -192,9 +200,25 @@ kubectl get events -n vibeteam --sort-by='.lastTimestamp' | tail -10
 kubectl get deployments -n vibeteam
 ```
 
-## k3s Cluster Information
-- Cluster: vibeteam-k3s
-- Namespace: vibeteam
+## Cluster Information
+
+### Namespace Map (CRITICAL — use the correct namespace!)
+| Namespace   | Environment | What Lives There |
+|-------------|-------------|------------------|
+| `vibe`      | Production  | VibeBrowser product: user-portal, stripe-service, litellm |
+| `vibe-dev`  | Staging     | VibeBrowser product (staging mirrors prod) |
+| `vibeteam`  | Internal    | VibeTeam agents: vibeteam-gateway, openhands-svc, autogen-svc |
+
+### Repository → Image Map
+| Repository | Image | Namespaces |
+|------------|-------|------------|
+| `VibeTechnologies/VibeWebAgent` | `ghcr.io/vibetechnologies/vibe-user-portal:<SHA>` | vibe, vibe-dev |
+| `VibeTechnologies/VibeWebAgent` | `ghcr.io/vibetechnologies/vibe-stripe-service:<SHA>` | vibe, vibe-dev |
+| `VibeTechnologies/VibeTeam`     | `ghcr.io/vibetechnologies/vibeteam:<SHA>` | vibeteam |
+
+### How to Find Image Tags
+- **From a PR number:** `gh pr view <N> --repo VibeTechnologies/VibeWebAgent --json mergeCommit -q .mergeCommit.oid`
+- **NEVER use `:latest`** — always use a specific commit SHA
 - Registry: ghcr.io/vibetechnologies
 - Config: In-cluster (ServiceAccount: vibeteam-agent)
 
@@ -221,17 +245,23 @@ kubectl get deployments -n vibeteam
 ### For Deployments:
 ```
 **Deployment Executed:**
-- Current image: `ghcr.io/vibetechnologies/vibeteam:<old_tag>`
-- Updated to: `ghcr.io/vibetechnologies/vibeteam:<new_tag>`
-- Ran: `kubectl set image deployment/vibeteam-gateway gateway=ghcr.io/vibetechnologies/vibeteam:<new_tag> -n vibeteam`
-- Rollout: `kubectl rollout status deployment/vibeteam-gateway -n vibeteam` -> Complete
+- PR: #<PR_NUMBER> on VibeTechnologies/VibeWebAgent
+- Merge commit SHA: <40-char SHA from gh pr view>
+- Target namespace: <vibe-dev|vibe> (staging|production)
+- Updated deployments:
+  - user-portal: `ghcr.io/vibetechnologies/vibe-user-portal:<SHA>`
+  - stripe-service: `ghcr.io/vibetechnologies/vibe-stripe-service:<SHA>`
+- Commands run:
+  - `kubectl set image deployment/user-portal user-portal=ghcr.io/vibetechnologies/vibe-user-portal:<SHA> -n <NAMESPACE>`
+  - `kubectl set image deployment/stripe-service stripe-service=ghcr.io/vibetechnologies/vibe-stripe-service:<SHA> -n <NAMESPACE>`
+- Rollout status: Complete
 
 **Verification:**
 - Pods: All Running (kubectl get pods output)
 - Events: No warnings or errors
 - Health: Endpoints responding normally
 
-Deployment to staging complete. Team notified.
+Deployment to <staging|production> complete. Team notified.
 ```
 
 ### For Rollbacks/Incident Response:

--- a/tests/test_system_prompt.py
+++ b/tests/test_system_prompt.py
@@ -290,22 +290,19 @@ class TestDeploymentTaskTemplateSafety:
         # Find the deployment template section
         deploy_start = content.find("## Slack Deployment Request")
         assert deploy_start != -1, "Deployment template not found"
-        deploy_end = content.find("elif is_notification", deploy_start)
+        deploy_end = content.find('elif template == "notification"', deploy_start)
         deploy_section = content[deploy_start:deploy_end]
 
         # kubectl apply -k must be in FORBIDDEN section, not as instruction
         assert "kubectl apply -k" in deploy_section
-        # The STEP 3 should use kubectl set image, not kubectl apply
-        step3_start = deploy_section.find("STEP 3")
-        assert step3_start != -1
-        step3_section = deploy_section[step3_start:]
-        assert "kubectl set image" in step3_section
+        # The deployment steps should use kubectl set image
+        assert "kubectl set image" in deploy_section
 
     def test_deployment_template_uses_set_image(self):
         """Deployment template must instruct agent to use kubectl set image."""
         content = self._read_slack_py()
         deploy_start = content.find("## Slack Deployment Request")
-        deploy_end = content.find("elif is_notification", deploy_start)
+        deploy_end = content.find('elif template == "notification"', deploy_start)
         deploy_section = content[deploy_start:deploy_end]
         assert "kubectl set image" in deploy_section
 
@@ -313,6 +310,117 @@ class TestDeploymentTaskTemplateSafety:
         """Deployment template must include a step to check current image tags."""
         content = self._read_slack_py()
         deploy_start = content.find("## Slack Deployment Request")
-        deploy_end = content.find("elif is_notification", deploy_start)
+        deploy_end = content.find('elif template == "notification"', deploy_start)
         deploy_section = content[deploy_start:deploy_end]
         assert "Check Current Image Tags" in deploy_section or "jsonpath" in deploy_section
+
+
+class TestNamespaceAwareness:
+    """Verify ReleaseEngineer and deployment template have correct namespace awareness.
+
+    The agent must know:
+    - vibe-dev is staging for VibeBrowser (VibeTechnologies/VibeWebAgent)
+    - vibe is production for VibeBrowser
+    - vibeteam is internal (VibeTeam agents)
+    - Image names: vibe-user-portal, vibe-stripe-service (not vibeteam-gateway)
+    - Use `gh pr view` to get merge commit SHA, never use :latest
+    """
+
+    @staticmethod
+    def _read_re_context() -> str:
+        filepath = os.path.join(
+            os.path.dirname(__file__),
+            os.pardir,
+            "agents",
+            "openhands",
+            "release_engineer.py",
+        )
+        with open(filepath) as f:
+            return f.read()
+
+    @staticmethod
+    def _read_slack_py() -> str:
+        filepath = os.path.join(
+            os.path.dirname(__file__),
+            os.pardir,
+            "vibeteam",
+            "gateway",
+            "routes",
+            "slack.py",
+        )
+        with open(filepath) as f:
+            return f.read()
+
+    # --- ReleaseEngineer context tests ---
+
+    def test_re_context_has_namespace_map(self):
+        """RE context must include a namespace map with vibe, vibe-dev, vibeteam."""
+        content = self._read_re_context()
+        assert "vibe-dev" in content
+        assert "Staging" in content or "staging" in content
+
+    def test_re_context_has_vibebrowser_images(self):
+        """RE context must reference VibeBrowser images (vibe-user-portal, vibe-stripe-service)."""
+        content = self._read_re_context()
+        assert "vibe-user-portal" in content
+        assert "vibe-stripe-service" in content
+
+    def test_re_context_references_vibewebagent_repo(self):
+        """RE context must reference VibeTechnologies/VibeWebAgent as the product repo."""
+        content = self._read_re_context()
+        assert "VibeTechnologies/VibeWebAgent" in content
+
+    def test_re_context_uses_gh_pr_view(self):
+        """RE context must instruct using `gh pr view` to get merge commit SHA."""
+        content = self._read_re_context()
+        assert "gh pr view" in content
+        assert "mergeCommit" in content
+
+    def test_re_context_forbids_latest_tag(self):
+        """RE context must forbid using :latest tag."""
+        content = self._read_re_context()
+        assert "NEVER use `:latest`" in content or "NEVER use `:latest`" in content
+
+    # --- Deployment task template tests ---
+
+    def test_deploy_template_has_namespace_map(self):
+        """Deployment template must include namespace map with vibe-dev."""
+        content = self._read_slack_py()
+        deploy_start = content.find("## Slack Deployment Request")
+        deploy_end = content.find('elif template == "notification"', deploy_start)
+        deploy_section = content[deploy_start:deploy_end]
+        assert "vibe-dev" in deploy_section
+        assert "NAMESPACE MAP" in deploy_section
+
+    def test_deploy_template_uses_gh_pr_view(self):
+        """Deployment template must use gh pr view to get image tags."""
+        content = self._read_slack_py()
+        deploy_start = content.find("## Slack Deployment Request")
+        deploy_end = content.find('elif template == "notification"', deploy_start)
+        deploy_section = content[deploy_start:deploy_end]
+        assert "gh pr view" in deploy_section
+
+    def test_deploy_template_references_vibewebagent(self):
+        """Deployment template must reference VibeTechnologies/VibeWebAgent."""
+        content = self._read_slack_py()
+        deploy_start = content.find("## Slack Deployment Request")
+        deploy_end = content.find('elif template == "notification"', deploy_start)
+        deploy_section = content[deploy_start:deploy_end]
+        assert "VibeTechnologies/VibeWebAgent" in deploy_section
+
+    def test_deploy_template_forbids_latest(self):
+        """Deployment template must forbid :latest tag."""
+        content = self._read_slack_py()
+        deploy_start = content.find("## Slack Deployment Request")
+        deploy_end = content.find('elif template == "notification"', deploy_start)
+        deploy_section = content[deploy_start:deploy_end]
+        assert "NEVER use `:latest`" in deploy_section or ":latest" in deploy_section
+
+    def test_deploy_template_has_vibebrowser_images(self):
+        """Deployment template must reference VibeBrowser images."""
+        content = self._read_slack_py()
+        deploy_start = content.find("## Slack Deployment Request")
+        deploy_end = content.find('elif template == "notification"', deploy_start)
+        deploy_section = content[deploy_start:deploy_end]
+        assert "vibe-user-portal" in deploy_section
+        assert "vibe-stripe-service" in deploy_section

--- a/vibeteam/gateway/routes/slack.py
+++ b/vibeteam/gateway/routes/slack.py
@@ -402,54 +402,87 @@ A user has requested a deployment via Slack.
 ###
 ### You run in a temporary sandbox with NO access to the source code.
 ### DO NOT try to: ls, cat, find, or access k8s/, Dockerfile, or any repo files.
-### Your ONLY tools for deployment are kubectl commands against the live cluster.
-### If you need to find image tags, use kubectl to check current deployments
-### or use the tag "latest" (CI pushes latest for every master merge).
+### Your tools are: kubectl commands and `gh` CLI (GitHub CLI, pre-authenticated).
+### To find image tags, use `gh pr view` to get the merge commit SHA from a PR.
+### NEVER use `:latest` — always use a specific commit SHA for traceability.
 ###
+### =================================================================
+
+### =================================================================
+### NAMESPACE MAP (CRITICAL — deploy to the CORRECT namespace!)
+### =================================================================
+###
+### | Namespace   | Environment | What Lives There |
+### |-------------|-------------|------------------|
+### | `vibe`      | Production  | VibeBrowser: user-portal, stripe-service, litellm |
+### | `vibe-dev`  | Staging     | VibeBrowser (staging mirrors prod) |
+### | `vibeteam`  | Internal    | VibeTeam agents: vibeteam-gateway, openhands-svc |
+###
+### Repository → Image Map:
+### | Repository                        | Image                                              | Namespaces    |
+### |-----------------------------------|------------------------------------------------------|---------------|
+### | VibeTechnologies/VibeWebAgent     | ghcr.io/vibetechnologies/vibe-user-portal:<SHA>      | vibe, vibe-dev |
+### | VibeTechnologies/VibeWebAgent     | ghcr.io/vibetechnologies/vibe-stripe-service:<SHA>   | vibe, vibe-dev |
+### | VibeTechnologies/VibeTeam         | ghcr.io/vibetechnologies/vibeteam:<SHA>              | vibeteam       |
+###
+### "staging" / "dev" → namespace: vibe-dev
+### "production" / "prod" → namespace: vibe
 ### =================================================================
 
 ### CRITICAL INSTRUCTIONS — DEPLOYMENT EXECUTION
 
 You are the ReleaseEngineer. You MUST execute the deployment, not just describe it.
 
-**STEP 1 — Verify Pre-Deployment State (MANDATORY):**
-Run kubectl to check current state before making changes:
+**STEP 1 — Identify Target Namespace (MANDATORY):**
+From the user's message, determine the target namespace:
+- "staging" / "dev" → namespace: `vibe-dev`
+- "production" / "prod" → namespace: `vibe`
+- "agents" / "vibeteam" → namespace: `vibeteam`
+If the request mentions a PR on VibeTechnologies/VibeWebAgent, default to `vibe-dev`.
+
+**STEP 2 — Get Image Tag from PR (MANDATORY):**
+Use `gh` CLI to get the merge commit SHA from the PR:
 ```bash
-kubectl get pods -n vibeteam -o wide
-kubectl get deployments -n vibeteam -o wide
+gh pr view <PR_NUMBER> --repo VibeTechnologies/VibeWebAgent --json mergeCommit -q .mergeCommit.oid
+```
+This returns a 40-char SHA — use it as the image tag. NEVER use `:latest`.
+
+**STEP 3 — Verify Pre-Deployment State (MANDATORY):**
+Run kubectl to check current state in the TARGET namespace:
+```bash
+kubectl get pods -n <NAMESPACE> -o wide
+kubectl get deployments -n <NAMESPACE> -o wide
 ```
 
-**STEP 2 — Check Current Image Tags (MANDATORY):**
+**STEP 4 — Check Current Image Tags (MANDATORY):**
 ```bash
-kubectl get deployment vibeteam-gateway -n vibeteam -o jsonpath='{{{{.spec.template.spec.containers[0].image}}}}'
-kubectl get deployment openhands-svc -n vibeteam -o jsonpath='{{{{.spec.template.spec.containers[0].image}}}}'
+kubectl get deployment user-portal -n <NAMESPACE> -o jsonpath='{{{{.spec.template.spec.containers[0].image}}}}'
+kubectl get deployment stripe-service -n <NAMESPACE> -o jsonpath='{{{{.spec.template.spec.containers[0].image}}}}'
 ```
 
-**STEP 3 — Determine Target Tag (MANDATORY):**
-Identify what image tag to deploy. If the user specifies a tag, use it.
-Otherwise check the latest available tag from the container registry.
-
-**STEP 4 — Execute Deployment (MANDATORY):**
-Use `kubectl set image` to update ONE deployment at a time:
+**STEP 5 — Execute Deployment (MANDATORY):**
+Use `kubectl set image` to update VibeBrowser deployments:
 ```bash
-kubectl set image deployment/<DEPLOYMENT> <CONTAINER>=ghcr.io/vibetechnologies/<IMAGE>:<NEW_TAG> -n vibeteam
+kubectl set image deployment/user-portal user-portal=ghcr.io/vibetechnologies/vibe-user-portal:<SHA> -n <NAMESPACE>
+kubectl set image deployment/stripe-service stripe-service=ghcr.io/vibetechnologies/vibe-stripe-service:<SHA> -n <NAMESPACE>
 ```
 Do NOT run `kubectl apply -k` — it modifies pod specs and kills your own pod.
-Do NOT deploy openhands-svc unless explicitly requested (it hosts YOUR runtime).
+Do NOT deploy to the `vibeteam` namespace unless the request is explicitly about VibeTeam agents.
 
 Then monitor rollout (safe, read-only):
 ```bash
-kubectl rollout status deployment/<DEPLOYMENT> -n vibeteam --timeout=120s
+kubectl rollout status deployment/user-portal -n <NAMESPACE> --timeout=120s
+kubectl rollout status deployment/stripe-service -n <NAMESPACE> --timeout=120s
 ```
 
-**STEP 5 — Verify Post-Deployment (MANDATORY):**
+**STEP 6 — Verify Post-Deployment (MANDATORY):**
 Confirm pods are healthy after deployment:
 ```bash
-kubectl get pods -n vibeteam
-kubectl get events -n vibeteam --sort-by='.lastTimestamp' | tail -10
+kubectl get pods -n <NAMESPACE>
+kubectl get events -n <NAMESPACE> --sort-by='.lastTimestamp' | tail -10
 ```
 
-**STEP 6 — Report Results (MANDATORY):**
+**STEP 7 — Report Results (MANDATORY):**
 Summarize deployment outcome clearly.
 
 **FORBIDDEN ACTIONS:**
@@ -459,16 +492,18 @@ Summarize deployment outcome clearly.
 - DO NOT just describe what you would do — ACTUALLY RUN the commands
 - DO NOT hand off deployment to another agent — YOU are the ReleaseEngineer
 - DO NOT skip verification steps
+- DO NOT use `:latest` tag — always use a specific commit SHA
 
 **REQUIRED OUTPUT:**
 Your response MUST include:
-1. Pre-deployment state (pod status before)
-2. Current image tags (what's running now)
-3. Target image tag and how you determined it
-4. Deployment command output (kubectl set image output)
-5. Rollout status (success/failure)
-6. Post-deployment verification (pods healthy, events clean)
-7. Summary: deployment succeeded/failed with evidence
+1. Target namespace identified (vibe-dev, vibe, or vibeteam) and why
+2. PR merge commit SHA (from `gh pr view`)
+3. Pre-deployment state (pod status before)
+4. Current image tags (what's running now)
+5. Deployment commands and output (kubectl set image for vibe-user-portal and vibe-stripe-service)
+6. Rollout status (success/failure)
+7. Post-deployment verification (pods healthy, events clean)
+8. Summary: deployment succeeded/failed with evidence
 """
 
     elif template == "notification":


### PR DESCRIPTION
## Summary

- **Problem:** ReleaseEngineer deployed to `vibeteam` namespace (its own infrastructure) instead of `vibe-dev` (staging) when asked to deploy VibeBrowser PRs from VibeTechnologies/VibeWebAgent
- **Root cause:** Agent context and deployment template only referenced `vibeteam-gateway`/`openhands-svc` images with no namespace mapping
- **Fix:** Added namespace map, repository→image mapping, and `gh pr view` for commit SHA lookup to both the RE agent context (`release_engineer.py`) and the deployment task template (`slack.py`)

## Changes

### `agents/openhands/release_engineer.py`
- Replaced "NO LOCAL REPOSITORY FILES" section with `gh` CLI tool instructions and `:latest` tag prohibition
- Replaced "Deploy New Code" section with VibeBrowser-specific deployment steps targeting `vibe-dev`/`vibe` namespaces using `vibe-user-portal` and `vibe-stripe-service` images
- Replaced "k3s Cluster Information" with full namespace map (`vibe`=prod, `vibe-dev`=staging, `vibeteam`=internal) and repository→image mapping
- Replaced response format template with VibeBrowser deployment output format including PR number, namespace, and merge commit SHA

### `vibeteam/gateway/routes/slack.py`
- Replaced "NO LOCAL REPOSITORY FILES" section with `gh` CLI instructions and namespace map
- Replaced 6-step deployment flow with 7-step flow: identify namespace → get SHA via `gh pr view` → verify → check current → deploy `vibe-user-portal`/`vibe-stripe-service` → verify → report
- Added `:latest` prohibition to forbidden actions list
- Updated required output to 8 items including target namespace and PR merge commit SHA

### `tests/test_system_prompt.py`
- Added `TestNamespaceAwareness` class with 10 tests (5 for RE context, 5 for deployment template)
- Fixed `test_deployment_template_forbids_kubectl_apply_k` to use correct section delimiter after step renumbering

## Test Results

```
398 passed, 79 skipped in 26.95s
```

## Expected Agent Behavior After This Fix

When receiving: `@ReleaseEngineer deploy the latest changes to staging. PR #123 has been merged...`

1. Parse "staging" → namespace `vibe-dev`
2. `gh pr view 123 --repo VibeTechnologies/VibeWebAgent --json mergeCommit -q .mergeCommit.oid` → `91a6b76d...`
3. `kubectl set image deployment/user-portal user-portal=ghcr.io/vibetechnologies/vibe-user-portal:91a6b76d... -n vibe-dev`
4. `kubectl set image deployment/stripe-service stripe-service=ghcr.io/vibetechnologies/vibe-stripe-service:91a6b76d... -n vibe-dev`
5. Monitor rollout, verify, report