### PR TITLE
feat: add Gmail processor deployment for automated email support

### DIFF
--- a/k8s/base/gmail-processor.yaml
+++ b/k8s/base/gmail-processor.yaml
@@ -1,0 +1,93 @@
+---
+# Gmail Processor - Daemon that polls for support emails and processes them
+# Runs process_emails.py in --daemon mode, checking every 5 minutes
+apiVersion: apps/v1
+kind: Deployment
+metadata:
+  name: gmail-processor
+  namespace: vibeteam
+  labels:
+    app: gmail-processor
+    team: vibeteam
+spec:
+  replicas: 1
+  selector:
+    matchLabels:
+      app: gmail-processor
+  template:
+    metadata:
+      labels:
+        app: gmail-processor
+        team: vibeteam
+    spec:
+      serviceAccountName: vibeteam-agent
+      imagePullSecrets:
+        - name: ghcr-pull-secret
+      initContainers:
+        # Copy token to writable volume so OAuth refresh can update it
+        - name: copy-token
+          image: ghcr.io/vibetechnologies/vibeteam:latest
+          command: ["sh", "-c"]
+          args:
+            - |
+              cp /gmail-secrets/gmail-token.json /gmail-writable/gmail-token.json 2>/dev/null || true
+              cp /gmail-secrets/gmail-credentials.json /gmail-writable/gmail-credentials.json 2>/dev/null || true
+              echo "Gmail credentials copied to writable volume"
+          volumeMounts:
+            - name: gmail-secrets
+              mountPath: /gmail-secrets
+              readOnly: true
+            - name: gmail-writable
+              mountPath: /gmail-writable
+      containers:
+        - name: gmail-processor
+          image: ghcr.io/vibetechnologies/vibeteam:latest
+          command: ["python", "scripts/process_emails.py"]
+          args:
+            - "--daemon"
+            - "--interval"
+            - "300"
+            - "--max-emails"
+            - "10"
+            - "--credentials"
+            - "/gmail/gmail-credentials.json"
+            - "--token"
+            - "/gmail/gmail-token.json"
+          env:
+            # Azure OpenAI (for future AI-powered responses)
+            - name: AZURE_OPENAI_ENDPOINT
+              valueFrom:
+                secretKeyRef:
+                  name: vibeteam-secrets
+                  key: AZURE_API_BASE
+                  optional: true
+            - name: AZURE_OPENAI_API_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: vibeteam-secrets
+                  key: AZURE_API_KEY
+                  optional: true
+            - name: AZURE_OPENAI_DEPLOYMENT
+              valueFrom:
+                secretKeyRef:
+                  name: vibeteam-secrets
+                  key: AZURE_OPENAI_DEPLOYMENT
+                  optional: true
+          volumeMounts:
+            - name: gmail-writable
+              mountPath: /gmail
+          resources:
+            requests:
+              cpu: 50m
+              memory: 128Mi
+            limits:
+              cpu: 200m
+              memory: 256Mi
+      volumes:
+        - name: gmail-secrets
+          secret:
+            secretName: gmail-oauth-secret
+            optional: false
+        - name: gmail-writable
+          emptyDir: {}
+      restartPolicy: Always

