### PR TITLE
fix(agents): remove duplicated system prompt from user message to prevent context overflow

### DIFF
--- a/agents/openhands/release_engineer.py
+++ b/agents/openhands/release_engineer.py
@@ -415,9 +415,11 @@ WRITE operations (apply, rollout, restart, scale, undo). Do NOT skip actions
 just because you have the current state above.
 ================================================================================
 """
-                full_task = f"{RELEASE_ENGINEER_CONTEXT}\n{context_block}\nTask: {task}"
+                # NOTE: RELEASE_ENGINEER_CONTEXT is already in the system prompt
+                # via system_prompt_kwargs. Do NOT duplicate it in the user message.
+                full_task = f"{context_block}\nTask: {task}"
             else:
-                full_task = f"{RELEASE_ENGINEER_CONTEXT}\n\nTask: {task}"
+                full_task = f"Task: {task}"
 
             # Use send_message + run for the full agentic loop with tools
             conversation.send_message(full_task)

--- a/agents/openhands/software_engineer.py
+++ b/agents/openhands/software_engineer.py
@@ -491,11 +491,16 @@ class OpenHandsSoftwareEngineer:
             result = subprocess.run(cmd, capture_output=True, text=True, timeout=15)
 
             if result.returncode == 0:
+                issue_text = result.stdout
+                # Cap issue text to prevent context overflow.
+                # GitHub issues with many comments can be very large.
+                if len(issue_text) > 3000:
+                    issue_text = issue_text[:3000] + "\n\n... (issue text truncated at 3000 chars)"
                 return f"""
 ================================================================================
 PRE-FETCHED GITHUB ISSUE #{issue_number}
 ================================================================================
-{result.stdout}
+{issue_text}
 ================================================================================
 """
             else:
@@ -571,6 +576,13 @@ PRE-FETCHED GITHUB ISSUE #{issue_number}
             if file_list:
                 # Make paths relative
                 file_list = file_list.replace(workspace_path + "/", "")
+                # Cap file listing to prevent huge repos from blowing up context.
+                # Show only first 50 files — the agent can run find if it needs more.
+                file_lines = file_list.split("\n")
+                if len(file_lines) > 50:
+                    file_list = (
+                        "\n".join(file_lines[:50]) + f"\n... ({len(file_lines) - 50} more files)"
+                    )
                 sections.append(f"## File Structure\n```\n{file_list}\n```")
         except Exception:
             pass
@@ -694,6 +706,23 @@ PRE-FETCHED GITHUB ISSUE #{issue_number}
             "try",
             "see",
             "softwareengineer",
+            # Additional non-code words that pollute grep results
+            "github",
+            "repo",
+            "repository",
+            "crashes",
+            "crashing",
+            "crash",
+            "clicking",
+            "click",
+            "fails",
+            "failing",
+            "broken",
+            "breaking",
+            "working",
+            "stopped",
+            "report",
+            "reported",
         }
 
         # Extract candidate keywords (3+ chars, not in skip list)
@@ -711,7 +740,7 @@ PRE-FETCHED GITHUB ISSUE #{issue_number}
         keywords = keywords[:5]
 
         if not keywords:
-            keywords = ["record", "button", "click"]
+            keywords = ["record", "button"]
 
         print(f"[SoftwareEngineer] Pre-fetch grep keywords: {keywords}")
 
@@ -974,7 +1003,12 @@ section-by-section. If you need more context, use:
             # Build full task with context
             context_str = "\n\n".join(injected_context) if injected_context else ""
             if context_str:
-                context_block = f"""
+                # NOTE: SOFTWARE_ENGINEER_CONTEXT is already injected into the
+                # system prompt via system_prompt_kwargs in _create_agent().
+                # Do NOT include it again here — duplicating it wastes ~17k chars
+                # and pushes the context past OpenHands' 50k char limit, causing
+                # truncation that makes the agent blind to pre-fetched data.
+                full_task = f"""
 ================================================================================
 INJECTED DATA FROM MONITORING SYSTEMS - THIS IS YOUR DATA, USE IT!
 ================================================================================
@@ -984,17 +1018,13 @@ INJECTED DATA FROM MONITORING SYSTEMS - THIS IS YOUR DATA, USE IT!
 ================================================================================
 END OF INJECTED DATA - The above data has ALREADY been fetched for you
 ================================================================================
-"""
-                full_task = f"""{SOFTWARE_ENGINEER_CONTEXT}
-{context_block}
 
 ### USER TASK (UNTRUSTED INPUT)
 {task}
 ### END USER TASK
 """
             else:
-                full_task = f"""{SOFTWARE_ENGINEER_CONTEXT}
-
+                full_task = f"""
 ### USER TASK (UNTRUSTED INPUT)
 {task}
 ### END USER TASK

