### PR TITLE
fix(agents,k8s): improve EBD evidence requirements and Recreate deployment strategy

### DIFF
--- a/agents/openhands/software_engineer.py
+++ b/agents/openhands/software_engineer.py
@@ -253,15 +253,30 @@ You have 35 tool calls total. Budget them carefully across these 3 phases:
 - If you find the bug: edit the file, create a branch, commit, and push
 - Create a PR with `gh pr create`
 - If you CANNOT find the bug after reading 3 targeted sections: STOP and go to Phase 3
+- **EVIDENCE RULE**: Every claim you make MUST cite a specific file:line or command output.
+  Do NOT say "the root cause is likely X" — say "In file.js:142, the function does X which causes Y"
+  or say "I could not find the root cause — grep for 'record' returned no matches in src/"
 
 **PHASE 3: REPORT (iterations 26-35, MUST call finish())**
-Call `finish()` with a structured report. Include ALL of these:
+Call `finish()` with a structured report. Your report MUST be **evidence-based** — every
+claim must reference a specific file, line number, grep result, or command output.
+
+Include ALL of these sections:
 - **Issue summary**: What the user reported (1-2 sentences)
 - **Files examined**: List the exact files and line numbers you looked at
-- **Root cause**: What you found (be specific: function name, line number, the bug)
-  OR state clearly "Could not identify root cause" with what you tried
-- **Fix applied**: Branch name and PR link if you made a fix
-- **Recommendation**: Concrete next steps (not vague "investigate further")
+  Example: `video-recorder.js:142-175 (startRecording function)`
+- **Evidence found**: Quote the specific code or command output that supports your diagnosis.
+  Example: "Line 148 calls `navigator.mediaDevices.getDisplayMedia()` without a try/catch,
+  which throws on Chrome 120 when permissions are denied."
+  If no evidence found, say: "No matching code found. grep -rn 'record' src/ returned 0 results."
+- **Root cause**: State clearly what you found OR say "Could not identify root cause."
+  NEVER use words like "likely", "probably", "might be" without citing specific evidence.
+  If uncertain, list what you checked and what you ruled out.
+- **Fix applied**: Branch name and PR link if you made a fix, OR "No fix applied"
+- **Recommendation**: Concrete, specific next steps tied to your findings.
+  BAD: "Investigate the extension UI code for the record button handler"
+  GOOD: "The record handler in content.js:89 should add error handling for the
+  getDisplayMedia() call. Alternatively, check if Chrome 120 changed the permissions API."
 
 **⚠️ If you reach iteration 20 without a clear diagnosis, STOP investigating and start
 writing your report. An incomplete but structured report is infinitely better than
@@ -271,10 +286,16 @@ running out of iterations with no response.**
 infrastructure checks entirely and go straight to code investigation. Infra checks are
 only useful for server-side errors (5xx, timeouts, deployment failures).
 
+**DO NOT waste iterations on kubectl or Sentry for frontend/extension bugs.** If the issue
+is about a button crash, UI glitch, or extension behavior — the answer is in the code, not
+in Kubernetes logs. Every iteration spent on `kubectl get pods` for a UI bug is wasted.
+
 **Failure Conditions (You will be penalized if you do this):**
 - Reading a file section-by-section instead of using grep to find target lines
 - Running out of iterations without calling finish()
 - Returning a response that says "Recommended fix: please check code..."
+- Using words like "likely", "probably", "might be" without citing file:line evidence
+- Running kubectl/Sentry checks for a UI bug (e.g., button crash, extension issue)
 - Stopping after checking `kubectl` and finding no errors
 - Viewing more than 2 sections of the same file without using grep between them
 

--- a/k8s/base/openhands-svc.yaml
+++ b/k8s/base/openhands-svc.yaml
@@ -13,6 +13,12 @@ metadata:
     framework: openhands
 spec:
   replicas: 1
+  # Recreate strategy: single-node cluster cannot run two openhands pods simultaneously
+  # (each requires 3-6Gi memory). RollingUpdate causes deadlock since the new pod
+  # can't schedule until the old one terminates, but the old won't terminate until
+  # the new one is ready.
+  strategy:
+    type: Recreate
   selector:
     matchLabels:
       app: openhands-svc

--- a/tests/test_system_prompt.py
+++ b/tests/test_system_prompt.py
@@ -740,6 +740,94 @@ class TestSoftwareEngineerIterationBudget:
             "Prompt must include a BAD investigation example showing what NOT to do"
         )
 