--- a/k8s/base/gmail-secrets.yaml
+++ b/k8s/base/gmail-secrets.yaml
@@ -1,0 +1,57 @@
+# Gmail OAuth Secret for Email Processor
+#
+# This is a TEMPLATE file. Actual values must be populated before use.
+#
+# To create the secret from existing credential files:
+#
+#   kubectl create secret generic gmail-oauth-secret -n vibeteam \
+#     --from-file=gmail-credentials.json=.secrets/gmail-credentials.json \
+#     --from-file=gmail-token.json=.secrets/gmail-token.json \
+#     --dry-run=client -o yaml | kubectl apply -f -
+#
+# The gmail-credentials.json contains the OAuth2 client ID and secret
+# (static, doesn't change). The gmail-token.json contains the access
+# and refresh tokens (refreshed automatically by the processor).
+#
+# Note: Token refresh writes happen to an emptyDir volume inside the pod,
+# NOT back to this secret. If the pod restarts, it copies the secret's
+# token again. To persist a newly refreshed token, update this secret.
+---
+apiVersion: v1
+kind: Secret
+metadata:
+  name: gmail-oauth-secret
+  namespace: vibeteam
+  labels:
+    app: gmail-processor
+    team: vibeteam
+type: Opaque
+stringData:
+  gmail-credentials.json: |
+    {
+      "installed": {
+        "client_id": "REPLACE_WITH_CLIENT_ID",
+        "client_secret": "REPLACE_WITH_CLIENT_SECRET",
+        "project_id": "REPLACE_WITH_PROJECT_ID",
+        "auth_uri": "https://accounts.google.com/o/oauth2/auth",
+        "token_uri": "https://oauth2.googleapis.com/token",
+        "auth_provider_x509_cert_url": "https://www.googleapis.com/oauth2/v1/certs",
+        "redirect_uris": ["http://localhost"]
+      }
+    }
+  gmail-token.json: |
+    {
+      "token": "REPLACE_WITH_ACCESS_TOKEN",
+      "refresh_token": "REPLACE_WITH_REFRESH_TOKEN",
+      "token_uri": "https://oauth2.googleapis.com/token",
+      "client_id": "REPLACE_WITH_CLIENT_ID",
+      "client_secret": "REPLACE_WITH_CLIENT_SECRET",
+      "scopes": [
+        "https://www.googleapis.com/auth/gmail.readonly",
+        "https://www.googleapis.com/auth/gmail.send",
+        "https://www.googleapis.com/auth/gmail.modify"
+      ],
+      "universe_domain": "googleapis.com",
+      "account": "",
+      "expiry": "2026-01-01T00:00:00.000000Z"
+    }

--- a/k8s/base/kustomization.yaml
+++ b/k8s/base/kustomization.yaml
@@ -14,6 +14,8 @@ resources:
   - crewai-svc.yaml
   - openhands-svc.yaml
   - scheduler-svc.yaml
+  # Gmail email processor (daemon polling for support emails)
+  - gmail-processor.yaml
   # Multi-framework agent deployments (AutoGen, CrewAI, OpenHands)
   - frameworks/
   # Note: Slack agents removed - gateway receives webhooks and routes to agent services

--- a/plan.md
+++ b/plan.md
@@ -1,30 +1,22 @@
 # Current Work Plan
 
