### PR TITLE
fix(tests): update test paths after agent_service migration

### DIFF
--- a/tests/test_async_callback.py
+++ b/tests/test_async_callback.py
@@ -1084,7 +1084,7 @@ class TestOpenHandsRunAsync:
         client = TestClient(agent_app)
 
         with patch(
-            "agents.openhands.server._execute_and_callback",
+            "agent_service.openhands.server._execute_and_callback",
             new_callable=AsyncMock,
         ):
             response = client.post(

--- a/tests/test_system_prompt.py
+++ b/tests/test_system_prompt.py
@@ -14,7 +14,13 @@ import os
 import pytest
 
 # Path to the prompts directory (same logic agents use at runtime)
-PROMPTS_DIR = os.path.join(os.path.dirname(__file__), os.pardir, "agents", "openhands", "prompts")
+PROMPTS_DIR = os.path.join(
+    os.path.dirname(__file__),
+    os.pardir,
+    "agent_service",
+    "openhands",
+    "prompts",
+)
 TEMPLATE_PATH = os.path.join(PROMPTS_DIR, "agent_system.j2")
 
 
@@ -78,7 +84,7 @@ class TestAgentPromptFilenameConstruction:
         filepath = os.path.join(
             os.path.dirname(__file__),
             os.pardir,
-            "agents",
+            "agent_service",
             "openhands",
             agent_file,
         )
@@ -95,7 +101,7 @@ class TestAgentPromptFilenameConstruction:
         filepath = os.path.join(
             os.path.dirname(__file__),
             os.pardir,
-            "agents",
+            "agent_service",
             "openhands",
             agent_file,
         )
@@ -114,7 +120,7 @@ class TestAgentPromptFilenameConstruction:
         agent_dir = os.path.join(
             os.path.dirname(__file__),
             os.pardir,
-            "agents",
+            "agent_service",
             "openhands",
         )
         resolved = os.path.join(agent_dir, "prompts", "agent_system.j2")
@@ -126,7 +132,7 @@ class TestAgentPromptFilenameConstruction:
         filepath = os.path.join(
             os.path.dirname(__file__),
             os.pardir,
-            "agents",
+            "agent_service",
             "openhands",
             agent_file,
         )
@@ -180,7 +186,7 @@ class TestReleaseEngineerSafetyGuardrails:
         filepath = os.path.join(
             os.path.dirname(__file__),
             os.pardir,
-            "agents",
+            "agent_service",
             "openhands",
             "release_engineer.py",
         )
@@ -360,7 +366,7 @@ class TestNamespaceAwareness:
         filepath = os.path.join(
             os.path.dirname(__file__),
             os.pardir,
-            "agents",
+            "agent_service",
             "openhands",
             "release_engineer.py",
         )
@@ -468,12 +474,17 @@ class TestSoftwareEngineerCodeFirstInvestigation:
         filepath = os.path.join(
             os.path.dirname(__file__),
             os.pardir,
-            "agents",
+            "agent_service",
             "openhands",
             "software_engineer.py",
         )
         with open(filepath) as f:
-            return f.read()
+            content = f.read()
+        # Normalize the marker name to keep older tests stable after renaming.
+        return content.replace(
+            'SOFTWARE_ENGINEER_CONTEXT_FALLBACK = """',
+            'SOFTWARE_ENGINEER_CONTEXT = """',
+        )
 
     def test_has_code_first_investigation_priority(self):
         """Must explicitly say to investigate code FIRST, infra SECOND."""
@@ -555,12 +566,17 @@ class TestSoftwareEngineerIterationBudget:
         filepath = os.path.join(
             os.path.dirname(__file__),
             os.pardir,
-            "agents",
+            "agent_service",
             "openhands",
             "software_engineer.py",
         )
         with open(filepath) as f:
-            return f.read()
+            content = f.read()
+        # Normalize the marker name to keep older tests stable after renaming.
+        return content.replace(
+            'SOFTWARE_ENGINEER_CONTEXT_FALLBACK = """',
+            'SOFTWARE_ENGINEER_CONTEXT = """',
+        )
 
     def test_has_final_reminder_section(self):
         """Prompt must have a FINAL REMINDER section near the end."""
@@ -672,7 +688,7 @@ class TestSoftwareEngineerIterationBudget:
         se_filepath = os.path.join(
             os.path.dirname(__file__),
             os.pardir,
-            "agents",
+            "agent_service",
             "openhands",
             "support_engineer.py",
         )
@@ -686,7 +702,7 @@ class TestSoftwareEngineerIterationBudget:
         re_filepath = os.path.join(
             os.path.dirname(__file__),
             os.pardir,
-            "agents",
+            "agent_service",
             "openhands",
             "release_engineer.py",
         )
@@ -971,7 +987,12 @@ class TestAzureLLMConsolidation:
     Now AzureLLM lives in agents/shared/llm.py and all agents import from there.
     """
 
-    AGENTS_DIR = os.path.join(os.path.dirname(__file__), os.pardir, "agents", "openhands")
+    AGENTS_DIR = os.path.join(
+        os.path.dirname(__file__),
+        os.pardir,
+        "agent_service",
+        "openhands",
+    )
 
     ALL_AGENT_FILES = [
         "software_engineer.py",
@@ -986,7 +1007,7 @@ class TestAzureLLMConsolidation:
         filepath = os.path.join(
             os.path.dirname(__file__),
             os.pardir,
-            "agents",
+            "agent_service",
             "openhands",
             filename,
         )
@@ -1090,12 +1111,17 @@ class TestSoftwareEngineerFileEditorTool:
         filepath = os.path.join(
             os.path.dirname(__file__),
             os.pardir,
-            "agents",
+            "agent_service",
             "openhands",
             "software_engineer.py",
         )
         with open(filepath) as f:
-            return f.read()
+            content = f.read()
+        # Normalize marker for legacy prompt parsing in tests.
+        return content.replace(
+            'SOFTWARE_ENGINEER_CONTEXT_FALLBACK = """',
+            'SOFTWARE_ENGINEER_CONTEXT = """',
+        )
 
     def test_create_agent_includes_file_editor_tool(self):
         """_create_agent must include FileEditorTool in the tools list."""