+    def test_evidence_rule_in_phase2(self):
+        """Phase 2 must require evidence-based claims with file:line citations."""
+        content = self._read_swe_context()
+        ctx_start = content.find('SOFTWARE_ENGINEER_CONTEXT = """')
+        ctx_end = content.find('"""', ctx_start + 30)
+        ctx = content[ctx_start:ctx_end]
+
+        assert "EVIDENCE RULE" in ctx, (
+            "PHASE 2 must contain an EVIDENCE RULE requiring file:line citations"
+        )
+
+    def test_report_requires_evidence_found_section(self):
+        """Phase 3 report must require an 'Evidence found' section with code quotes."""
+        content = self._read_swe_context()
+        ctx_start = content.find('SOFTWARE_ENGINEER_CONTEXT = """')
+        ctx_end = content.find('"""', ctx_start + 30)
+        ctx = content[ctx_start:ctx_end]
+
+        assert "Evidence found" in ctx, (
+            "PHASE 3 report template must include an 'Evidence found' section "
+            "requiring specific code quotes or command output"
+        )
+
+    def test_forbids_speculative_language_without_evidence(self):
+        """Prompt must forbid 'likely', 'probably', 'might be' without evidence."""
+        content = self._read_swe_context()
+        ctx_start = content.find('SOFTWARE_ENGINEER_CONTEXT = """')
+        ctx_end = content.find('"""', ctx_start + 30)
+        ctx = content[ctx_start:ctx_end]
+
+        assert "likely" in ctx.lower() and "evidence" in ctx.lower(), (
+            "Prompt must explicitly forbid speculative language like 'likely' "
+            "without citing specific evidence"
+        )
+
+    def test_forbids_infra_checks_for_ui_bugs(self):
+        """Prompt must forbid kubectl/Sentry for frontend/extension bugs."""
+        content = self._read_swe_context()
+        ctx_start = content.find('SOFTWARE_ENGINEER_CONTEXT = """')
+        ctx_end = content.find('"""', ctx_start + 30)
+        ctx = content[ctx_start:ctx_end]
+
+        assert "kubectl" in ctx and "UI bug" in ctx.lower() or "frontend" in ctx.lower(), (
+            "Prompt must forbid wasting iterations on kubectl for UI/frontend bugs"
+        )
+
+    def test_report_has_good_bad_recommendation_examples(self):
+        """Phase 3 report must show examples of good vs bad recommendations."""
+        content = self._read_swe_context()
+        ctx_start = content.find('SOFTWARE_ENGINEER_CONTEXT = """')
+        ctx_end = content.find('"""', ctx_start + 30)
+        ctx = content[ctx_start:ctx_end]
+
+        assert "BAD:" in ctx and "GOOD:" in ctx, (
+            "Report template must include concrete BAD and GOOD recommendation examples"
+        )
+
+
+class TestKubernetesDeploymentStrategy:
+    """Verify openhands-svc uses Recreate strategy.
+
+    The cluster has a single node with limited memory. RollingUpdate with 1 replica
+    creates a deadlock: new pod can't schedule until old pod terminates, but old pod
+    won't terminate until new pod is ready. Recreate avoids this by terminating the
+    old pod first.
+    """
+
+    K8S_BASE = os.path.join(
+        os.path.dirname(__file__), os.pardir, "k8s", "base", "openhands-svc.yaml"
+    )
+
+    def test_openhands_uses_recreate_strategy(self):
+        """openhands-svc must use Recreate strategy to avoid memory deadlock."""
+        with open(self.K8S_BASE) as f:
+            content = f.read()
+        assert "type: Recreate" in content, (
+            "openhands-svc deployment must use 'type: Recreate' strategy. "
+            "RollingUpdate causes deadlock on single-node clusters with memory constraints."
+        )
+
+    def test_openhands_has_strategy_comment(self):
+        """Strategy section must have a comment explaining why Recreate is used."""
+        with open(self.K8S_BASE) as f:
+            content = f.read()
+        assert "single-node" in content.lower() or "cannot run two" in content.lower(), (
+            "Strategy section must explain why Recreate is needed (single-node memory constraint)"
+        )
+
 
 class TestAzureLLMConsolidation:
     """Verify all agents use AzureLLM from the shared module.


### PR DESCRIPTION
## Summary

- **SWE prompt improvements** for higher Evidence-Based Decision (EBD) scores: require `file:line` citations for every claim, forbid speculative language ("likely"/"probably") without evidence, add "Evidence Found" section to Phase 3 report template, skip kubectl/Sentry checks for UI/extension bugs
- **K8s deployment strategy fix**: permanently set openhands-svc to `Recreate` strategy to avoid RollingUpdate deadlock on single-node cluster (new pod can't schedule while old pod holds 3-6Gi memory)

## Context

The `github_issue` eval's EBD score was 0.60 (barely at threshold). The agent was:
- Saying "root cause is **likely** a bug" — speculative, no evidence cited
- Recommending "investigate the extension UI code" — vague, not tied to findings
- Wasting iterations on `kubectl get pods` and Sentry checks for a UI/extension bug

The RollingUpdate deadlock has been a recurring operational issue — we've had to manually `kubectl patch` to Recreate on every deployment.

## Changes

### `agents/openhands/software_engineer.py`
- Phase 2: Added **EVIDENCE RULE** requiring every claim cite file:line or command output
- Phase 3: Expanded report template from 4 bullets to 6 detailed sections (Issue summary, Files examined, Evidence found, Root cause, Fix applied, Recommendation)
- Added BAD/GOOD recommendation examples
- Added explicit "DO NOT waste iterations on kubectl/Sentry for frontend/extension bugs"
- Added failure conditions for speculative language and irrelevant infra checks

### `k8s/base/openhands-svc.yaml`
- Set `strategy.type: Recreate` with explanatory comment about single-node constraint

### `tests/test_system_prompt.py` — 7 new tests
- 5 in `TestSoftwareEngineerIterationBudget`: evidence rule, evidence section, speculative language, infra checks, good/bad examples
- 2 in new `TestKubernetesDeploymentStrategy`: recreate strategy, strategy comment

## Test Results

- **103 system prompt tests passed**
- **545 total tests passed**, 79 skipped, 0 failed
- Lint clean