### PR TITLE
fix(agents): improve SWE investigation strategy with FORBIDDEN ACTIONS

### DIFF
--- a/agents/openhands/software_engineer.py
+++ b/agents/openhands/software_engineer.py
@@ -50,7 +50,7 @@ SOFTWARE_ENGINEER_CONTEXT = """You are Alan, the Software Engineer for VibeTeam.
 
 ## ⚠️ STRICT ITERATION LIMIT
 You have a MAXIMUM of 35 tool calls to complete this task. Plan your investigation carefully.
-After ~25 calls, you MUST start wrapping up and provide your findings even if incomplete.
+After ~20 calls, you MUST start wrapping up and provide your findings even if incomplete.
 
 **CRITICAL: You MUST call finish() with your final response.**
 If you do not call finish(), your response will be LOST and the user will see nothing.
@@ -199,46 +199,84 @@ Never return an empty response. The user needs to know what happened.
 
 **DO NOT** stop at analysis or recommendations. Your job is to **actually fix the code**.
 
+## ❌ FORBIDDEN ACTIONS — THESE WASTE ALL YOUR ITERATIONS
+
+**NEVER do any of these. If you catch yourself doing them, STOP immediately:**
+
+1. **NEVER read a file sequentially** (lines 1-40, then 41-80, then 81-120, etc.)
+   This is the #1 cause of running out of iterations. You will waste 20+ iterations
+   reading ONE file and have nothing to show for it.
+
+2. **NEVER view "the next method" or "continue reading"** in the same file.
+   If you already read one section of a file, use `grep -n` to find the EXACT line
+   you need next. Do NOT blindly continue reading.
+
+3. **NEVER read more than 30 lines at once** without a grep-targeted line number.
+
+4. **NEVER explore more than 3 files total** during investigation. If you haven't
+   found the bug in 3 files, summarize what you've learned and call finish().
+
+**GOOD investigation (5 tool calls):**
+```
+grep -rn "record" VibeWebAgent/src/ | head -20       # Find where "record" appears
+sed -n '145,175p' VibeWebAgent/src/recorder.js        # Read the specific function
+grep -n "click\\|addEventListener" VibeWebAgent/src/recorder.js | head -10  # Find event handlers
+sed -n '52,72p' VibeWebAgent/src/recorder.js          # Read the click handler
+# Now you have enough context to diagnose — call finish() with findings
+```
+
+**BAD investigation (wastes 15+ tool calls):**
+```
+cat VibeWebAgent/src/recorder.js | head -40          # Lines 1-40... nothing useful
+sed -n '41,80p' VibeWebAgent/src/recorder.js         # Lines 41-80... keep reading
+sed -n '81,120p' VibeWebAgent/src/recorder.js        # Lines 81-120... still reading
+sed -n '121,160p' VibeWebAgent/src/recorder.js       # Lines 121-160... wasting iterations
+# ... 10 more reads and you run out of iterations with no diagnosis
+```
+
 ### For GitHub Issue Investigation — STRICT 3-PHASE WORKFLOW
 
 You have 35 tool calls total. Budget them carefully across these 3 phases:
 
-**PHASE 1: GATHER (iterations 1-5, MAX 5 tool calls)**
-1. `gh issue view <number> > /tmp/issue.txt && cat /tmp/issue.txt`
+**PHASE 1: SETUP + TARGETED SEARCH (iterations 1-8, MAX 8 tool calls)**
+1. `gh issue view <number> --repo VibeTechnologies/VibeWebAgent > /tmp/issue.txt && cat /tmp/issue.txt`
 2. `gh auth setup-git && git clone --depth 1 https://github.com/VibeTechnologies/VibeWebAgent/`
 3. `find VibeWebAgent/ -type f \\( -name '*.ts' -o -name '*.js' -o -name '*.tsx' \\) | head -30`
-4. `grep -rn "KEYWORD" VibeWebAgent/ | head -20` (use 2-3 keywords from the issue)
+4. Extract 2-3 keywords from the issue (e.g., "record", "crash", "button") and run:
+   `grep -rn "KEYWORD1\\|KEYWORD2" VibeWebAgent/src/ | head -30`
 5. If needed: one more targeted grep with a different keyword
+6-8. Read ONLY the specific functions found by grep using `sed -n 'START,ENDp' file`
 
-**PHASE 2: ANALYZE & FIX (iterations 6-25, MAX 20 tool calls)**
-- View ONLY the specific lines found by grep (e.g., `sed -n '100,130p' file.js`)
-- **NEVER view more than 2 sections of the same file** — use grep to find the exact lines
-- If you find the bug: edit the file, create a branch, commit, and make a PR
-- If you can't find it after 3 targeted reads: STOP and go to Phase 3
-
-**⚠️ HARD RULE: Do NOT read files section-by-section (e.g., lines 1-40, then 41-80, then 81-120).
-This wastes iterations. Use `grep -n "keyword" file` to find exact line numbers, then read ONLY those lines.**
+**PHASE 2: DIAGNOSE AND FIX (iterations 9-25, MAX 17 tool calls)**
+- By now you should know which file and function is involved
+- Read the specific error-prone code (max 30 lines per read)
+- If you find the bug: edit the file, create a branch, commit, and push
+- Create a PR with `gh pr create`
+- If you CANNOT find the bug after reading 3 targeted sections: STOP and go to Phase 3
 
 **PHASE 3: REPORT (iterations 26-35, MUST call finish())**
-Call `finish()` with your findings. Include:
-- **Issue summary**: What the user reported
-- **Investigation**: What files/functions you examined
-- **Root cause**: What you found (or couldn't find)
-- **Fix applied**: Branch name and PR link, OR what you recommend
-- **Next steps**: What should happen next
+Call `finish()` with a structured report. Include ALL of these:
+- **Issue summary**: What the user reported (1-2 sentences)
+- **Files examined**: List the exact files and line numbers you looked at
+- **Root cause**: What you found (be specific: function name, line number, the bug)
+  OR state clearly "Could not identify root cause" with what you tried
+- **Fix applied**: Branch name and PR link if you made a fix
+- **Recommendation**: Concrete next steps (not vague "investigate further")
 
-**⚠️ If you reach iteration 25 without having called finish(), you MUST call finish() on your NEXT action.
-Do NOT start any new investigation after iteration 25.**
+**⚠️ If you reach iteration 20 without a clear diagnosis, STOP investigating and start
+writing your report. An incomplete but structured report is infinitely better than
+running out of iterations with no response.**
 
 **IMPORTANT: For user-reported bugs** (crashes, UI glitches, feature not working), SKIP
 infrastructure checks entirely and go straight to code investigation. Infra checks are
 only useful for server-side errors (5xx, timeouts, deployment failures).
 
 **Failure Conditions (You will be penalized if you do this):**
-- Reading a file section-by-section instead of using grep
+- Reading a file section-by-section instead of using grep to find target lines
 - Running out of iterations without calling finish()
 - Returning a response that says "Recommended fix: please check code..."
-- Stopping after checking `kubectl` and finding no errors.
+- Stopping after checking `kubectl` and finding no errors
+- Viewing more than 2 sections of the same file without using grep between them
 
 **ONLY hand off to another role if:**
 - The fix requires **Kubernetes/infrastructure changes** (ingress, deployments, secrets) → @ReleaseEngineer
@@ -293,8 +331,9 @@ When you complete a task, summarize what was done, files changed, and any next s
 
 **You have a hard limit of 35 tool calls. You CANNOT exceed this.**
 
-- After 25 tool calls: STOP all new investigation. Begin writing your summary.
-- After 30 tool calls: You are in EMERGENCY mode. Call finish() IMMEDIATELY.
+- After 20 tool calls: STOP all new investigation. Begin writing your structured report.
+- After 25 tool calls: You are in EMERGENCY mode. Call finish() IMMEDIATELY with whatever you have.
+- After 30 tool calls: CRITICAL — you have 5 calls left. finish() NOW or lose everything.
 - If you run out of iterations without calling finish(), your entire response is LOST.
   The user will see NOTHING — no analysis, no findings, no recommendations.
 

--- a/plan.md
+++ b/plan.md
@@ -1,76 +1,89 @@
 # Current Work Plan
 
-## Status: PR pending — SWE iteration budget fix (branch: fix/swe-iteration-budget)
-
-**Branch:** `fix/swe-iteration-budget` (based on `master` at `874ba07`)
+## Status: PR pending — SWE investigation strategy fix (branch: fix/swe-investigation-strategy)
 
 ---
 
-## Current Fix: SWE Iteration Budget (github_issue eval)
+## In Progress: SWE Investigation Strategy Fix
+
+**Branch:** `fix/swe-investigation-strategy`
+**PR:** Pending
 
 ### Problem
-The `github_issue` eval fails with all 0.00 scores because the SoftwareEngineer agent:
-1. Uses all 25 iterations searching code (grep, find, cat) without producing a summary
-2. Never calls `finish()`, so the response is empty
-3. The fallback extraction chain (ThinkAction, ActionEvent.thought, event summaries) from commit `874ba07` still returns empty because gpt-4.1-mini doesn't populate thought fields
+The `github_issue` eval fails because the SWE agent reads files sequentially (method-by-method, lines 1-40, 41-80, etc.) instead of using grep to find target code. Even with 35 iterations, it exhausts them all reading one file without producing a diagnosis.
 
-### Root Cause
-- 25 iterations is insufficient for code search tasks (clone + search + read + fix + verify)
-- The iteration warning at the TOP of the prompt (lines 62-73) gets lost during the agent's investigation loop
-- No reminder near the END of the prompt catches the agent before it exhausts iterations
-
-### Fix (Two Parts)
-
-**Part 1: Prompt Changes** (`agents/openhands/software_engineer.py`)
-- Updated STRICT ITERATION LIMIT: 25→35 max, wrap up at ~25 (was 25/15)
-- Added ITERATION CHECK step to GitHub Issue Investigation workflow (step 7)
-- Added **FINAL REMINDER** section at the END of the prompt with escalating urgency:
-  - After 25 calls: STOP investigation, begin summary
-  - After 30 calls: EMERGENCY mode, call finish() immediately
-  - Includes checklist of what to include in finish()
-
-**Part 2: Config Change** (`agents/openhands/software_engineer.py`)
-- Changed `max_iteration_per_run` from 25 to 35 (SWE only)
-- SupportEngineer and ReleaseEngineer remain at 25 (they finish in 10-15 iterations)
-
-### Tests Added (`tests/test_system_prompt.py`)
-- `TestSoftwareEngineerIterationBudget`: 9 tests
-  - FINAL REMINDER exists in last 30% of prompt
-  - FINAL REMINDER mentions finish()
-  - FINAL REMINDER has escalating urgency (EMERGENCY/IMMEDIATELY)
-  - STRICT ITERATION LIMIT says 35
-  - Wrap-up at ~25 iterations
-  - max_iteration_per_run=35 in code
-  - GitHub Issue workflow has ITERATION CHECK
-  - Other agents still use 25 iterations
+### Fix
+- Added FORBIDDEN ACTIONS section with 4 explicit anti-patterns and concrete GOOD vs BAD investigation examples
+- Limited file exploration to 3 files max, 30 lines per read without grep-targeted line numbers
+- Trigger wrap-up at iteration 20 (was 25) to ensure finish() is called sooner
+- Improved 3-phase workflow with explicit iteration budgets per phase (8/17/10)
+- 4 new tests for FORBIDDEN ACTIONS enforcement
 
 ### Checklist
-- [x] Create feature branch `fix/swe-iteration-budget`
-- [x] Update STRICT ITERATION LIMIT numbers (25→35, 15→25)
-- [x] Add FINAL REMINDER section at end of prompt
-- [x] Add ITERATION CHECK step to GitHub Issue Investigation workflow
-- [x] Change max_iteration_per_run from 25 to 35
-- [x] Add 9 tests for iteration budget
-- [x] Full test suite passes (506 passed, 79 skipped)
-- [x] Lint clean
+- [x] Add FORBIDDEN ACTIONS section to software_engineer.py
+- [x] Add GOOD vs BAD investigation examples
+- [x] Update 3-phase workflow iteration budgets
+- [x] Update FINAL REMINDER thresholds (wrap at 20, emergency at 25, critical at 30)
+- [x] Add 4 new tests (forbidden actions section, sequential reading, file limits, examples)
+- [x] Update existing test for new wrap-up threshold (25 -> 20)
+- [x] All 96 system prompt tests pass
+- [x] Full suite passes (537 passed, 78 skipped, 0 failed)
+- [x] Lint clean (fixed `\|` escape sequence)
 - [ ] Commit and push
 - [ ] Create PR
 - [ ] CI checks pass
-- [ ] Merge and deploy
-- [ ] Run `github_issue` eval to verify fix
+- [ ] Merge
+- [ ] Deploy and run `github_issue` eval
 - [ ] Run `support_400_errors` regression eval
 
 ---
 
-## Previous Eval Results (2026-02-10 23:51 UTC)
+## Completed: SWE Investigation Workflow & Response Extraction (#82)
 
-| Scenario | Result | Key Scores | Latency | Notes |
-|----------|--------|------------|---------|-------|
-| `support_400_errors` | PASS | IQ:0.90, EBD:1.00, HC:0.70 | 68s | Regression check passed |
-| `stripe_webhook_failure` | PASS | IQ:0.90, TC:0.90, EBD:0.90, HC:0.90 | 74s | New scenario, strong pass |
-| `support_notify_check` | PASS | NO:1.00 | 21s | Perfect score |
-| `github_issue` | FAIL | All 0.00 | 132s | Agent used all 25 iterations, empty response |
-| `release_deploy` | BLOCKED | N/A | 900s x4 | Pod killed mid-request by other sessions |
+**PR:** https://github.com/VibeTechnologies/VibeTeam/pull/82 — **Merged** (`0ee5ffb`)
+
+---
+
+## Completed: SWE 3-Phase Workflow (#81)
+
+**PR:** https://github.com/VibeTechnologies/VibeTeam/pull/81 — **Merged** (`02100ba`)
+
+---
+
+## Completed: AzureLLM Consolidation (#80)
+
+**PR:** https://github.com/VibeTechnologies/VibeTeam/pull/80 — **Merged** (`d3e8dea`)
+
+### Fix
+- Created `agents/shared/llm.py` as single source of truth for AzureLLM
+- Updated all 5 agent files to import from shared module
+- Fixed marketing_manager and product_manager to use AzureLLM (was base LLM causing 404)
+- 23 new tests in `TestAzureLLMConsolidation`
+
+---
+
+## Completed: SWE Iteration Budget (#79)
+
+**PR:** https://github.com/VibeTechnologies/VibeTeam/pull/79 — **Merged** (`ae162bb`)
+
+### Fix
+- Increased `max_iteration_per_run` from 25 to 35 for SWE agent
+- Added FINAL REMINDER section at end of prompt with escalating urgency
+- Added ITERATION CHECK step to GitHub Issue Investigation workflow
+- 8 new tests in `TestSoftwareEngineerIterationBudget`
+
+---
+
+## Eval Results (2026-02-10)
+
+| Scenario | Result | Key Scores | Notes |
+|----------|--------|------------|-------|
+| `support_400_errors` | PASS | IQ:0.90, EBD:0.90, HC:0.80 | Post AzureLLM consolidation |
+| `stripe_webhook_failure` | PASS | IQ:0.90, TC:0.90, EBD:0.90, HC:0.90 | Strong pass |
+| `support_notify_check` | PASS | NO:1.00 | Perfect score |
+| `github_issue` (stale pod) | FAIL | All 0.20 | Agent read files sequentially, ran out of iterations |
+| `github_issue` (35 iter pod) | TIMEOUT | N/A | No response in 600s — agent still reading files |
+| `release_deploy` | BLOCKED | N/A | Pod killed mid-request by other sessions |
 
 ---
 
@@ -84,9 +97,13 @@ The `github_issue` eval fails with all 0.00 scores because the SoftwareEngineer 
 | #72 | Gmail Processor K8s Deployment | Merged |
 | #73 | Wire CALLBACK_SECRET to K8s | Merged |
 | #74 | `--use-async` flag for eval/trigger | Merged |
-| #76 | Type annotation fixes (pyright) | Merged (`be61bb2`) |
-| #77 | Sentry routing + deploy secrets | Merged (`6ed158f`) |
-| #78 | Eval timeouts + agent prompt improvements | Merged (`5c0b634`) |
+| #76 | Type annotation fixes (pyright) | Merged |
+| #77 | Sentry routing + deploy secrets | Merged |
+| #78 | Eval timeouts + agent prompt improvements | Merged |
+| #79 | SWE iteration budget + FINAL REMINDER | Merged |
+| #80 | AzureLLM consolidation + marketing/product fix | Merged |
+| #81 | SWE 3-phase workflow | Merged |
+| #82 | SWE investigation workflow + response extraction | Merged |
 
 ## Open Issues
 
@@ -104,5 +121,12 @@ The `github_issue` eval fails with all 0.00 scores because the SoftwareEngineer 
 | SENTRY_CLIENT_SECRET | Needs Sentry admin to retrieve from dashboard |
 | Issue #22 full closure | Needs Gmail OAuth credentials deployed to cluster |
 
+## Next Steps (after current PR)
+
+1. Deploy and run `github_issue` eval to verify FORBIDDEN ACTIONS fix
+2. Run `support_400_errors` regression eval
+3. If `github_issue` still fails, consider runtime iteration counting in agent code
+4. Fix `release_deploy` eval reliability (infrastructure contention)
+
 ---
-Last updated: 2026-02-11 00:20 UTC
+Last updated: 2026-02-11 UTC

--- a/tests/test_system_prompt.py
+++ b/tests/test_system_prompt.py
@@ -545,9 +545,10 @@ class TestSoftwareEngineerIterationBudget:
     The github_issue eval fails when the SWE agent exhausts all iterations
     searching code without calling finish(). These tests ensure:
     1. The prompt has a FINAL REMINDER at the end about calling finish()
-    2. The iteration limit numbers are consistent (35 max, wrap up at 25)
+    2. The iteration limit numbers are consistent (35 max, wrap up at 20)
     3. max_iteration_per_run is set to 35 (higher than other agents)
     4. The GitHub Issue workflow includes an iteration check step
+    5. FORBIDDEN ACTIONS section prevents sequential file reading
     """
 
     @staticmethod
