### PR TITLE
fix(routing): route Sentry issues to SupportEngineer + add missing deploy secrets

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -128,7 +128,10 @@ jobs:
             --from-literal=AZURE_API_VERSION="${{ secrets.AZURE_API_VERSION }}" \
             --from-literal=SLACK_BOT_TOKEN="${{ secrets.SLACK_BOT_TOKEN }}" \
             --from-literal=SLACK_SIGNING_SECRET="${{ secrets.SLACK_SIGNING_SECRET }}" \
-            --from-literal=SLACK_TRIGGER_SECRET="${{ secrets.SLACK_TRIGGER_SECRET }}"
+            --from-literal=SLACK_TRIGGER_SECRET="${{ secrets.SLACK_TRIGGER_SECRET }}" \
+            --from-literal=GITHUB_WEBHOOK_SECRET="${{ secrets.GITHUB_WEBHOOK_SECRET }}" \
+            --from-literal=SENTRY_CLIENT_SECRET="${{ secrets.SENTRY_CLIENT_SECRET }}" \
+            --from-literal=CALLBACK_SECRET="${{ secrets.CALLBACK_SECRET }}"
 
           if [ -n "${{ secrets.GMAIL_CREDENTIALS_JSON }}" ]; then
             kubectl -n $NAMESPACE delete secret gmail-oauth-secrets --ignore-not-found

--- a/vibeteam/gateway/routes/sentry.py
+++ b/vibeteam/gateway/routes/sentry.py
@@ -2,7 +2,7 @@
 Sentry Webhook Handlers.
 
 Handles Sentry webhook events for error monitoring:
-- issue.created: Triage new errors and route to Release Engineer
+- issue.created: Triage new errors and route to Support Engineer
 """
 
 import asyncio
@@ -93,10 +93,14 @@ def classify_sentry_issue(issue: dict[str, Any]) -> str:
     return "NEEDS_INVESTIGATION"
 
 
-async def run_release_engineer_agent(issue_data: dict[str, Any], classification: str) -> None:
-    """Run the Release Engineer agent on a Sentry issue."""
+async def run_support_engineer_agent(issue_data: dict[str, Any], classification: str) -> None:
+    """Run the Support Engineer agent on a Sentry issue.
+
+    Per AGENTS.md Service Ownership Matrix, Sentry is owned by SupportEngineer
+    with escalation to ReleaseEngineer (infra) or SoftwareEngineer (code).
+    """
     issue_id = issue_data.get("shortId", "unknown")
-    logger.info(f"Starting Release Engineer agent for Sentry issue {issue_id}")
+    logger.info(f"Starting Support Engineer agent for Sentry issue {issue_id}")
 
     # Build task for the agent
     task = f"""## Sentry Error Triage
@@ -138,18 +142,18 @@ Please triage this error and take appropriate action.
     try:
         result = await call_agent_service(
             task=task,
-            role="release_engineer",
+            role="support_engineer",
             context_type="sentry",
             context_id=issue_id,
         )
 
         if "error" in result:
-            logger.error(f"Release Engineer agent failed for {issue_id}: {result['error']}")
+            logger.error(f"Support Engineer agent failed for {issue_id}: {result['error']}")
         else:
-            logger.info(f"Release Engineer agent completed for {issue_id}")
+            logger.info(f"Support Engineer agent completed for {issue_id}")
 
     except Exception as e:
-        logger.exception(f"Failed to run Release Engineer agent: {e}")
+        logger.exception(f"Failed to run Support Engineer agent: {e}")
 
 
 @router.post("/webhook/sentry")