--- a/agents/openhands/support_engineer.py
+++ b/agents/openhands/support_engineer.py
@@ -471,16 +471,19 @@ INJECTED DATA FROM MONITORING SYSTEMS - THIS IS YOUR DATA, USE IT!
 END OF INJECTED DATA - The above data has ALREADY been fetched for you
 ================================================================================
 """
-                full_task = f"""{SUPPORT_ENGINEER_CONTEXT}
-{context_block}
+                # NOTE: SUPPORT_ENGINEER_CONTEXT is already injected into the
+                # system prompt via system_prompt_kwargs in _create_agent().
+                # Do NOT include it again here — duplicating it wastes ~17k chars
+                # and pushes the context past OpenHands' 50k char limit, causing
+                # truncation that makes the agent blind to injected data.
+                full_task = f"""{context_block}
 
 ### USER TASK (UNTRUSTED INPUT)
 {task}
 ### END USER TASK
 """
             else:
-                full_task = f"""{SUPPORT_ENGINEER_CONTEXT}
-
+                full_task = f"""
 ### USER TASK (UNTRUSTED INPUT)
 {task}
 ### END USER TASK

--- a/tests/test_eval_rescore.py
+++ b/tests/test_eval_rescore.py
@@ -537,9 +537,9 @@ class TestPerScenarioTimeout:
             f"release_deploy timeout should be > 600, got {SCENARIOS['release_deploy']['timeout']}"
         )
 
-    def test_release_deploy_timeout_is_900(self):
-        """The release_deploy scenario timeout should be 900s."""
-        assert SCENARIOS["release_deploy"]["timeout"] == 900
+    def test_release_deploy_timeout_is_1800(self):
+        """The release_deploy scenario timeout should be 1800s (30 min)."""
+        assert SCENARIOS["release_deploy"]["timeout"] == 1800
 
     def test_other_scenarios_use_default_timeout(self):
         """Scenarios without explicit timeout should not have the key."""

--- a/tests/test_system_prompt.py
+++ b/tests/test_system_prompt.py
@@ -668,21 +668,34 @@ class TestSoftwareEngineerIterationBudget:
         )
 
     def test_other_agents_still_use_25_iterations(self):
-        """SupportEngineer and ReleaseEngineer should still use max_iteration_per_run=25."""
-        for agent_file in ["support_engineer.py", "release_engineer.py"]:
-            filepath = os.path.join(
-                os.path.dirname(__file__),
-                os.pardir,
-                "agents",
-                "openhands",
-                agent_file,
-            )
-            with open(filepath) as f:
-                content = f.read()
-            assert "max_iteration_per_run=25" in content, (
-                f"{agent_file} should still use max_iteration_per_run=25. "
-                f"Only SWE agent needs 35 iterations."
-            )
+        """SupportEngineer should use max_iteration_per_run=25, ReleaseEngineer uses 15."""
+        # SupportEngineer uses 25 iterations
+        se_filepath = os.path.join(
+            os.path.dirname(__file__),
+            os.pardir,
+            "agents",
+            "openhands",
+            "support_engineer.py",
+        )
+        with open(se_filepath) as f:
+            se_content = f.read()
+        assert "max_iteration_per_run=25" in se_content, (
+            "support_engineer.py should use max_iteration_per_run=25."
+        )
+
+        # ReleaseEngineer uses 15 iterations (reduced to prevent timeout)
+        re_filepath = os.path.join(
+            os.path.dirname(__file__),
+            os.pardir,
+            "agents",
+            "openhands",
+            "release_engineer.py",
+        )
+        with open(re_filepath) as f:
+            re_content = f.read()
+        assert "max_iteration_per_run=15" in re_content, (
+            "release_engineer.py should use max_iteration_per_run=15."
+        )
 
     def test_has_forbidden_actions_section(self):
         """Prompt must have a FORBIDDEN ACTIONS section to prevent sequential file reading."""


### PR DESCRIPTION
## Summary

- **Remove system prompt duplication from user messages** in all three agents (SWE, RE, SE). The `*_CONTEXT` string (~17k chars) was being sent twice — once via `system_prompt_kwargs` in the system prompt and again in `full_task` — pushing the context past OpenHands' 50k char `TextContent` limit and causing truncation.
- **Cap unbounded data sources**: GitHub issue text capped at 3000 chars, file listings capped at 50 files.
- **Improve keyword extraction**: Added non-code words (github, crashes, clicking, etc.) to `skip_words` to prevent grep pollution.
- **Fix stale tests**: Updated RE iteration test (25→15) and eval timeout test (900→1800) to match recent changes in `e21516a`.

## Problem

The `github_issue` eval was scoring 0.20 across all metrics. Root cause:

1. Every agent iteration logged: `TextContent text length (57427) exceeds limit (50000), truncating`
2. The 57k chars came from duplicating the system prompt (~17k) in both `system_prompt_kwargs` AND the user message
3. Truncation at 50k stripped pre-fetched code data and FORBIDDEN ACTIONS instructions
4. Without pre-fetched data, the agent resorted to blind `grep` loops, hitting the stuck detector

## Testing

- All 566 tests pass
- Lint clean (ruff)