### PR DESCRIPTION
## Problem\n\n19 tests were failing on `master` after the OpenHands agents directory was migrated from `agents/openhands/` to `agent_service/openhands/` and `SOFTWARE_ENGINEER_CONTEXT` was renamed to `SOFTWARE_ENGINEER_CONTEXT_FALLBACK`.\n\nFailing tests were in `test_system_prompt.py` (18 failures) and `test_async_callback.py` (1 failure).\n\n## Root Cause\n\n1. **Stale file paths** – Test helpers constructed paths like `Path(\"agents/openhands/prompts/...\")` which no longer exist.\n2. **Renamed variable** – Tests parsed `software_engineer.py` looking for `SOFTWARE_ENGINEER_CONTEXT = \"\"\"` but the variable was renamed to `SOFTWARE_ENGINEER_CONTEXT_FALLBACK`.\n3. **Stale mock patch target** – `test_async_callback.py` patched `agents.openhands.server._execute_and_callback` (old module path).\n\n## Changes\n\n### `tests/test_system_prompt.py`\n- Update all file path references from `agents/openhands` → `agent_service/openhands`\n- Add `.replace('SOFTWARE_ENGINEER_CONTEXT_FALLBACK', 'SOFTWARE_ENGINEER_CONTEXT')` normalization in `_read_swe_context()`, `_read_swe_source()`, and related helpers so existing assertions continue to work\n\n### `tests/test_async_callback.py`\n- Fix mock patch path from `agents.openhands.server` → `agent_service.openhands.server`\n\n## Validation\n\n```\n567 passed, 82 skipped (behind --run-integration flag), 0 failures\n```"