@@ -161,7 +165,7 @@ async def handle_sentry_webhook(
     Handle incoming Sentry webhook events.
 
     Sentry webhooks are triggered when new issues are created or existing
-    issues receive new events. We route these to the Release Engineer agent
+    issues receive new events. We route these to the Support Engineer agent
     for triage.
     """
     payload_bytes = await request.body()
@@ -196,8 +200,8 @@ async def handle_sentry_webhook(
             "short_id": issue.get("shortId"),
         }
 
-    # Trigger Release Engineer agent in background
-    asyncio.create_task(run_release_engineer_agent(issue, classification))
+    # Trigger Support Engineer agent (Sentry owner per AGENTS.md)
+    asyncio.create_task(run_support_engineer_agent(issue, classification))
 
     return {
         "status": "accepted",

--- a/vibeteam/webhook/server.py
+++ b/vibeteam/webhook/server.py
@@ -185,10 +185,14 @@ async def post_acknowledgment(repo: str, issue_number: int) -> None:
         logger.exception(f"Failed to post acknowledgment: {e}")
 
 
-async def run_release_engineer_agent(issue_data: dict[str, Any], classification: str) -> None:
-    """Run the Release Engineer agent on a Sentry issue."""
+async def run_support_engineer_agent(issue_data: dict[str, Any], classification: str) -> None:
+    """Run the Support Engineer agent on a Sentry issue.
+
+    Per AGENTS.md Service Ownership Matrix, Sentry is owned by SupportEngineer
+    with escalation to ReleaseEngineer (infra) or SoftwareEngineer (code).
+    """
     issue_id = issue_data.get("shortId", "unknown")
-    logger.info(f"Starting Release Engineer agent for Sentry issue {issue_id}")
+    logger.info(f"Starting Support Engineer agent for Sentry issue {issue_id}")
 
     # Run the CLI command asynchronously
     cmd = [
@@ -196,7 +200,7 @@ async def run_release_engineer_agent(issue_data: dict[str, Any], classification:
         "-m",
         "vibeteam.cli",
         "scheduled",
-        "release-triage",
+        "support-triage",
         "--issue-json",
         json.dumps(issue_data),
         "--classification",
@@ -212,12 +216,12 @@ async def run_release_engineer_agent(issue_data: dict[str, Any], classification:
         stdout, stderr = await process.communicate()
 
         if process.returncode == 0:
-            logger.info(f"Release Engineer agent completed successfully for {issue_id}")
+            logger.info(f"Support Engineer agent completed successfully for {issue_id}")
         else:
-            logger.error(f"Release Engineer agent failed: {stderr.decode()}")
+            logger.error(f"Support Engineer agent failed: {stderr.decode()}")
 
     except Exception as e:
-        logger.exception(f"Failed to run Release Engineer agent: {e}")
+        logger.exception(f"Failed to run Support Engineer agent: {e}")
 
 
 @app.get("/health")
@@ -452,7 +456,7 @@ async def handle_sentry_webhook(
     Handle incoming Sentry webhook events.
 
     Sentry webhooks are triggered when new issues are created or existing
-    issues receive new events. We route these to the Release Engineer agent
+    issues receive new events. We route these to the Support Engineer agent
     via OpenHands with Sentry-specific context.
     """
     payload_bytes = await request.body()
@@ -493,8 +497,8 @@ async def handle_sentry_webhook(
     # Start agent conversation in background
     # asyncio.create_task(start_openhands_conversation(task))
 
-    # Trigger Release Engineer agent directly
-    asyncio.create_task(run_release_engineer_agent(issue, classification))
+    # Trigger Support Engineer agent (Sentry owner per AGENTS.md)
+    asyncio.create_task(run_support_engineer_agent(issue, classification))
 
     return {
         "status": "accepted",


### PR DESCRIPTION
## Summary
Two related fixes:

1. **Sentry routing correction** — Routes Sentry webhook issues to `SupportEngineer` instead of `ReleaseEngineer`, matching the Service Ownership Matrix in AGENTS.md
2. **Missing deploy secrets** — Adds `GITHUB_WEBHOOK_SECRET`, `SENTRY_CLIENT_SECRET`, and `CALLBACK_SECRET` to the k8s deployment workflow

## Changes

### Sentry Routing (`sentry.py` + `webhook/server.py`)
- Rename `run_release_engineer_agent` → `run_support_engineer_agent`
- Change `call_agent_service(role=...)` from `"release_engineer"` to `"support_engineer"`
- Change CLI subcommand from `release-triage` to `support-triage`
- Update all log messages, docstrings, and comments

### Deploy Workflow (`.github/workflows/deploy.yml`)
- Add `GITHUB_WEBHOOK_SECRET` to `vibeteam-secrets`
- Add `SENTRY_CLIENT_SECRET` to `vibeteam-secrets`
- Add `CALLBACK_SECRET` to `vibeteam-secrets`

These secrets were missing from the deployment, causing signature verification failures.

## Context
Per AGENTS.md:
> | **Sentry** | SupportEngineer | → ReleaseEngineer (infra) / SoftwareEngineer (code) |

The SupportEngineer investigates Sentry issues first, then escalates to ReleaseEngineer or SoftwareEngineer as needed.