### PR TITLE
fix(agents): consolidate AzureLLM into shared module and fix marketing/product managers

### DIFF
--- a/agents/openhands/marketing_manager.py
+++ b/agents/openhands/marketing_manager.py
@@ -34,15 +34,15 @@ from agents.shared.browser_tools import (
 )
 
 try:
-    from openhands.sdk import LLM, Agent, LocalConversation
+    from openhands.sdk import Agent, LocalConversation
 
     OPENHANDS_AVAILABLE = True
 except ImportError:
     OPENHANDS_AVAILABLE = False
-    LLM = None
     Agent = None
     LocalConversation = None
 
+from agents.shared.llm import LLM, AzureLLM
 
 MARKETING_MANAGER_CONTEXT = """You are Ada, the Marketing Manager for VibeTeam.
 
@@ -89,13 +89,17 @@ class OpenHandsMarketingManager:
 
         self.config = config or MARKETING_MANAGER_CONFIG
 
-    def _create_llm(self) -> LLM:
-        """Create LLM with Azure configuration."""
+    def _create_llm(self) -> AzureLLM:
+        """Create AzureLLM with Azure configuration.
+
+        Uses AzureLLM (not base LLM) because Azure OpenAI doesn't support the
+        Responses API. AzureLLM overrides uses_responses_api() to return False.
+        """
         model_name = self.config.llm.model or "gpt-4.1-mini"
         if not model_name.startswith("azure/"):
             model_name = f"azure/{model_name}"
 
-        return LLM(
+        return AzureLLM(
             model=model_name,
             api_key=self.config.llm.api_key,
             base_url=self.config.llm.api_base,

--- a/agents/openhands/product_manager.py
+++ b/agents/openhands/product_manager.py
@@ -23,15 +23,15 @@ from agents.config import PRODUCT_MANAGER_CONFIG, AgentConfig
 from agents.sessions import get_or_create_session, get_session_store
 
 try:
-    from openhands.sdk import LLM, Agent, LocalConversation
+    from openhands.sdk import Agent, LocalConversation
 
     OPENHANDS_AVAILABLE = True
 except ImportError:
     OPENHANDS_AVAILABLE = False
-    LLM = None
     Agent = None
     LocalConversation = None
 
+from agents.shared.llm import LLM, AzureLLM
 
 PRODUCT_MANAGER_CONTEXT = """You are Maya, the Product Manager for VibeTeam.
 
@@ -113,13 +113,17 @@ class OpenHandsProductManager:
 
         self.config = config or PRODUCT_MANAGER_CONFIG
 
-    def _create_llm(self) -> LLM:
-        """Create LLM with Azure configuration."""
+    def _create_llm(self) -> AzureLLM:
+        """Create AzureLLM with Azure configuration.
+
+        Uses AzureLLM (not base LLM) because Azure OpenAI doesn't support the
+        Responses API. AzureLLM overrides uses_responses_api() to return False.
+        """
         model_name = self.config.llm.model or "gpt-4.1-mini"
         if not model_name.startswith("azure/"):
             model_name = f"azure/{model_name}"
 