@@ -626,8 +627,8 @@ class TestSoftwareEngineerIterationBudget:
             f"STRICT ITERATION LIMIT must mention 35 max iterations. Found: {limit_section[:100]}"
         )
 
-    def test_wrap_up_at_25_iterations(self):
-        """The prompt must tell the agent to wrap up at ~25 iterations."""
+    def test_wrap_up_at_20_iterations(self):
+        """The prompt must tell the agent to wrap up at ~20 iterations."""
         content = self._read_swe_context()
         ctx_start = content.find('SOFTWARE_ENGINEER_CONTEXT = """')
         ctx_end = content.find('"""', ctx_start + 30)
@@ -637,8 +638,8 @@ class TestSoftwareEngineerIterationBudget:
         assert limit_start != -1
         limit_section = ctx[limit_start : limit_start + 200]
 
-        assert "25" in limit_section, (
-            f"STRICT ITERATION LIMIT must tell agent to wrap up at ~25 calls. "
+        assert "20" in limit_section, (
+            f"STRICT ITERATION LIMIT must tell agent to wrap up at ~20 calls. "
             f"Found: {limit_section[:100]}"
         )
 
@@ -681,6 +682,63 @@ class TestSoftwareEngineerIterationBudget:
                 f"{agent_file} should still use max_iteration_per_run=25. "
                 f"Only SWE agent needs 35 iterations."
             )
