### PR TITLE
fix(agents): improve SWE investigation workflow and response extraction

### DIFF
--- a/agents/openhands/software_engineer.py
+++ b/agents/openhands/software_engineer.py
@@ -175,19 +175,9 @@ Your responsibilities:
 7. **PR**: Create a pull request with summary using `gh pr create`
 
 ## DEBUGGING TIPS
-- When searching for API routes, use `grep -r "route_path" .` or `grep -r "app.post" .`
-- Do not read large files line-by-line unless necessary. Use `grep` to find relevant sections first.
-- If you get stuck, try a different approach (e.g. search for a different keyword).
-
-### CRITICAL: AVOID FILE READING LOOPS
-**DO NOT** sequentially view a large file in 40-line chunks. This wastes time!
-If you've viewed MORE THAN 2 SECTIONS of the same file, STOP IMMEDIATELY and:
-1. Use `grep -n "keyword" filename` to find the exact line numbers you need
-2. Only view the specific 20-40 lines around the match
-3. If you can't find what you need after 2 grep searches, provide your findings and ask for clarification
-
-**TIME LIMIT**: You have ~10 minutes total to complete your investigation and fix.
-Reading files line-by-line will waste precious time. USE GREP.
+- Use `grep -rn "keyword" .` to search for code patterns. **NEVER use `rg` or `ripgrep`.**
+- Use `find . -name "filename"` to locate files. Do not guess paths.
+- If you get stuck, try a different keyword. Do NOT read files section-by-section.
 
 ## IMPORTANT: Always Provide a Response
 Even if you cannot fully solve the problem, you MUST provide a response with:
@@ -209,42 +199,45 @@ Never return an empty response. The user needs to know what happened.
 
 **DO NOT** stop at analysis or recommendations. Your job is to **actually fix the code**.
 
-### For GitHub Issue Investigation (follow this exact workflow):
-1. `gh issue view <number> > /tmp/issue.txt && cat /tmp/issue.txt` - read the issue
-2. Clone repo: `git clone --depth 1 https://github.com/VibeTechnologies/VibeWebAgent/`
-3. Search the codebase for relevant code using keywords from the issue:
-   - `grep -rn "keyword" VibeWebAgent/ | head -20` (use -n for line numbers, head to limit output)
-   - `find VibeWebAgent/ -type f -name "*.ts" -o -name "*.tsx" | head -20` to find file structure
-   - For browser extension bugs: search `extension/`, `chrome/`, `popup/`, `content/`, `src/` dirs
-4. View ONLY the specific lines found by grep (e.g., lines 100-120), NOT the whole file
-5. If you find the bug, edit the file to fix it
-6. If you can't find it in 3 grep searches, provide your analysis and findings
-7. **ITERATION CHECK**: If you have used 25+ iterations, STOP searching immediately.
-   Call finish() NOW with whatever you found so far. An incomplete summary is
-   infinitely better than exhausting all iterations with no response.
+### For GitHub Issue Investigation — STRICT 3-PHASE WORKFLOW
 
-**NEVER read a file section-by-section.** Use grep to find exact locations first.
+You have 35 tool calls total. Budget them carefully across these 3 phases:
 