-        return LLM(
+        return AzureLLM(
             model=model_name,
             api_key=self.config.llm.api_key,
             base_url=self.config.llm.api_base,

--- a/agents/openhands/release_engineer.py
+++ b/agents/openhands/release_engineer.py
@@ -32,29 +32,21 @@ def fetch_kubectl_context() -> str:
 
 # OpenHands imports - will fail gracefully if not installed
 try:
-    from openhands.sdk import LLM, Agent, LocalConversation, Tool
+    from openhands.sdk import Agent, LocalConversation, Tool
     from openhands.tools.file_editor import FileEditorTool
     from openhands.tools.terminal import TerminalTool
 
     OPENHANDS_AVAILABLE = True
 
-    class AzureLLM(LLM):
-        """LLM subclass that forces completion API for Azure OpenAI."""
-
-        def uses_responses_api(self) -> bool:
-            """Azure OpenAI doesn't support the Responses API."""
-            return False
-
 except ImportError:
     OPENHANDS_AVAILABLE = False
-    LLM = None
-    AzureLLM = None
     Agent = None
     LocalConversation = None
     Tool = None
     TerminalTool = None
     FileEditorTool = None
 
+from agents.shared.llm import LLM, AzureLLM
 
 # OpenHands uses Jinja2 templates for system prompts.
 # We use agents/openhands/prompts/agent_system.j2 as a custom template

--- a/agents/openhands/software_engineer.py
+++ b/agents/openhands/software_engineer.py
@@ -30,33 +30,21 @@ def fetch_kubectl_context() -> str:
 
 
 try:
-    from openhands.sdk import LLM, Agent, LocalConversation, Tool
+    from openhands.sdk import Agent, LocalConversation, Tool
     from openhands.tools.file_editor import FileEditorTool
     from openhands.tools.terminal import TerminalTool
 
     OPENHANDS_AVAILABLE = True
 
-    class AzureLLM(LLM):
-        """LLM subclass that forces completion API for Azure OpenAI.
-
-        Azure OpenAI doesn't support the Responses API endpoint, so we override
-        uses_responses_api() to always return False.
-        """
-
-        def uses_responses_api(self) -> bool:
-            """Azure OpenAI doesn't support the Responses API."""
-            return False
-
 except ImportError:
     OPENHANDS_AVAILABLE = False
-    LLM = None
-    AzureLLM = None
     Agent = None
     LocalConversation = None
     Tool = None
     TerminalTool = None
     FileEditorTool = None
 
+from agents.shared.llm import LLM, AzureLLM
 
 SOFTWARE_ENGINEER_CONTEXT = """You are Alan, the Software Engineer for VibeTeam.
 

--- a/agents/openhands/support_engineer.py
+++ b/agents/openhands/support_engineer.py
@@ -82,29 +82,21 @@ def convert_numbered_lists_to_bullets(text: str) -> str:
 
 
 try:
-    from openhands.sdk import LLM, Agent, LocalConversation, Tool
+    from openhands.sdk import Agent, LocalConversation, Tool
     from openhands.tools.file_editor import FileEditorTool
     from openhands.tools.terminal import TerminalTool
 
     OPENHANDS_AVAILABLE = True
 
-    class AzureLLM(LLM):
-        """LLM subclass that forces completion API for Azure OpenAI."""
-
-        def uses_responses_api(self) -> bool:
-            """Azure OpenAI doesn't support the Responses API."""
-            return False
-
 except ImportError:
     OPENHANDS_AVAILABLE = False
-    LLM = None
-    AzureLLM = None
     Agent = None
     LocalConversation = None
     Tool = None
     TerminalTool = None
     FileEditorTool = None
 
+from agents.shared.llm import LLM, AzureLLM
 
 SUPPORT_ENGINEER_CONTEXT = """You are Grace, the Support Engineer for VibeTeam.
 

--- a/agents/shared/llm.py
+++ b/agents/shared/llm.py
@@ -1,0 +1,35 @@
+"""Shared LLM utilities for OpenHands agents.
+
+Azure OpenAI doesn't support the Responses API endpoint. All agents must use
+AzureLLM (which forces the completion API) instead of the base LLM class.
+
+This module is the single source of truth for AzureLLM — do NOT define it
+in individual agent files.
+"""
+
+from __future__ import annotations
+
+try:
+    from openhands.sdk import LLM
+
+    OPENHANDS_LLM_AVAILABLE = True
+
+    class AzureLLM(LLM):
+        """LLM subclass that forces completion API for Azure OpenAI.
+
+        Azure OpenAI doesn't support the Responses API endpoint, so we override
+        uses_responses_api() to always return False. Without this, the SDK
+        attempts to call the Responses API and gets a 404 from Azure.
+        """
+
+        def uses_responses_api(self) -> bool:
+            """Azure OpenAI doesn't support the Responses API."""
+            return False
+
+except ImportError:
+    OPENHANDS_LLM_AVAILABLE = False
+    LLM = None  # type: ignore[assignment,misc]
+    AzureLLM = None  # type: ignore[assignment,misc]
+
+
+__all__ = ["AzureLLM", "LLM", "OPENHANDS_LLM_AVAILABLE"]

--- a/tests/test_system_prompt.py
+++ b/tests/test_system_prompt.py
@@ -681,3 +681,126 @@ class TestSoftwareEngineerIterationBudget:
                 f"{agent_file} should still use max_iteration_per_run=25. "
                 f"Only SWE agent needs 35 iterations."
             )
+
+
+class TestAzureLLMConsolidation:
+    """Verify all agents use AzureLLM from the shared module.
+
+    Azure OpenAI doesn't support the Responses API. The base LLM class
+    attempts to use it and gets 404 errors. All agents MUST use AzureLLM
+    (which overrides uses_responses_api() to return False).
+
+    Previously, AzureLLM was defined 3 times (SWE, support, release) and
+    marketing_manager + product_manager used base LLM — a production bug.
+    Now AzureLLM lives in agents/shared/llm.py and all agents import from there.
+    """
+
+    AGENTS_DIR = os.path.join(os.path.dirname(__file__), os.pardir, "agents", "openhands")
+
+    ALL_AGENT_FILES = [
+        "software_engineer.py",
+        "support_engineer.py",
+        "release_engineer.py",
+        "marketing_manager.py",
+        "product_manager.py",
+    ]
+
+    @staticmethod
+    def _read_agent(filename: str) -> str:
+        filepath = os.path.join(
+            os.path.dirname(__file__),
+            os.pardir,
+            "agents",
+            "openhands",
+            filename,
+        )
+        with open(filepath) as f:
+            return f.read()
+
+    @staticmethod
+    def _read_shared_llm() -> str:
+        filepath = os.path.join(
+            os.path.dirname(__file__),
+            os.pardir,
+            "agents",
+            "shared",
+            "llm.py",
+        )
+        with open(filepath) as f:
+            return f.read()
+
+    def test_shared_llm_module_exists(self):
+        """agents/shared/llm.py must exist as the single source of truth."""
+        filepath = os.path.join(os.path.dirname(__file__), os.pardir, "agents", "shared", "llm.py")
+        assert os.path.exists(filepath), (
+            "agents/shared/llm.py must exist. AzureLLM should be defined once, not per-agent."
+        )
+
+    def test_shared_llm_defines_azure_llm_class(self):
+        """The shared module must define the AzureLLM class."""
+        content = self._read_shared_llm()
+        assert "class AzureLLM" in content
+
+    def test_shared_llm_overrides_uses_responses_api(self):
+        """AzureLLM must override uses_responses_api to return False."""
+        content = self._read_shared_llm()
+        assert "def uses_responses_api" in content
+        assert "return False" in content
+
+    @pytest.mark.parametrize("agent_file", ALL_AGENT_FILES)
+    def test_agent_imports_from_shared_llm(self, agent_file: str):
+        """Every agent must import AzureLLM from agents.shared.llm."""
+        content = self._read_agent(agent_file)
+        assert "from agents.shared.llm import" in content, (
+            f"{agent_file} must import from agents.shared.llm, "
+            f"not define its own AzureLLM or use base LLM"
+        )
+        assert "AzureLLM" in content.split("from agents.shared.llm import")[1].split("\n")[0], (
+            f"{agent_file} must import AzureLLM from agents.shared.llm"
+        )
+
+    @pytest.mark.parametrize("agent_file", ALL_AGENT_FILES)
+    def test_agent_does_not_define_own_azure_llm(self, agent_file: str):
+        """No agent should define its own AzureLLM class — use the shared one."""
+        content = self._read_agent(agent_file)
+        assert "class AzureLLM" not in content, (
+            f"{agent_file} defines its own AzureLLM class. "
+            f"Remove it and import from agents.shared.llm instead."
+        )
+
+    @pytest.mark.parametrize("agent_file", ALL_AGENT_FILES)
+    def test_agent_create_llm_returns_azure_llm(self, agent_file: str):
+        """Every agent's _create_llm must return AzureLLM(), not LLM()."""
+        content = self._read_agent(agent_file)
+        # Find the _create_llm method body
+        method_start = content.find("def _create_llm")
+        assert method_start != -1, f"{agent_file} must have a _create_llm method"
+        # Find the next method or class definition
+        next_def = content.find("\n    def ", method_start + 10)
+        method_body = content[method_start:next_def] if next_def != -1 else content[method_start:]
+
+        assert "return AzureLLM(" in method_body, (
+            f"{agent_file}._create_llm() must return AzureLLM(...), not LLM(...). "
+            f"Azure OpenAI doesn't support the Responses API."
+        )
+        # Ensure it does NOT return plain LLM (but AzureLLM contains "LLM" so check carefully)
+        # Remove all "AzureLLM" occurrences then check for standalone "return LLM("
+        sanitized = method_body.replace("AzureLLM", "XXXX")
+        assert "return LLM(" not in sanitized, (
+            f"{agent_file}._create_llm() returns base LLM(). "
+            f"Must use AzureLLM() for Azure OpenAI compatibility."
+        )
+
+    @pytest.mark.parametrize("agent_file", ALL_AGENT_FILES)
+    def test_agent_does_not_import_llm_from_openhands_sdk(self, agent_file: str):
+        """Agents must not import LLM from openhands.sdk directly (use shared module)."""
+        content = self._read_agent(agent_file)
+        import re
+
+        sdk_imports = re.findall(r"from openhands\.sdk import (.+)", content)
+        for import_line in sdk_imports:
+            imported_names = [name.strip() for name in import_line.split(",")]
+            assert "LLM" not in imported_names, (
+                f"{agent_file} imports LLM from openhands.sdk. "
+                f"Import from agents.shared.llm instead for Azure compatibility."
+            )


### PR DESCRIPTION
## Summary

- **Created `agents/shared/llm.py`** as single source of truth for `AzureLLM` — eliminates 3x duplicate class definitions
- **Fixed production bug** in `marketing_manager.py` and `product_manager.py` that used base `LLM()` instead of `AzureLLM()`, which would cause 404 errors on Azure OpenAI (Responses API not supported)
- **23 new tests** in `TestAzureLLMConsolidation` ensuring no agent defines its own `AzureLLM`, all import from the shared module, and all `_create_llm()` methods return `AzureLLM`

## Problem

Azure OpenAI doesn't support the Responses API endpoint. The `AzureLLM` subclass overrides `uses_responses_api()` to return `False`, forcing the completion API instead.

Previously:
- `AzureLLM` was defined identically in `software_engineer.py`, `support_engineer.py`, and `release_engineer.py` (DRY violation)
- `marketing_manager.py` and `product_manager.py` used base `LLM()` — they would hit 404 errors when the SDK attempts the Responses API on Azure

## Changes

| File | Change |
|------|--------|
| `agents/shared/llm.py` | **New** — single source of truth for `AzureLLM` |
| `agents/openhands/software_engineer.py` | Remove local `AzureLLM`, import from shared |
| `agents/openhands/support_engineer.py` | Remove local `AzureLLM`, import from shared |
| `agents/openhands/release_engineer.py` | Remove local `AzureLLM`, import from shared |
| `agents/openhands/marketing_manager.py` | Import from shared, `_create_llm()` returns `AzureLLM` |
| `agents/openhands/product_manager.py` | Import from shared, `_create_llm()` returns `AzureLLM` |
| `tests/test_system_prompt.py` | 23 new tests in `TestAzureLLMConsolidation` |

## Test Results

```
529 passed, 78 skipped, 0 failed
ruff: All checks passed!
```