-## Status: Fix SWE agent response extraction + improve response reliability
+## Status: PR ready — SWE response extraction fix + Gmail processor deployment
 
 **Branch:** `fix/swe-agent-response-extraction`
 **Base:** `c5b15eb` (master with PRs #68-#70 merged)
 
 ---
 
-## Goal
+## Goals
 
-Fix the `github_issue` eval scenario where the SoftwareEngineer agent never responds
-(600s timeout, 0 messages from agent).
+### 1. Fix SWE agent response extraction (DONE)
+SoftwareEngineer and ReleaseEngineer agents only extracted responses from `MessageEvent`,
+missing `FinishAction`/`AgentFinishAction`. Created shared `extract_response_from_events()`
+in `agents/openhands/utils.py` and wired all 3 agents to use it.
 
-## Root Cause Analysis
-
-**Finding:** The SoftwareEngineer and ReleaseEngineer agents only extract responses
-from `MessageEvent` with `source=="agent"`. The SupportEngineer (which works reliably)
-also checks for `ActionEvent` with `FinishAction`/`AgentFinishAction`.
-
-When the OpenHands agent completes via `finish()` (which creates a `FinishAction`),
-the SWE/RE code misses it entirely and returns `response = ""`.
-
-**Additional factors:**
-1. The eval's 600s timeout may be too short for the SWE agentic loop (clone repo, grep, etc.)
-2. The `conversation.run()` could hang if the agent gets stuck in loops
-3. No max iteration enforcement in code (only mentioned in prompt)
+### 2. Gmail email processor K8s deployment (DONE)
+Added K8s Deployment for automated support email processing (closes last gap in Issue #22).
+Uses init container + emptyDir pattern for writable OAuth token refresh.
 
 ## Checklist
 
@@ -32,13 +24,18 @@ the SWE/RE code misses it entirely and returns `response = ""`.
 - [x] Identify root cause: SWE/RE missing FinishAction extraction
 - [x] Create shared `extract_response()` function in `agents/openhands/utils.py`
 - [x] Update SoftwareEngineer to use shared extraction
-- [x] Update ReleaseEngineer to use shared extraction  
+- [x] Update ReleaseEngineer to use shared extraction
 - [x] Update SupportEngineer to use shared extraction (DRY)
 - [x] Add debug logging to response extraction for better diagnostics
-- [x] Write tests for the shared extraction function
-- [x] Run full test suite
-- [x] Run ruff lint
-- [ ] Create PR
+- [x] Write tests for the shared extraction function (36 tests)
+- [x] Add Gmail processor K8s Deployment (`k8s/base/gmail-processor.yaml`)
+- [x] Add Gmail secrets template (`k8s/base/gmail-secrets.yaml`)
+- [x] Add Gmail processor to kustomization resources
+- [x] Write Gmail processor tests (35 tests)
+- [x] Run full test suite (469 passed, 79 skipped, 0 failures)
+- [x] Run ruff lint (clean)
+- [x] Commit all changes
+- [ ] Push branch and create PR
 - [ ] Deploy and run `github_issue` eval
 - [ ] Run regression evals (support_400_errors, release_deploy)
 
@@ -48,8 +45,8 @@ the SWE/RE code misses it entirely and returns `response = ""`.
 
 | Issue | Title | Status | Notes |
 |-------|-------|--------|-------|
-| #47 | User Document Upload for Knowledge Base | Open | Feature request |
-| #22 | Complete VibeTeam Integration Setup | Open | Umbrella issue |
+| #22 | Complete VibeTeam Integration Setup | Open | Gmail processor closes the LAST gap |
+| #47 | User Document Upload for Knowledge Base | Open | Feature request, ~2-3hrs |
 
 ## Blocked
 

--- a/tests/test_gmail_processor.py
+++ b/tests/test_gmail_processor.py
@@ -1,0 +1,419 @@
+"""
+Tests for Gmail Processor K8s deployment and process_emails.py script.
+
+Tests cover:
+- K8s manifest structure validation (YAML parsing, required fields)
+- Gmail processor deployment configuration
+- Secret template structure
+- Kustomization resource references
+- EmailProcessor class behavior (unit tests)
+"""
+
+from __future__ import annotations
+
+import asyncio
+from pathlib import Path
+from unittest.mock import MagicMock
+
+import pytest
+import yaml
+
+# Project root
+PROJECT_ROOT = Path(__file__).parent.parent
+K8S_BASE = PROJECT_ROOT / "k8s" / "base"
+
+
+# ---------------------------------------------------------------------------
+# K8s Manifest Validation
+# ---------------------------------------------------------------------------
+
+
+class TestGmailProcessorManifest:
+    """Validate gmail-processor.yaml K8s manifest."""
+
+    @pytest.fixture
+    def manifest_path(self) -> Path:
+        return K8S_BASE / "gmail-processor.yaml"
+
+    @pytest.fixture
+    def manifest(self, manifest_path: Path) -> dict:
+        assert manifest_path.exists(), f"Missing: {manifest_path}"
+        with open(manifest_path) as f:
+            docs = list(yaml.safe_load_all(f))
+        # Filter out None docs (from trailing ---)
+        return [d for d in docs if d is not None]
+
+    def test_manifest_exists(self, manifest_path: Path):
+        assert manifest_path.exists()
+
+    def test_manifest_is_valid_yaml(self, manifest: list[dict]):
+        assert len(manifest) >= 1, "Expected at least one YAML document"
+
+    def test_deployment_kind(self, manifest: list[dict]):
+        deployment = manifest[0]
+        assert deployment["kind"] == "Deployment"
+        assert deployment["apiVersion"] == "apps/v1"
+
+    def test_deployment_metadata(self, manifest: list[dict]):
+        meta = manifest[0]["metadata"]
+        assert meta["name"] == "gmail-processor"
+        assert meta["namespace"] == "vibeteam"
+        assert meta["labels"]["app"] == "gmail-processor"
+        assert meta["labels"]["team"] == "vibeteam"
+
+    def test_deployment_selector(self, manifest: list[dict]):
+        spec = manifest[0]["spec"]
+        assert spec["replicas"] == 1
+        assert spec["selector"]["matchLabels"]["app"] == "gmail-processor"
+
+    def test_pod_template_labels(self, manifest: list[dict]):
+        pod_labels = manifest[0]["spec"]["template"]["metadata"]["labels"]
+        assert pod_labels["app"] == "gmail-processor"
+        assert pod_labels["team"] == "vibeteam"
+
+    def test_image_pull_secrets(self, manifest: list[dict]):
+        pod_spec = manifest[0]["spec"]["template"]["spec"]
+        assert any(s["name"] == "ghcr-pull-secret" for s in pod_spec["imagePullSecrets"])
+
+    def test_init_container_copies_credentials(self, manifest: list[dict]):
+        pod_spec = manifest[0]["spec"]["template"]["spec"]
+        init_containers = pod_spec.get("initContainers", [])
+        assert len(init_containers) >= 1, "Need init container to copy Gmail credentials"
+
+        copy_init = init_containers[0]
+        assert copy_init["name"] == "copy-token"
+        # Must mount both secrets (read-only) and writable volume
+        mount_names = [m["name"] for m in copy_init["volumeMounts"]]
+        assert "gmail-secrets" in mount_names
+        assert "gmail-writable" in mount_names
+
+    def test_main_container_command(self, manifest: list[dict]):
+        container = manifest[0]["spec"]["template"]["spec"]["containers"][0]
+        assert container["name"] == "gmail-processor"
+        assert "process_emails.py" in " ".join(container["command"])
+        assert "--daemon" in container["args"]
+        assert "--interval" in container["args"]
+
+    def test_daemon_interval_is_reasonable(self, manifest: list[dict]):
+        container = manifest[0]["spec"]["template"]["spec"]["containers"][0]
+        args = container["args"]
+        interval_idx = args.index("--interval")
+        interval = int(args[interval_idx + 1])
+        # Between 1 minute and 30 minutes
+        assert 60 <= interval <= 1800, f"Interval {interval}s seems unreasonable"
+
+    def test_credential_paths_point_to_writable_volume(self, manifest: list[dict]):
+        container = manifest[0]["spec"]["template"]["spec"]["containers"][0]
+        args = container["args"]
+        creds_idx = args.index("--credentials")
+        token_idx = args.index("--token")
+        creds_path = args[creds_idx + 1]
+        token_path = args[token_idx + 1]
+
+        # Both should point to the writable mount, not the secret mount
+        mount_paths = [m["mountPath"] for m in container["volumeMounts"]]
+        # At least one mount should be a prefix of the credential paths
+        assert any(creds_path.startswith(mp) for mp in mount_paths), (
+            f"Credentials path {creds_path} not under any mount: {mount_paths}"
+        )
+        assert any(token_path.startswith(mp) for mp in mount_paths), (
+            f"Token path {token_path} not under any mount: {mount_paths}"
+        )
+
+    def test_resource_limits_set(self, manifest: list[dict]):
+        container = manifest[0]["spec"]["template"]["spec"]["containers"][0]
+        resources = container.get("resources", {})
+        assert "requests" in resources, "Missing resource requests"
+        assert "limits" in resources, "Missing resource limits"
+        assert "cpu" in resources["requests"]
+        assert "memory" in resources["requests"]
+
+    def test_volumes_defined(self, manifest: list[dict]):
+        volumes = manifest[0]["spec"]["template"]["spec"]["volumes"]
+        vol_names = [v["name"] for v in volumes]
+        assert "gmail-secrets" in vol_names, "Missing gmail-secrets volume"
+        assert "gmail-writable" in vol_names, "Missing gmail-writable volume"
+
+        # gmail-secrets should reference the K8s secret
+        secrets_vol = next(v for v in volumes if v["name"] == "gmail-secrets")
+        assert "secret" in secrets_vol
+        assert secrets_vol["secret"]["secretName"] == "gmail-oauth-secret"
+
+        # gmail-writable should be emptyDir (writable)
+        writable_vol = next(v for v in volumes if v["name"] == "gmail-writable")
+        assert "emptyDir" in writable_vol
+
+    def test_uses_vibeteam_image(self, manifest: list[dict]):
+        """Gmail processor should use the main vibeteam image (has scripts/ included)."""
+        container = manifest[0]["spec"]["template"]["spec"]["containers"][0]
+        assert "ghcr.io/vibetechnologies/vibeteam" in container["image"]
+
+    def test_service_account(self, manifest: list[dict]):
+        pod_spec = manifest[0]["spec"]["template"]["spec"]
+        assert pod_spec.get("serviceAccountName") == "vibeteam-agent"
+
+
+class TestGmailSecretsManifest:
+    """Validate gmail-secrets.yaml template."""
+
+    @pytest.fixture
+    def manifest_path(self) -> Path:
+        return K8S_BASE / "gmail-secrets.yaml"
+
+    @pytest.fixture
+    def manifest(self, manifest_path: Path) -> dict:
+        assert manifest_path.exists(), f"Missing: {manifest_path}"
+        with open(manifest_path) as f:
+            docs = list(yaml.safe_load_all(f))
+        return [d for d in docs if d is not None]
+
+    def test_manifest_exists(self, manifest_path: Path):
+        assert manifest_path.exists()
+
+    def test_secret_kind(self, manifest: list[dict]):
+        secret = manifest[0]
+        assert secret["kind"] == "Secret"
+        assert secret["type"] == "Opaque"
+
+    def test_secret_name_matches_deployment_reference(self, manifest: list[dict]):
+        """Secret name must match what gmail-processor.yaml references."""
+        assert manifest[0]["metadata"]["name"] == "gmail-oauth-secret"
+
+    def test_secret_namespace(self, manifest: list[dict]):
+        assert manifest[0]["metadata"]["namespace"] == "vibeteam"
+
+    def test_contains_credentials_key(self, manifest: list[dict]):
+        string_data = manifest[0].get("stringData", {})
+        assert "gmail-credentials.json" in string_data, "Missing gmail-credentials.json key"
+
+    def test_contains_token_key(self, manifest: list[dict]):
+        string_data = manifest[0].get("stringData", {})
+        assert "gmail-token.json" in string_data, "Missing gmail-token.json key"
+
+    def test_credentials_has_placeholder_values(self, manifest: list[dict]):
+        """Template should have REPLACE_ placeholders, not real credentials."""
+        creds = manifest[0]["stringData"]["gmail-credentials.json"]
+        assert "REPLACE_" in creds, "Template should have placeholder values"
+
+    def test_token_has_required_oauth_fields(self, manifest: list[dict]):
+        """Token template should have the expected OAuth2 fields."""
+        import json
+
+        token_str = manifest[0]["stringData"]["gmail-token.json"]
+        token = json.loads(token_str)
+        required_fields = ["token", "refresh_token", "token_uri", "client_id", "client_secret"]
+        for field in required_fields:
+            assert field in token, f"Missing required field: {field}"
+
+
+class TestKustomizationIncludesGmail:
+    """Verify gmail-processor is referenced in kustomization.yaml."""
+
+    @pytest.fixture
+    def kustomization(self) -> dict:
+        path = K8S_BASE / "kustomization.yaml"
+        assert path.exists()
+        with open(path) as f:
+            return yaml.safe_load(f)
+
+    def test_gmail_processor_in_resources(self, kustomization: dict):
+        resources = kustomization.get("resources", [])
+        assert "gmail-processor.yaml" in resources, (
+            f"gmail-processor.yaml not in kustomization resources: {resources}"
+        )
+
+
+# ---------------------------------------------------------------------------
+# EmailProcessor Unit Tests
+# ---------------------------------------------------------------------------
+
+
+class TestEmailProcessorUnit:
+    """Unit tests for the EmailProcessor class in process_emails.py."""
+
+    @pytest.fixture
+    def mock_gmail(self):
+        """Create a mock GmailConnector."""
+        gmail = MagicMock()
+        gmail.fetch_unread_emails.return_value = []
+        gmail.mark_as_read.return_value = True
+        gmail.send_reply.return_value = "msg-123"
+        return gmail
+
+    @pytest.fixture
+    def processor(self, mock_gmail):
+        """Create an EmailProcessor with mock Gmail."""
+        # Import from the script
+        import importlib
+        import sys
+
+        # Add the connectors path so the script can import gmail module
+        connectors_path = str(PROJECT_ROOT / "vibeteam" / "connectors")
+        if connectors_path not in sys.path:
+            sys.path.insert(0, connectors_path)
+
+        spec = importlib.util.spec_from_file_location(
+            "process_emails",
+            PROJECT_ROOT / "scripts" / "process_emails.py",
+        )
+        mod = importlib.util.module_from_spec(spec)
+        spec.loader.exec_module(mod)
+
+        return mod.EmailProcessor(gmail=mock_gmail, dry_run=True)
+
+    def test_processor_initializes(self, processor):
+        assert processor.dry_run is True
+        assert processor.stats["processed"] == 0
+
+    def test_no_emails_returns_empty_stats(self, processor):
+        stats = asyncio.get_event_loop().run_until_complete(processor.process_emails())
+        assert stats["processed"] == 0
+        assert stats["skipped"] == 0
+
+    def test_non_support_email_is_skipped(self, processor, mock_gmail):
+        """Emails not matching docs portal format should be skipped."""
+        from gmail import Email
+
+        mock_email = Email(
+            id="msg-1",
+            thread_id="thread-1",
+            subject="npm security advisory: lodash",
+            sender="npm <noreply@npmjs.com>",
+            sender_email="noreply@npmjs.com",
+            recipient="support@vibebrowser.app",
+            date="2026-01-15",
+            body="A security vulnerability was found in lodash...",
+            snippet="A security vulnerability...",
+            labels=["INBOX", "UNREAD"],
+        )
+        mock_gmail.fetch_unread_emails.return_value = [mock_email]
+
+        stats = asyncio.get_event_loop().run_until_complete(processor.process_emails())
+        assert stats["skipped"] == 1
+        assert stats["processed"] == 0
+
+    def test_docs_portal_escalation_is_processed(self, processor, mock_gmail):
+        """Emails matching [Docs Support #...] format should be processed."""
+        from gmail import Email
+
+        mock_email = Email(
+            id="msg-2",
+            thread_id="thread-2",
+            subject="[Docs Support #ABC-123] New request from user@example.com",
+            sender="noreply@vibebrowser.app",
+            sender_email="noreply@vibebrowser.app",
+            recipient="support@vibebrowser.app",
+            date="2026-01-15",
+            body="How do I configure the browser extension?",
+            snippet="How do I configure...",
+            labels=["INBOX", "UNREAD"],
+        )
+        mock_gmail.fetch_unread_emails.return_value = [mock_email]
+
+        stats = asyncio.get_event_loop().run_until_complete(processor.process_emails())
+        assert stats["processed"] == 1
+        assert stats["skipped"] == 0
+
+    def test_billing_email_triggers_escalation(self, processor, mock_gmail):
+        """Emails about billing should be escalated."""
+        from gmail import Email
+
+        mock_email = Email(
+            id="msg-3",
+            thread_id="thread-3",
+            subject="[Docs Support #BILL-001] New request from billing@example.com",
+            sender="noreply@vibebrowser.app",
+            sender_email="noreply@vibebrowser.app",
+            recipient="support@vibebrowser.app",
+            date="2026-01-15",
+            body="I was charged twice for my subscription. Please refund.",
+            snippet="I was charged twice...",
+            labels=["INBOX", "UNREAD"],
+        )
+        mock_gmail.fetch_unread_emails.return_value = [mock_email]
+
+        stats = asyncio.get_event_loop().run_until_complete(processor.process_emails())
+        assert stats["escalated"] == 1
+        assert stats["responded"] == 0
+
+    def test_how_to_question_gets_response(self, processor, mock_gmail):
+        """Simple how-to questions should get auto-response."""
+        from gmail import Email
+
+        mock_email = Email(
+            id="msg-4",
+            thread_id="thread-4",
+            subject="[Docs Support #HELP-001] New request from newuser@example.com",
+            sender="noreply@vibebrowser.app",
+            sender_email="noreply@vibebrowser.app",
+            recipient="support@vibebrowser.app",
+            date="2026-01-15",
+            body="How do I install VibeBrowser on Linux?",
+            snippet="How do I install...",
+            labels=["INBOX", "UNREAD"],
+        )
+        mock_gmail.fetch_unread_emails.return_value = [mock_email]
+
+        stats = asyncio.get_event_loop().run_until_complete(processor.process_emails())
+        assert stats["responded"] == 1
+        assert stats["escalated"] == 0
+
+    def test_dry_run_does_not_mark_as_read(self, processor, mock_gmail):
+        """In dry run mode, emails should NOT be marked as read."""
+        from gmail import Email
+
+        mock_email = Email(
+            id="msg-5",
+            thread_id="thread-5",
+            subject="[Docs Support #DRY-001] New request from test@example.com",
+            sender="noreply@vibebrowser.app",
+            sender_email="noreply@vibebrowser.app",
+            recipient="support@vibebrowser.app",
+            date="2026-01-15",
+            body="This is a test question about VibeBrowser.",
+            snippet="This is a test...",
+            labels=["INBOX", "UNREAD"],
+        )
+        mock_gmail.fetch_unread_emails.return_value = [mock_email]
+
+        asyncio.get_event_loop().run_until_complete(processor.process_emails())
+        mock_gmail.mark_as_read.assert_not_called()
+
+    def test_response_validation_catches_internal_urls(self, processor):
+        """Response validator should reject responses with internal URLs."""
+        result = processor._validate_response("Check out http://localhost:8080/admin")
+        assert not result["valid"]
+        assert any("localhost" in issue for issue in result["issues"])
+
+    def test_response_validation_catches_secrets(self, processor):
+        """Response validator should reject responses that might contain secrets."""
+        result = processor._validate_response("Use api_key=abc123 to authenticate")
+        assert not result["valid"]
+        assert any("api_key" in issue for issue in result["issues"])
+
+    def test_response_validation_passes_clean_response(self, processor):
+        """Clean responses should pass validation."""
+        result = processor._validate_response(
+            "Thanks for reaching out! Check https://docs.vibebrowser.app for help."
+        )
+        assert result["valid"]
+
+    def test_ticket_extraction_from_subject(self, processor):
+        """Should extract ticket ID and customer email from subject."""
+        from gmail import Email
+
+        email = Email(
+            id="x",
+            thread_id="x",
+            subject="[Docs Support #XYZ-789] New request from alice@corp.com",
+            sender="noreply@vibebrowser.app",
+            sender_email="noreply@vibebrowser.app",
+            recipient="support@vibebrowser.app",
+            date="2026-01-15",
+            body="test",
+            snippet="test",
+            labels=[],
+        )
+        info = processor._extract_ticket_info(email)
+        assert info["ticket_id"] == "XYZ-789"
+        assert info["customer_email"] == "alice@corp.com"


### PR DESCRIPTION
## Summary

- Add `gmail-processor` K8s Deployment that runs `scripts/process_emails.py` in daemon mode (5-minute polling interval) for automated support email processing
- Add `gmail-secrets` K8s Secret template for Gmail OAuth credentials (client ID/secret + access/refresh tokens)
- Use init container + emptyDir pattern so the Gmail connector can write refreshed OAuth tokens (K8s Secrets mount read-only)

## Details

**Problem:** Gmail tools work when triggered manually, but nothing invokes them automatically — the last unchecked item in #22.

**Solution:** A standalone K8s Deployment that polls Gmail every 5 minutes for unread support emails, categorizes them (billing, security, how-to, etc.), auto-responds to simple questions, and escalates complex issues.

### Architecture
- Init container `copy-token` copies OAuth credentials from read-only Secret volume to writable `emptyDir`
- Main container runs `process_emails.py --daemon --interval 300 --max-emails 10`
- Credential/token paths point to the writable volume at `/gmail/`
- Uses `vibeteam-agent` ServiceAccount for cluster access
- No Service needed — daemon, not a server

### How to deploy

1. Create the Gmail OAuth secret:
```bash
kubectl create secret generic gmail-oauth-secret -n vibeteam \
  --from-file=gmail-credentials.json=/path/to/credentials.json \
  --from-file=gmail-token.json=/path/to/token.json \
  --dry-run=client -o yaml | kubectl apply -f -
```

2. Apply the deployment:
```bash
kubectl apply -k k8s/overlays/dev
```

### Tests

35 tests covering:
- Deployment manifest structure (15 tests)
- Secret manifest structure (8 tests)
- Kustomization includes gmail-processor (1 test)
- EmailProcessor unit tests (11 tests)

Relates to #22