### PR TITLE
feat(eval): add --use-async flag to eval script and trigger endpoint

### DIFF
--- a/scripts/eval_slack_e2e.py
+++ b/scripts/eval_slack_e2e.py
@@ -15,6 +15,7 @@ This script runs a true end-to-end evaluation:
 Usage:
     python scripts/eval_slack_e2e.py --scenario support_400_errors
     python scripts/eval_slack_e2e.py --scenario stripe_webhook_failure --timeout 300
+    python scripts/eval_slack_e2e.py --scenario support_400_errors --use-async
     python scripts/eval_slack_e2e.py --message "@SupportEngineer check Sentry for errors"
     python scripts/eval_slack_e2e.py --channel C0123456789 --skip-eval
     python scripts/eval_slack_e2e.py --list-scenarios
@@ -597,6 +598,7 @@ async def run_evaluation(
     skip_eval: bool = False,
     existing_thread_ts: str | None = None,
     handoff_timeout_extension: int = 600,
+    use_async: bool = False,
 ) -> dict[str, Any]:
     """
     Run a full E2E evaluation:
@@ -619,6 +621,9 @@ async def run_evaluation(
             conversation collection and evaluation.
         handoff_timeout_extension: Seconds to extend wait_timeout when a handoff is
             detected (default: 600). Applied once per handoff detection.
+        use_async: If True, trigger gateway in async mode (POST /run/async →
+            POST /callback/agent). This exercises the full async callback lifecycle
+            including CALLBACK_SECRET verification. Default: False (sync mode).
     """
     # Get scenario config
     if custom_message:
@@ -685,7 +690,8 @@ async def run_evaluation(
         print("    Posted successfully!")
 
         # Step 1b: Trigger the gateway to process this message
-        print("\n>>> Step 1b: Triggering gateway to process message")
+        mode_label = "ASYNC" if use_async else "SYNC"
+        print(f"\n>>> Step 1b: Triggering gateway to process message ({mode_label} mode)")
         default_prod_url = "https://webhook.team.vibebrowser.app"
         resolved_gateway_url = gateway_url or os.environ.get("GATEWAY_URL", default_prod_url)
         trigger_url = f"{resolved_gateway_url}/slack/trigger"
@@ -705,19 +711,26 @@ async def run_evaluation(
 
         try:
             async with httpx.AsyncClient(timeout=30.0) as client:
+                trigger_payload: dict[str, Any] = {
+                    "channel": channel,
+                    "thread_ts": thread_ts,
+                    "text": user_message,
+                    "user_id": "eval_script",
+                }
+                if use_async:
+                    trigger_payload["use_async"] = True
+
                 response = await client.post(
                     trigger_url,
-                    json={
-                        "channel": channel,
-                        "thread_ts": thread_ts,
-                        "text": user_message,
-                        "user_id": "eval_script",
-                    },
+                    json=trigger_payload,
                     headers=headers,
                 )
                 if response.status_code == 200:
                     result = response.json()
-                    print(f"    Gateway accepted: routing to {result.get('roles', [])}")
+                    mode = result.get("mode", "sync")
+                    print(
+                        f"    Gateway accepted: routing to {result.get('roles', [])} (mode={mode})"
+                    )
                 else:
                     print(f"    WARNING: Gateway returned {response.status_code}: {response.text}")
         except Exception as e:
@@ -978,6 +991,7 @@ Examples:
   python scripts/eval_slack_e2e.py --channel C0123456789 --skip-eval
   python scripts/eval_slack_e2e.py --list-scenarios
   python scripts/eval_slack_e2e.py --scenario stripe_webhook_failure --thread-ts 1770710833.425539 --channel C0AATPSADB8
+  python scripts/eval_slack_e2e.py --scenario support_400_errors --use-async
         """,
     )
     parser.add_argument(
@@ -1036,6 +1050,15 @@ Examples:
             "Ignored in --thread-ts mode."
         ),
     )
+    parser.add_argument(
+        "--use-async",
+        action="store_true",
+        help=(
+            "Use async callback flow (POST /run/async -> POST /callback/agent) "
+            "instead of the default synchronous path. This exercises the full "
+            "async lifecycle including CALLBACK_SECRET verification."
+        ),
+    )
 
     args = parser.parse_args()
 
@@ -1071,6 +1094,7 @@ Examples:
                 skip_eval=args.skip_eval,
                 existing_thread_ts=args.thread_ts,
                 handoff_timeout_extension=args.handoff_timeout,
+                use_async=args.use_async,
             )
         )
 

--- a/tests/test_gateway_trigger.py
+++ b/tests/test_gateway_trigger.py
@@ -198,3 +198,58 @@ class TestTriggerRateLimit:
             response = client.post("/slack/trigger", json=VALID_PAYLOAD)
             assert response.status_code == 429
             assert "Rate limit exceeded" in response.json()["detail"]
+
+
+class TestTriggerAsyncMode:
+    """Test /slack/trigger use_async parameter."""
+
+    @pytest.fixture(autouse=True)
+    def _reset_rate_limiter(self):
+        """Reset rate limiter before each test so prior tests don't cause 429s."""
+        from vibeteam.gateway.routes.slack import _trigger_rate_limiter
+
+        _trigger_rate_limiter.reset()
+
+    def test_default_mode_is_sync(self, client: TestClient, _patch_run_agent):
+        """Without use_async, mode should be 'sync' and run_agent called with use_async=False."""
+        with patch("vibeteam.gateway.routes.slack.config") as mock_config:
+            mock_config.SLACK_TRIGGER_SECRET = ""
+            mock_config.SLACK_BOT_TOKEN = "xoxb-test"
+            response = client.post("/slack/trigger", json=VALID_PAYLOAD)
+        assert response.status_code == 200
+        data = response.json()
+        assert data["mode"] == "sync"
+        # Verify run_agent_for_slack was called with use_async=False
+        _patch_run_agent.assert_called_once()
+        _, kwargs = _patch_run_agent.call_args
+        assert kwargs.get("use_async") is False
+
+    def test_async_mode_returns_async(self, client: TestClient, _patch_run_agent):
+        """With use_async=true, mode should be 'async' and run_agent called with use_async=True."""
+        payload = {**VALID_PAYLOAD, "use_async": True}
+        with patch("vibeteam.gateway.routes.slack.config") as mock_config:
+            mock_config.SLACK_TRIGGER_SECRET = ""
+            mock_config.SLACK_BOT_TOKEN = "xoxb-test"
+            response = client.post("/slack/trigger", json=payload)
+        assert response.status_code == 200
+        data = response.json()
+        assert data["mode"] == "async"
+        # Verify run_agent_for_slack was called with use_async=True
+        _patch_run_agent.assert_called_once()
+        _, kwargs = _patch_run_agent.call_args
+        assert kwargs.get("use_async") is True
+
+    def test_async_false_explicit(self, client: TestClient, _patch_run_agent):
+        """With use_async=false explicitly, mode should be 'sync'."""
+        payload = {**VALID_PAYLOAD, "use_async": False}
+        with patch("vibeteam.gateway.routes.slack.config") as mock_config:
+            mock_config.SLACK_TRIGGER_SECRET = ""
+            mock_config.SLACK_BOT_TOKEN = "xoxb-test"
+            response = client.post("/slack/trigger", json=payload)
+        assert response.status_code == 200
+        data = response.json()
+        assert data["mode"] == "sync"
+        # Verify run_agent_for_slack was called with use_async=False
+        _patch_run_agent.assert_called_once()
+        _, kwargs = _patch_run_agent.call_args
+        assert kwargs.get("use_async") is False

--- a/vibeteam/gateway/routes/slack.py
+++ b/vibeteam/gateway/routes/slack.py
@@ -1109,8 +1109,19 @@ async def trigger_agent_for_slack(
         "channel": "C0AATPSADB8",
         "thread_ts": "1234567890.123456",
         "text": "@SupportEngineer please investigate the issue",
-        "user_id": "eval_script"
+        "user_id": "eval_script",
+        "use_async": false
     }
+
+    Fields:
+    - channel (required): Slack channel ID
+    - text (required): Message text with @RoleName mention
+    - thread_ts (optional): Thread timestamp to post in
+    - user_id (optional): Identifier for the caller (default: "trigger_api")
+    - use_async (optional, default: false): If true, uses the async callback flow
+      (POST /run/async → agent processes → POST /callback/agent) instead of the
+      synchronous path. Useful for testing the full async lifecycle including
+      CALLBACK_SECRET verification.
     """
     # Rate limiting
     if not _trigger_rate_limiter.allow():
@@ -1144,6 +1155,7 @@ async def trigger_agent_for_slack(
     thread_ts = body.get("thread_ts")
     text = body.get("text", "")
     user_id = body.get("user_id", "trigger_api")
+    use_async = body.get("use_async", False)
 
     if not channel:
         raise HTTPException(status_code=400, detail="channel is required")
@@ -1160,14 +1172,18 @@ async def trigger_agent_for_slack(
             detail="text must contain @RoleName mention (e.g., @SupportEngineer)",
         )
 
-    logger.info(f"Trigger API: routing to {role_mentions} in {channel}")
+    mode = "async" if use_async else "sync"
+    logger.info(f"Trigger API: routing to {role_mentions} in {channel} (mode={mode})")
 
-    # Process in background (sync path — trigger is used by eval scripts)
-    asyncio.create_task(run_agent_for_slack(text, channel, thread_ts, user_id, use_async=False))
+    # Process in background
+    # use_async=True exercises the full /run/async → /callback/agent flow
+    # use_async=False (default) uses the synchronous path
+    asyncio.create_task(run_agent_for_slack(text, channel, thread_ts, user_id, use_async=use_async))
 
     return {
         "status": "accepted",
         "channel": channel,
         "thread_ts": thread_ts,
         "roles": role_mentions,
+        "mode": mode,
     }


### PR DESCRIPTION
## Summary

- Adds `use_async` parameter to `/slack/trigger` endpoint to switch between sync and async agent invocation paths
- Adds `--use-async` CLI flag to `eval_slack_e2e.py` to exercise the full async callback lifecycle (POST `/run/async` -> POST `/callback/agent`) including `CALLBACK_SECRET` verification
- Returns `mode` field (`"sync"` or `"async"`) in trigger endpoint response JSON

## Changes

| File | Change |
|------|--------|
| `vibeteam/gateway/routes/slack.py` | Parse `use_async` field, pass to `run_agent_for_slack`, return `mode` in response |
| `scripts/eval_slack_e2e.py` | Add `--use-async` flag, include `use_async: true` in trigger payload, display mode |
| `tests/test_gateway_trigger.py` | Add `TestTriggerAsyncMode` class (3 tests), fix rate limiter exhaustion between test classes |

## Testing

- 14/14 unit tests pass in `test_gateway_trigger.py`
- 31/31 unit tests pass in `test_async_callback.py` (2 skipped: sqlalchemy not installed)
- Ruff linting clean on all 3 modified files
- Async eval requires deployment of new gateway image before running E2E

## Usage

```bash
# Sync mode (default, existing behavior)
python scripts/eval_slack_e2e.py --scenario support_400_errors --channel C0AATPSADB8

# Async mode (exercises full callback lifecycle)
python scripts/eval_slack_e2e.py --scenario support_400_errors --channel C0AATPSADB8 --use-async
```

## Follow-up

After merging and deploying the new gateway image, run the async eval to verify the full callback flow end-to-end.