+
+    def test_has_forbidden_actions_section(self):
+        """Prompt must have a FORBIDDEN ACTIONS section to prevent sequential file reading."""
+        content = self._read_swe_context()
+        ctx_start = content.find('SOFTWARE_ENGINEER_CONTEXT = """')
+        ctx_end = content.find('"""', ctx_start + 30)
+        ctx = content[ctx_start:ctx_end]
+
+        assert "FORBIDDEN ACTIONS" in ctx, (
+            "SOFTWARE_ENGINEER_CONTEXT must contain a FORBIDDEN ACTIONS section "
+            "to prevent the agent from reading files section-by-section"
+        )
+
+    def test_forbidden_actions_mentions_sequential_reading(self):
+        """FORBIDDEN ACTIONS must explicitly forbid sequential file reading."""
+        content = self._read_swe_context()
+        ctx_start = content.find('SOFTWARE_ENGINEER_CONTEXT = """')
+        ctx_end = content.find('"""', ctx_start + 30)
+        ctx = content[ctx_start:ctx_end]
+
+        forbidden_start = ctx.find("FORBIDDEN ACTIONS")
+        assert forbidden_start != -1
+        forbidden_section = ctx[forbidden_start : forbidden_start + 800]
+
+        assert (
+            "section-by-section" in forbidden_section.lower()
+            or "sequentially" in forbidden_section.lower()
+        ), "FORBIDDEN ACTIONS must warn against reading files section-by-section"
+
+    def test_forbidden_actions_limits_files_explored(self):
+        """FORBIDDEN ACTIONS must limit the number of files the agent explores."""
+        content = self._read_swe_context()
+        ctx_start = content.find('SOFTWARE_ENGINEER_CONTEXT = """')
+        ctx_end = content.find('"""', ctx_start + 30)
+        ctx = content[ctx_start:ctx_end]
+
+        forbidden_start = ctx.find("FORBIDDEN ACTIONS")
+        assert forbidden_start != -1
+        forbidden_section = ctx[forbidden_start : forbidden_start + 800]
+
+        assert "3 files" in forbidden_section, (
+            "FORBIDDEN ACTIONS must limit exploration to 3 files max"
+        )
+
+    def test_has_good_bad_investigation_examples(self):
+        """Prompt must show concrete good vs bad investigation examples."""
+        content = self._read_swe_context()
+        ctx_start = content.find('SOFTWARE_ENGINEER_CONTEXT = """')
+        ctx_end = content.find('"""', ctx_start + 30)
+        ctx = content[ctx_start:ctx_end]
+
+        assert "GOOD investigation" in ctx or "Good investigation" in ctx, (
+            "Prompt must include a GOOD investigation example showing grep-first strategy"
+        )
+        assert "BAD investigation" in ctx or "Bad investigation" in ctx, (
+            "Prompt must include a BAD investigation example showing what NOT to do"
+        )
 
 
 class TestAzureLLMConsolidation:


### PR DESCRIPTION
## Summary

- Add **FORBIDDEN ACTIONS** section to the SWE agent prompt that explicitly bans sequential file reading and limits file exploration to 3 files max / 30 lines per read
- Include concrete GOOD vs BAD investigation examples showing grep-first approach vs wasteful line-by-line reading
- Tighten wrap-up threshold from iteration 25 to 20, giving the agent more pressure to produce a diagnosis early
- Improve 3-phase workflow iteration budgets: Phase 1 (8 calls), Phase 2 (17 calls), Phase 3 (10 calls)

## Problem

The `github_issue` eval consistently fails because the SWE agent:
1. Clones the repo and finds a relevant file (e.g., `video-recorder.js`)
2. Reads it method-by-method (lines 1-40, 41-80, 81-120...) using all iterations
3. Never produces a diagnosis or calls `finish()`
4. Increasing iterations from 25→35 just meant it read MORE of the file

## Testing

- 96 system prompt tests pass (4 new tests for FORBIDDEN ACTIONS)
- 537 passed, 78 skipped, 0 failed in full suite
- Lint clean

## Next Steps

After merge: deploy to cluster and re-run `github_issue` eval to verify the fix.