-If you find that the infrastructure is healthy (no pod errors, APIs returning 200), **YOU MUST IMMEDIATELY SWITCH TO CODE FIXING**.
-- Do not report "Infra is healthy" and stop.
-- Assume the bug is in the application code.
-- Locate the relevant files.
-- Reproduce the issue with a test or script.
-- **Implement the fix.**
+**PHASE 1: GATHER (iterations 1-5, MAX 5 tool calls)**
+1. `gh issue view <number> > /tmp/issue.txt && cat /tmp/issue.txt`
+2. `gh auth setup-git && git clone --depth 1 https://github.com/VibeTechnologies/VibeWebAgent/`
+3. `find VibeWebAgent/ -type f \\( -name '*.ts' -o -name '*.js' -o -name '*.tsx' \\) | head -30`
+4. `grep -rn "KEYWORD" VibeWebAgent/ | head -20` (use 2-3 keywords from the issue)
+5. If needed: one more targeted grep with a different keyword
+
+**PHASE 2: ANALYZE & FIX (iterations 6-25, MAX 20 tool calls)**
+- View ONLY the specific lines found by grep (e.g., `sed -n '100,130p' file.js`)
+- **NEVER view more than 2 sections of the same file** — use grep to find the exact lines
+- If you find the bug: edit the file, create a branch, commit, and make a PR
+- If you can't find it after 3 targeted reads: STOP and go to Phase 3
+
+**⚠️ HARD RULE: Do NOT read files section-by-section (e.g., lines 1-40, then 41-80, then 81-120).
+This wastes iterations. Use `grep -n "keyword" file` to find exact line numbers, then read ONLY those lines.**
+
+**PHASE 3: REPORT (iterations 26-35, MUST call finish())**
+Call `finish()` with your findings. Include:
+- **Issue summary**: What the user reported
+- **Investigation**: What files/functions you examined
+- **Root cause**: What you found (or couldn't find)
+- **Fix applied**: Branch name and PR link, OR what you recommend
+- **Next steps**: What should happen next
+
+**⚠️ If you reach iteration 25 without having called finish(), you MUST call finish() on your NEXT action.
+Do NOT start any new investigation after iteration 25.**
 
 **IMPORTANT: For user-reported bugs** (crashes, UI glitches, feature not working), SKIP
 infrastructure checks entirely and go straight to code investigation. Infra checks are
 only useful for server-side errors (5xx, timeouts, deployment failures).
 
-When you receive a bug report or feature request:
-1. **Clone the repo** and investigate the code
-2. **Implement the fix** by editing files
-3. **Create a branch, commit, and open a PR**
-4. Report what you did with the PR link
-
 **Failure Conditions (You will be penalized if you do this):**
+- Reading a file section-by-section instead of using grep
+- Running out of iterations without calling finish()
 - Returning a response that says "Recommended fix: please check code..."
-- Returning a response that says "I can help locate the code if you want..."
 - Stopping after checking `kubectl` and finding no errors.
 
 **ONLY hand off to another role if:**

--- a/agents/openhands/utils.py
+++ b/agents/openhands/utils.py
@@ -114,27 +114,62 @@ def extract_response_from_events(events: list[Any]) -> str:
                     break
 
     if not response:
-        # Fallback 3: Compose from event summaries.
-        # OpenHands events have a .summary field (e.g. "Check pod status in vibeteam namespace").
-        # Collect the last few action summaries to give a sense of what the agent investigated.
-        summaries: list[str] = []
-        for event in reversed(events):
+        # Fallback 3: Compose from action summaries + observation outputs.
+        # This produces a rich response showing both what the agent did AND what it found.
+        # We pair ActionEvents with their following ObservationEvents to include outputs.
+        steps: list[str] = []
+        max_obs_chars = 500  # Truncate each observation to avoid huge responses
+
+        # Walk forward to pair actions with observations
+        i = 0
+        while i < len(events):
+            event = events[i]
             event_type = type(event).__name__
+
             if event_type == "ActionEvent":
+                action = getattr(event, "action", None)
+                action_name = type(action).__name__ if action else ""
+                # Skip FinishAction/AgentFinishAction — already handled above
+                if action_name in ("FinishAction", "AgentFinishAction"):
+                    i += 1
+                    continue
+
                 summary = getattr(event, "summary", "")
-                if summary:
-                    summaries.append(summary)
-                if len(summaries) >= 8:
-                    break
-        if summaries:
-            summaries.reverse()
+                if not summary:
+                    i += 1
+                    continue
+
+                step = f"- {summary}"
+
+                # Look ahead for the next ObservationEvent (output of this action)
+                if i + 1 < len(events):
+                    next_event = events[i + 1]
+                    next_type = type(next_event).__name__
+                    if next_type == "ObservationEvent":
+                        obs_content = getattr(next_event, "content", "")
+                        if not obs_content:
+                            # Try .text or str fallback
+                            obs_content = getattr(next_event, "text", "")
+                        if obs_content and len(obs_content.strip()) > 0:
+                            obs_text = obs_content.strip()
+                            if len(obs_text) > max_obs_chars:
+                                obs_text = obs_text[:max_obs_chars] + "..."
+                            step += f"\n  ```\n  {obs_text}\n  ```"
+                        i += 1  # Skip the observation event
+
+                steps.append(step)
+            i += 1
+
+        # Take the last 8 steps to keep the response focused
+        if steps:
+            recent_steps = steps[-8:]
             response = (
                 "I investigated but ran out of iterations before completing. "
-                "Here's what I did:\n" + "\n".join(f"- {s}" for s in summaries)
+                "Here's what I did and found:\n\n" + "\n".join(recent_steps)
             )
             logger.info(
-                "Composed response from %d event summaries (%d chars)",
-                len(summaries),
+                "Composed response from %d action+observation pairs (%d chars)",
+                len(recent_steps),
                 len(response),
             )
 

--- a/tests/test_response_extraction.py
+++ b/tests/test_response_extraction.py
@@ -72,13 +72,24 @@ class MockMessageEvent:
 MockMessageEvent.__name__ = "MessageEvent"
 
 
+class MockObservationEvent:
+    """Mimics an OpenHands ObservationEvent containing command output."""
+
+    def __init__(self, content: str = "", text: str = ""):
+        self.content = content
+        self.text = text
+
+
+MockObservationEvent.__name__ = "ObservationEvent"
+
+
 class MockOtherEvent:
     """An event type that should be ignored by extraction."""
 
     pass
 
 
-MockOtherEvent.__name__ = "ObservationEvent"
+MockOtherEvent.__name__ = "OtherEvent"
 
 
 class MockCmdRunAction:
@@ -352,15 +363,15 @@ class TestActionThoughtFallback:
 
     def test_thought_fallback_with_observation_events(self):
         """Simulates typical max_iterations scenario: alternating actions and observations."""
-        other1 = MockOtherEvent()  # ObservationEvent
+        obs1 = MockObservationEvent(content="pod/gateway Running")
         action1 = MockCmdRunAction()
         event1 = MockActionEvent(action1, thought="Let me check the logs")
 
-        other2 = MockOtherEvent()
+        obs2 = MockObservationEvent(content="auth.py:42 def login():")
         action2 = MockCmdRunAction()
         event2 = MockActionEvent(action2, thought="The issue is in the auth module, line 42.")
 
-        events = [event1, other1, event2, other2]
+        events = [event1, obs1, event2, obs2]
 
         result = extract_response_from_events(events)
         # Should extract from the last ActionEvent (event2), skipping ObservationEvent
@@ -381,7 +392,7 @@ class TestThinkActionFallback:
         term_action = MockTerminalAction(command="grep -r 'auth' src/")
         term_event = MockActionEvent(term_action)
 
-        events = [think_event, term_event, MockOtherEvent()]
+        events = [think_event, term_event, MockObservationEvent(content="grep output")]
 
         result = extract_response_from_events(events)
         assert result == "After reviewing the code, the bug is in auth.py line 42."
@@ -408,28 +419,50 @@ class TestThinkActionFallback:
         think2 = MockThinkAction(thought="Deeper investigation reveals root cause in line 99.")
         event2 = MockActionEvent(think2)
 
-        events = [event1, MockOtherEvent(), event2]
+        events = [event1, MockObservationEvent(content="some output"), event2]
 
         result = extract_response_from_events(events)
         assert result == "Deeper investigation reveals root cause in line 99."
 
 
 class TestSummaryFallback:
-    """Test fallback that composes response from event summaries."""
+    """Test fallback that composes response from action summaries + observation outputs."""
 
-    def test_composes_from_summaries_when_no_other_response(self):
-        """When all other fallbacks fail, compose from event summaries."""
+    def test_composes_from_summaries_with_observations(self):
+        """When all other fallbacks fail, compose from action/observation pairs."""
+        events = []
+        steps = [
+            ("Check pod status in vibeteam namespace", "NAME  READY  STATUS\npod1  1/1    Running"),
+            ("Check recent events in vibeteam namespace", "LAST SEEN  TYPE    REASON  MESSAGE"),
+            ("Check logs of vibeteam-gateway deployment", "2026-02-10 GET /health 200"),
+        ]
+        for summary, obs_content in steps:
+            action = MockTerminalAction(command="kubectl ...")
+            event = MockActionEvent(action, thought="", summary=summary)
+            events.append(event)
+            events.append(MockObservationEvent(content=obs_content))
+
+        result = extract_response_from_events(events)
+        assert "I investigated but ran out of iterations" in result
+        # Should contain summaries
+        for summary, _ in steps:
+            assert summary in result
+        # Should contain observation content
+        assert "Running" in result
+        assert "GET /health 200" in result
+
+    def test_composes_summaries_without_observations(self):
+        """Works even when observations have no content."""
         events = []
         summaries = [
-            "Check pod status in vibeteam namespace",
-            "Check recent events in vibeteam namespace",
-            "Check logs of vibeteam-gateway deployment",
+            "Check pod status",
+            "Check logs",
         ]
         for s in summaries:
             action = MockTerminalAction(command="kubectl ...")
             event = MockActionEvent(action, thought="", summary=s)
             events.append(event)
-            events.append(MockOtherEvent())  # observation
+            events.append(MockObservationEvent(content=""))  # empty observation
 
         result = extract_response_from_events(events)
         assert "I investigated but ran out of iterations" in result
@@ -451,7 +484,7 @@ class TestSummaryFallback:
         assert result == "Investigation complete"
 
     def test_summaries_limited_to_8(self):
-        """At most 8 summaries should be collected."""
+        """At most 8 steps should be included."""
         events = []
         for i in range(15):
             action = MockTerminalAction(command=f"cmd{i}")
@@ -478,3 +511,46 @@ class TestSummaryFallback:
         result = extract_response_from_events(events)
         assert "Checked the logs" in result
         assert result.count("- ") == 1  # only one bullet point
+
+    def test_observation_content_truncated(self):
+        """Long observation outputs should be truncated to 500 chars."""
+        action = MockTerminalAction(command="cat large_file.py")
+        event = MockActionEvent(action, summary="Read large file")
+        obs = MockObservationEvent(content="x" * 1000)  # 1000 chars
+
+        events = [event, obs]
+
+        result = extract_response_from_events(events)
+        assert "Read large file" in result
+        # Should contain truncated output with "..."
+        assert "..." in result
+        # Total obs content in result should be ~500 + "..."
+        assert "x" * 500 in result
+        assert "x" * 501 not in result
+
+    def test_observation_text_fallback(self):
+        """If content is empty, fall back to .text attribute."""
+        action = MockTerminalAction(command="ls")
+        event = MockActionEvent(action, summary="List files")
+        obs = MockObservationEvent(content="", text="file1.py\nfile2.py")
+
+        events = [event, obs]
+
+        result = extract_response_from_events(events)
+        assert "file1.py" in result
+
+    def test_finish_action_excluded_from_summary(self):
+        """FinishAction events should not appear in the summary steps."""
+        action1 = MockTerminalAction(command="grep auth")
+        event1 = MockActionEvent(action1, summary="Search for auth")
+
+        finish_action = MockFinishAction(message="")  # empty finish
+        finish_action.__class__.__name__ = "FinishAction"
+        finish_event = MockActionEvent(finish_action, summary="Finish")
+
+        events = [event1, finish_event]
+
+        result = extract_response_from_events(events)
+        assert "Search for auth" in result
+        # Finish should not appear in summary
+        assert "Finish" not in result or "Search for auth" in result


### PR DESCRIPTION
## Summary

- Replace the SWE GitHub issue investigation workflow with a strict 3-phase approach (GATHER → ANALYZE & FIX → REPORT) with explicit iteration budgets
- Enhance the summary fallback to include observation outputs alongside action steps, producing richer responses when the agent doesn't call finish()

## Changes

### 1. Strict 3-Phase SWE Workflow (`software_engineer.py`)
- **PHASE 1: GATHER** (iterations 1-5) — fetch issue, clone repo, grep for keywords
- **PHASE 2: ANALYZE & FIX** (iterations 6-25) — targeted file reads, code fixes, PRs
- **PHASE 3: REPORT** (iterations 26-35) — MUST call finish() with findings
- Hard rule: no section-by-section file reading, use grep to find exact lines
- Clearer failure conditions and debugging tips

### 2. Observation-Enhanced Summary Fallback (`utils.py`)
- When agent exhausts iterations without finish(), the fallback now pairs action summaries with truncated observation outputs (max 500 chars each)
- Before: `- Search for 'auth' keyword in src/`
- After:
  ```
  - Search for 'auth' keyword in src/
    ```
    src/auth.py:42: def login():
    src/auth.py:87: def verify_token():
    ```
  ```
- Falls back gracefully when observations are empty

### Tests
- 33 extraction tests pass (4 new for observation content: truncation, text fallback, empty obs, finish exclusion)
- 111 system prompt + extraction tests pass
- Lint clean

## Context

The `github_issue` eval scenario was scoring 0.20-0.50 because:
1. The agent wasted iterations reading files section-by-section instead of using grep
2. The summary fallback only showed step descriptions, not findings
3. No structured phases meant the agent often didn't reach finish()

These changes address all three issues.