### PR TITLE
fix(k8s): wire CALLBACK_SECRET and GATEWAY_URL to gateway deployment

### DIFF
--- a/k8s/base/vibeteam-gateway.yaml
+++ b/k8s/base/vibeteam-gateway.yaml
@@ -101,6 +101,15 @@ spec:
                   name: vibeteam-secrets
                   key: SENTRY_CLIENT_SECRET
                   optional: true
+            # Async callback configuration
+            - name: GATEWAY_URL
+              value: "http://vibeteam-gateway:8080"
+            - name: CALLBACK_SECRET
+              valueFrom:
+                secretKeyRef:
+                  name: vibeteam-secrets
+                  key: CALLBACK_SECRET
+                  optional: true
           resources:
             requests:
               cpu: 100m


### PR DESCRIPTION
## Summary

- Adds `CALLBACK_SECRET` (from `vibeteam-secrets` secretKeyRef) and `GATEWAY_URL` env vars to the gateway deployment manifest
- Enables authentication on the `/callback/agent` endpoint introduced in PR #69

## Context

The async callback architecture (PR #69) added `CALLBACK_SECRET` for authenticating agent callbacks to the gateway. Without this env var wired in the k8s deployment, callback authentication was effectively disabled (empty string = no verification), meaning any entity that could reach the gateway pod could post fake callback results.

## Changes

- `k8s/base/vibeteam-gateway.yaml`: Added `GATEWAY_URL` (explicit default) and `CALLBACK_SECRET` (from secret) to the container env

## Verification

- Secret added to `vibeteam-secrets` in the live cluster
- Gateway deployment patched and rolled out
- Confirmed env vars present in running pod (`kubectl exec ... printenv`)
- Regression eval passed: `support_400_errors` — InvestigationQuality: 0.90, EvidenceBasedDecision: 1.00, HandoffCompletion: 0.90