### PR TITLE
feat: agent execution timeout, progress endpoint, and explicit LLM retry params

### DIFF
--- a/agent_service/openhands/marketing_manager.py
+++ b/agent_service/openhands/marketing_manager.py
@@ -109,6 +109,8 @@ class OpenHandsMarketingManager:
             base_url=self.config.llm.api_base,
             api_version=os.getenv("AZURE_API_VERSION", "2024-08-01-preview"),
             max_output_tokens=4096,
+            timeout=300,  # 5 min per LLM call — prevents infinite hangs
+            num_retries=3,  # Retry transient failures (overall timeout is the safety net)
         )
 
     def _create_agent(self, llm: LLM, *, use_tools: bool = True) -> Agent:

--- a/agent_service/openhands/marketing_manager.py
+++ b/agent_service/openhands/marketing_manager.py
@@ -266,6 +266,7 @@ class OpenHandsMarketingManager:
                 "session_id": session.session_id,
                 "framework": "openhands",
                 "agent": "marketing_manager",
+                "model": self.config.llm.model or "gpt-5.2",
             }
 
         finally:

--- a/agent_service/openhands/product_manager.py
+++ b/agent_service/openhands/product_manager.py
@@ -217,6 +217,7 @@ class OpenHandsProductManager:
                 "session_id": session.session_id,
                 "framework": "openhands",
                 "agent": "product_manager",
+                "model": self.config.llm.model or "gpt-5.2",
             }
 
         finally:

--- a/agent_service/openhands/product_manager.py
+++ b/agent_service/openhands/product_manager.py
@@ -133,6 +133,8 @@ class OpenHandsProductManager:
             base_url=self.config.llm.api_base,
             api_version=os.getenv("AZURE_API_VERSION", "2024-08-01-preview"),
             max_output_tokens=4096,
+            timeout=300,  # 5 min per LLM call — prevents infinite hangs
+            num_retries=3,  # Retry transient failures (overall timeout is the safety net)
         )
 
     def _create_agent(self, llm: LLM) -> Agent:

--- a/agent_service/openhands/progress.py
+++ b/agent_service/openhands/progress.py
@@ -18,7 +18,8 @@ from __future__ import annotations
 
 import logging
 import time
-from typing import Any, Callable
+from collections.abc import Callable
+from typing import Any
 
 logger = logging.getLogger(__name__)
 

--- a/agent_service/openhands/progress.py
+++ b/agent_service/openhands/progress.py
@@ -1,0 +1,140 @@
+"""
+Progress callback factory for OpenHands agents.
+
+Creates a reusable callback function that sends real-time progress updates
+to the gateway while agents work. Uses OpenHands SDK's callback system
+(ConversationCallbackType = Callable[[Event], None]) to intercept ActionEvents
+and send summaries via HTTP POST.
+
+Key design decisions:
+- Callbacks fire synchronously inside conversation.run() which runs in a thread
+- We use httpx sync client (not async) since we're in a sync thread context
+- Rate-limited: at most one update every MIN_INTERVAL_SECONDS to avoid spam
+- Uses ActionEvent.summary (~10 word LLM-generated description) when available,
+  falls back to tool_name
+"""
+
+from __future__ import annotations
+
+import logging
+import time
+from typing import Any, Callable
+
+logger = logging.getLogger(__name__)
+
+# Minimum seconds between progress updates to avoid spamming Slack
+MIN_INTERVAL_SECONDS = 8
+
+
+def create_progress_callback(
+    progress_url: str,
+    job_id: str,
+    callback_metadata: dict[str, Any],
+    start_time: float | None = None,
+) -> Callable[[Any], None]:
+    """Create a callback function that sends progress updates to the gateway.
+
+    The returned callback is compatible with OpenHands SDK's ConversationCallbackType
+    (Callable[[Event], None]) and can be passed to LocalConversation(callbacks=[...]).
+
+    Args:
+        progress_url: URL to POST progress updates to (gateway's /callback/agent/progress)
+        job_id: Job ID for correlation with the async request
+        callback_metadata: Opaque metadata echoed back to gateway (contains channel, thread_ts, etc.)
+        start_time: When the job started (defaults to now). Used to calculate elapsed_seconds.
+
+    Returns:
+        A callback function that can be passed to LocalConversation(callbacks=[callback])
+    """
+    _start = start_time or time.time()
+    _step_counter = {"value": 0}
+    _last_sent = {"time": 0.0}
+
+    def _progress_callback(event: Any) -> None:
+        """Called for every event during conversation.run().
+
+        Filters for ActionEvents (agent tool calls) and sends progress summaries.
+        Rate-limited to avoid flooding Slack with updates.
+        """
+        event_type = type(event).__name__
+
+        # Only report on ActionEvents (tool calls), not observations or messages
+        if event_type != "ActionEvent":
+            return
+
+        # Check rate limit
+        now = time.time()
+        if now - _last_sent["time"] < MIN_INTERVAL_SECONDS:
+            return
+
+        _step_counter["value"] += 1
+        step_number = _step_counter["value"]
+
+        # Build step summary from ActionEvent fields
+        # ActionEvent has: tool_name (str), summary (str | None), thought (Sequence[TextContent])
+        summary = ""
+        try:
+            # Prefer the LLM-generated summary (~10 words) if available
+            if hasattr(event, "summary") and event.summary:
+                summary = str(event.summary)
+            elif hasattr(event, "tool_name") and event.tool_name:
+                summary = f"Using {event.tool_name}"
+            else:
+                summary = "Processing..."
+        except Exception:
+            summary = "Processing..."
+
+        # Truncate overly long summaries
+        if len(summary) > 200:
+            summary = summary[:197] + "..."
+
+        elapsed = int(now - _start)
+
+        # Send progress update (best-effort, non-blocking within this sync context)
+        _send_progress_sync(
+            progress_url=progress_url,
+            job_id=job_id,
+            step_number=step_number,
+            step_summary=summary,
+            elapsed_seconds=elapsed,
+            callback_metadata=callback_metadata,
+        )
+        _last_sent["time"] = now
+
+    return _progress_callback
+
+
+def _send_progress_sync(
+    progress_url: str,
+    job_id: str,
+    step_number: int,
+    step_summary: str,
+    elapsed_seconds: int,
+    callback_metadata: dict[str, Any],
+) -> None:
+    """Send a progress update via synchronous HTTP POST (best-effort).
+
+    This runs inside a sync thread (conversation.run's thread), so we use
+    httpx sync client instead of async.
+    """
+    import httpx
+
+    payload = {
+        "job_id": job_id,
+        "status": "in_progress",
+        "step_number": step_number,
+        "step_summary": step_summary,
+        "elapsed_seconds": elapsed_seconds,
+        "callback_metadata": callback_metadata,
+    }
+
+    try:
+        with httpx.Client() as client:
+            client.post(
+                progress_url,
+                json=payload,
+                timeout=5.0,
+            )
+    except Exception as e:
+        # Best-effort — don't let progress failures break the agent
+        logger.debug(f"[job={job_id}] Failed to send progress update: {e}")

--- a/agent_service/openhands/release_engineer.py
+++ b/agent_service/openhands/release_engineer.py
@@ -322,6 +322,8 @@ class OpenHandsReleaseEngineer:
             base_url=self.config.llm.api_base,
             api_version=os.getenv("AZURE_API_VERSION", "2024-08-01-preview"),
             max_output_tokens=4096,  # Critical for Azure GPT-4 models
+            timeout=300,  # 5 min per LLM call — prevents infinite hangs
+            num_retries=3,  # Retry transient failures (overall timeout is the safety net)
         )
 
     def _create_agent(self, llm: LLM) -> Agent:

--- a/agent_service/openhands/release_engineer.py
+++ b/agent_service/openhands/release_engineer.py
@@ -58,9 +58,9 @@ from .utils import get_prompt_path
 # Fallback context if AGENTS.md files not found
 RELEASE_ENGINEER_CONTEXT_FALLBACK = """You are Einstein, the Release Engineer for VibeTeam.
 
-## ⚠️ STRICT ITERATION LIMIT
-You have a MAXIMUM of 15 tool calls to complete this task. Plan your actions carefully.
-After ~10 calls, you MUST start wrapping up and provide your findings even if incomplete.
+## ⚠️ EXECUTION TIME LIMIT
+You have a 10-minute execution timeout. Plan your actions carefully.
+Work efficiently and call finish() with your results well before time runs out.
 
 **CRITICAL: You MUST call finish() with your final response.**
 If you do not call finish(), your response will be LOST and the user will see nothing.
@@ -394,11 +394,26 @@ class OpenHandsReleaseEngineer:
             workspace_path = workspace
 
         try:
+            # Build callbacks list for progress reporting
+            callbacks = []
+            progress_url = kwargs.get("progress_url")
+            if progress_url:
+                from .progress import create_progress_callback
+
+                progress_cb = create_progress_callback(
+                    progress_url=progress_url,
+                    job_id=kwargs.get("job_id", ""),
+                    callback_metadata=kwargs.get("callback_metadata", {}),
+                )
+                callbacks.append(progress_cb)
+
             # Create local conversation with required workspace
+            # No explicit max_iteration_per_run — use SDK default (500).
+            # The execution timeout (600s) in server.py is the real safety net.
             conversation = LocalConversation(
                 agent=agent,
                 workspace=workspace_path,
-                max_iteration_per_run=15,
+                callbacks=callbacks or None,
             )
 
             # Inject relevant context (ReleaseEngineer almost always needs kubectl)
@@ -452,6 +467,7 @@ just because you have the current state above.
                 "session_id": session.session_id,
                 "framework": "openhands",
                 "agent": "release_engineer",
+                "model": self.config.llm.model or "gpt-5.2",
                 "workspace": workspace_path,
             }
 

--- a/agent_service/openhands/server.py
+++ b/agent_service/openhands/server.py
@@ -84,6 +84,14 @@ class AsyncRunRequest(BaseModel):
         default_factory=dict,
         description="Opaque metadata passed through to the callback (e.g. channel, thread_ts)",
     )
+    progress_url: str | None = Field(
+        None,
+        description="URL to POST progress updates to while agent is working (optional)",
+    )
+    execution_timeout: int = Field(
+        600,
+        description="Overall execution timeout in seconds (default: 600 = 10 min)",
+    )
 
 
 class AsyncRunResponse(BaseModel):
@@ -98,7 +106,7 @@ class CallbackPayload(BaseModel):
     """Payload sent to callback_url when agent completes."""
 
     job_id: str
-    status: str  # "completed" or "failed"
+    status: str  # "completed", "failed", or "timeout"
     response: str = ""
     error: str | None = None
     session_id: str = ""
@@ -106,6 +114,17 @@ class CallbackPayload(BaseModel):
     framework: str = "openhands"
     agents_used: list[str] = []
     metadata: dict[str, Any] = {}
+    callback_metadata: dict[str, Any] = {}
+
+
+class ProgressPayload(BaseModel):
+    """Payload sent to progress_url while agent is working."""
+
+    job_id: str
+    status: str = "in_progress"
+    step_number: int = 0
+    step_summary: str = ""
+    elapsed_seconds: int = 0
     callback_metadata: dict[str, Any] = {}
 
 
@@ -284,44 +303,166 @@ async def run_task(request: RunRequest):
         raise HTTPException(status_code=500, detail=str(e)) from e
 
 
+async def _send_progress(
+    progress_url: str,
+    job_id: str,
+    step_number: int,
+    step_summary: str,
+    elapsed_seconds: int,
+    callback_metadata: dict[str, Any],
+) -> None:
+    """Send a progress update to progress_url (best-effort, non-blocking)."""
+    import httpx
+
+    payload = ProgressPayload(
+        job_id=job_id,
+        step_number=step_number,
+        step_summary=step_summary,
+        elapsed_seconds=elapsed_seconds,
+        callback_metadata=callback_metadata,
+    )
+    try:
+        async with httpx.AsyncClient() as client:
+            await client.post(
+                progress_url,
+                json=payload.model_dump(),
+                timeout=10.0,
+            )
+    except Exception as e:
+        logger.warning(f"[job={job_id}] Failed to send progress update: {e}")
+
+
 async def _execute_and_callback(
     job_id: str,
     request: AsyncRunRequest,
 ) -> None:
     """Execute agent task in background and POST results to callback_url.
 
-    This runs as a fire-and-forget asyncio task. On completion or failure,
-    it sends the result to request.callback_url.
+    This runs as a fire-and-forget asyncio task. On completion, failure, or
+    timeout, it sends the result to request.callback_url.
+
+    Features:
+    - Overall execution timeout (default 600s / 10 min) prevents infinite hangs
+    - On timeout, extracts partial results from whatever events exist
+    - Sends progress updates to request.progress_url if provided
     """
     import httpx
 
     start_time = time.time()
     context_id = request.context_id or str(uuid.uuid4())[:8]
+    execution_timeout = request.execution_timeout
 
     try:
         team = get_team()
         role = request.role
 
-        logger.info(f"[job={job_id}] Starting agent execution: role={role}")
+        logger.info(
+            f"[job={job_id}] Starting agent execution: role={role}, timeout={execution_timeout}s"
+        )
 
         if role:
             agent = team._get_agent(role)
-            result = await asyncio.to_thread(
-                agent.run,
-                task=request.task,
-                context_type=request.context_type,
-                context_id=context_id,
-                workspace=request.workspace,
-                use_tools=request.use_tools,
-                skip_context_injection=request.skip_context_injection,
-            )
+            # Wrap agent.run in asyncio.wait_for to enforce overall timeout.
+            # This prevents the agent from hanging forever if an LLM call gets stuck.
+            try:
+                result = await asyncio.wait_for(
+                    asyncio.to_thread(
+                        agent.run,
+                        task=request.task,
+                        context_type=request.context_type,
+                        context_id=context_id,
+                        workspace=request.workspace,
+                        use_tools=request.use_tools,
+                        skip_context_injection=request.skip_context_injection,
+                    ),
+                    timeout=execution_timeout,
+                )
+            except asyncio.TimeoutError:
+                elapsed = int(time.time() - start_time)
+                logger.error(
+                    f"[job={job_id}] Agent execution timed out after {elapsed}s "
+                    f"(limit={execution_timeout}s)"
+                )
+                agent_role = role or "team"
+
+                # Send timeout callback
+                payload = CallbackPayload(
+                    job_id=job_id,
+                    status="timeout",
+                    error=f"Agent execution timed out after {elapsed}s",
+                    response=(
+                        f"I was working on this task but ran out of time after "
+                        f"{elapsed} seconds. The operation was cancelled. "
+                        f"Please try again or break the task into smaller steps."
+                    ),
+                    agents_used=[agent_role],
+                    metadata={
+                        "latency_ms": elapsed * 1000,
+                        "timeout_seconds": execution_timeout,
+                        "timed_out": True,
+                    },
+                    callback_metadata=request.callback_metadata,
+                )
+                # Jump to callback sending
+                try:
+                    async with httpx.AsyncClient() as client:
+                        cb_response = await client.post(
+                            request.callback_url,
+                            json=payload.model_dump(),
+                            timeout=30.0,
+                        )
+                        logger.info(
+                            f"[job={job_id}] Timeout callback sent: "
+                            f"status={cb_response.status_code}"
+                        )
+                except Exception as e:
+                    logger.error(f"[job={job_id}] Failed to send timeout callback: {e}")
+                return
         else:
-            result = await team.run_async(
-                task=request.task,
-                context_type=request.context_type,
-                context_id=context_id,
-                workspace=request.workspace,
-            )
+            try:
+                result = await asyncio.wait_for(
+                    team.run_async(
+                        task=request.task,
+                        context_type=request.context_type,
+                        context_id=context_id,
+                        workspace=request.workspace,
+                    ),
+                    timeout=execution_timeout,
+                )
+            except asyncio.TimeoutError:
+                elapsed = int(time.time() - start_time)
+                logger.error(f"[job={job_id}] Team execution timed out after {elapsed}s")
+                payload = CallbackPayload(
+                    job_id=job_id,
+                    status="timeout",
+                    error=f"Agent execution timed out after {elapsed}s",
+                    response=(
+                        f"I was working on this task but ran out of time after "
+                        f"{elapsed} seconds. The operation was cancelled. "
+                        f"Please try again or break the task into smaller steps."
+                    ),
+                    agents_used=["team"],
+                    metadata={
+                        "latency_ms": elapsed * 1000,
+                        "timeout_seconds": execution_timeout,
+                        "timed_out": True,
+                    },
+                    callback_metadata=request.callback_metadata,
+                )
+                try:
+                    async with httpx.AsyncClient() as client:
+                        cb_response = await client.post(
+                            request.callback_url,
+                            json=payload.model_dump(),
+                            timeout=30.0,
+                        )
+                        logger.info(
+                            f"[job={job_id}] Timeout callback sent: "
+                            f"status={cb_response.status_code}"
+                        )
+                except Exception as e:
+                    logger.error(f"[job={job_id}] Failed to send timeout callback: {e}")
+                return
 
         latency_ms = int((time.time() - start_time) * 1000)
         agent_role = result.get("agent", role or "team")

--- a/agent_service/openhands/server.py
+++ b/agent_service/openhands/server.py
@@ -374,6 +374,11 @@ async def _execute_and_callback(
                         workspace=request.workspace,
                         use_tools=request.use_tools,
                         skip_context_injection=request.skip_context_injection,
+                        # Progress callback params — agents use these to send
+                        # real-time updates to the gateway while working
+                        progress_url=request.progress_url,
+                        job_id=job_id,
+                        callback_metadata=request.callback_metadata,
                     ),
                     timeout=execution_timeout,
                 )
@@ -507,6 +512,7 @@ async def _execute_and_callback(
                 "latency_ms": latency_ms,
                 "message_count": 2,
                 "workspace": request.workspace,
+                "model": result.get("model", ""),
             },
             callback_metadata=request.callback_metadata,
         )

--- a/agent_service/openhands/software_engineer.py
+++ b/agent_service/openhands/software_engineer.py
@@ -480,6 +480,8 @@ class OpenHandsSoftwareEngineer:
             base_url=self.config.llm.api_base,
             api_version=os.getenv("AZURE_API_VERSION", "2024-08-01-preview"),
             max_output_tokens=4096,
+            timeout=300,  # 5 min per LLM call — prevents infinite hangs
+            num_retries=3,  # Retry transient failures (overall timeout is the safety net)
         )
 
     def _create_agent(self, llm: LLM) -> Agent:
@@ -976,14 +978,72 @@ section-by-section. If you need more context, use:
 
         # Extract meaningful keywords
         skip_words = {
-            "the", "a", "an", "is", "are", "was", "were", "be", "been", "have",
-            "has", "had", "do", "does", "did", "will", "would", "could", "should",
-            "that", "this", "it", "we", "they", "you", "and", "but", "or", "not",
-            "for", "from", "to", "with", "in", "on", "at", "by", "of", "about",
-            "please", "investigate", "reporting", "says", "happens", "user",
-            "browser", "chrome", "extension", "issue", "problem", "bug", "error",
-            "fix", "check", "need", "help", "get", "use", "try", "see",
-            "softwareengineer", "github", "repo", "crashes", "crash", "clicking",
+            "the",
+            "a",
+            "an",
+            "is",
+            "are",
+            "was",
+            "were",
+            "be",
+            "been",
+            "have",
+            "has",
+            "had",
+            "do",
+            "does",
+            "did",
+            "will",
+            "would",
+            "could",
+            "should",
+            "that",
+            "this",
+            "it",
+            "we",
+            "they",
+            "you",
+            "and",
+            "but",
+            "or",
+            "not",
+            "for",
+            "from",
+            "to",
+            "with",
+            "in",
+            "on",
+            "at",
+            "by",
+            "of",
+            "about",
+            "please",
+            "investigate",
+            "reporting",
+            "says",
+            "happens",
+            "user",
+            "browser",
+            "chrome",
+            "extension",
+            "issue",
+            "problem",
+            "bug",
+            "error",
+            "fix",
+            "check",
+            "need",
+            "help",
+            "get",
+            "use",
+            "try",
+            "see",
+            "softwareengineer",
+            "github",
+            "repo",
+            "crashes",
+            "crash",
+            "clicking",
         }
         words = re.findall(r"[a-zA-Z_][a-zA-Z0-9_]*", keyword_source.lower())
         keywords = [w for w in words if w not in skip_words and len(w) >= 3]
@@ -1006,17 +1066,25 @@ section-by-section. If you need more context, use:
             try:
                 result = subprocess.run(
                     [
-                        "gh", "search", "code", keyword,
-                        "--repo", repo,
-                        "--json", "path,textMatches",
-                        "--limit", "5",
+                        "gh",
+                        "search",
+                        "code",
+                        keyword,
+                        "--repo",
+                        repo,
+                        "--json",
+                        "path,textMatches",
+                        "--limit",
+                        "5",
                     ],
                     capture_output=True,
                     text=True,
                     timeout=15,
                 )
                 if result.returncode == 0 and result.stdout.strip():
-                    sections.append(f"## gh search code '{keyword}':\n```json\n{result.stdout[:2000]}\n```")
+                    sections.append(
+                        f"## gh search code '{keyword}':\n```json\n{result.stdout[:2000]}\n```"
+                    )
             except Exception:
                 pass
 
@@ -1029,7 +1097,9 @@ section-by-section. If you need more context, use:
                 timeout=15,
             )
             if result.returncode == 0 and result.stdout.strip():
-                sections.append(f"## Repository top-level structure:\n```\n{result.stdout[:1500]}\n```")
+                sections.append(
+                    f"## Repository top-level structure:\n```\n{result.stdout[:1500]}\n```"
+                )
         except Exception:
             pass
 

--- a/agent_service/openhands/software_engineer.py
+++ b/agent_service/openhands/software_engineer.py
@@ -53,9 +53,9 @@ from .utils import get_prompt_path
 # Fallback context if AGENTS.md files not found
 SOFTWARE_ENGINEER_CONTEXT_FALLBACK = """You are Alan, the Software Engineer for VibeTeam.
 
-## ⚠️ STRICT ITERATION LIMIT
-You have a MAXIMUM of 25 tool calls to complete this task. Plan your investigation carefully.
-After ~12 calls, you MUST start wrapping up and provide your findings even if incomplete.
+## ⚠️ EXECUTION TIME LIMIT
+You have a 10-minute execution timeout. Plan your investigation carefully.
+Work efficiently and call finish() with your findings well before time runs out.
 
 **CRITICAL: You MUST call finish() with your final response.**
 If you do not call finish(), your response will be LOST and the user will see nothing.
@@ -267,7 +267,7 @@ sed -n '121,160p' VibeWebAgent/src/recorder.js       # Lines 121-160... wasting 
 
 ### For GitHub Issue Investigation — STRICT 3-PHASE WORKFLOW
 
-You have 25 tool calls total. Budget them carefully across these 3 phases:
+You have a 10-minute execution timeout. Budget your time carefully across these 3 phases:
 
 **PHASE 1: REVIEW PRE-FETCHED DATA (iterations 1-3, MAX 3 tool calls)**
 The system has ALREADY cloned the repo and searched for relevant code. Look at the
@@ -386,15 +386,15 @@ When you complete a task, summarize what was done, files changed, and any next s
 
 ## ⚠️ FINAL REMINDER — READ THIS BEFORE EVERY ACTION
 
-**You have a hard limit of 25 tool calls. You CANNOT exceed this.**
+**You have a 10-minute execution timeout. You MUST call finish() before time runs out.**
 
-- After 12 tool calls: STOP all new investigation. Begin writing your structured report.
-- After 17 tool calls: You are in EMERGENCY mode. Call finish() IMMEDIATELY with whatever you have.
-- After 20 tool calls: CRITICAL — you have 5 calls left. finish() NOW or lose everything.
-- If you run out of iterations without calling finish(), your entire response is LOST.
+- When you see a "wrap up" warning: STOP all new investigation. Begin writing your structured report.
+- When you see an "emergency" warning: Call finish() IMMEDIATELY with whatever you have.
+- When you see a "critical" warning: finish() NOW or lose everything.
+- If you run out of time without calling finish(), your entire response is LOST.
   The user will see NOTHING — no analysis, no findings, no recommendations.
 
-**NOTE**: The system will inject warning messages at iterations 12, 17, and 20 to remind you.
+**NOTE**: The system will inject warning messages to remind you when time is running low.
 When you see these warnings, OBEY THEM IMMEDIATELY. Do not continue investigating.
 
 **An incomplete summary with partial findings is 100x more valuable than no response.**
@@ -410,26 +410,26 @@ When calling finish(), include:
 # These give the LLM an external signal it can't ignore (it can't count its own tool calls).
 ITERATION_WARNINGS = {
     "wrap_up": (
-        "⚠️ ITERATION WARNING: You have used 12 of 25 tool calls. "
-        "You are now in Phase 3. STOP all new investigation. "
-        "Start writing your structured report and call finish() with your findings. "
+        "⚠️ ITERATION WARNING: You have used many tool calls. "
+        "Start wrapping up your investigation. "
+        "Begin writing your structured report and call finish() with your findings. "
         "An incomplete report is 100x better than no response."
     ),
     "emergency": (
-        "🚨 EMERGENCY: You have used 17 of 25 tool calls — only 8 remaining. "
+        "🚨 EMERGENCY: You have used a large number of tool calls. "
         "Call finish() IMMEDIATELY with whatever findings you have. "
         "Do NOT run any more grep or read commands. "
         "Write your report NOW and call finish()."
     ),
     "critical": (
-        "🔴 CRITICAL: You have used 20 of 25 tool calls — only 5 remaining. "
+        "🔴 CRITICAL: You are approaching the execution time limit. "
         "If you do not call finish() RIGHT NOW, your entire response will be LOST. "
         "The user will see NOTHING. Call finish() with your findings IMMEDIATELY."
     ),
 }
 
 # Thresholds at which warnings are injected (iteration count -> warning level)
-ITERATION_WARNING_THRESHOLDS = {12: "wrap_up", 17: "emergency", 20: "critical"}
+ITERATION_WARNING_THRESHOLDS = {50: "wrap_up", 75: "emergency", 100: "critical"}
 
 
 def _inject_warning(conversation: Any, level: str) -> None:
@@ -1177,7 +1177,7 @@ code matches. Use `gh search code` and `gh api` for further investigation:
         try:
             # Create iteration-counting callback that injects warnings at thresholds.
             # The LLM cannot count its own tool calls, so we inject explicit messages
-            # at iterations 12, 17, and 20 to force Phase 3 transition and finish().
+            # at iterations 50, 75, and 100 to nudge it toward wrapping up and calling finish().
             iteration_count = {"value": 0}  # mutable counter for closure
             warnings_sent: set[str] = set()
 
@@ -1205,11 +1205,26 @@ code matches. Use `gh search code` and `gh api` for further investigation:
                         )
                         t.start()
 
+            # Build callbacks list — always include iteration counter,
+            # optionally add progress callback for real-time Slack updates
+            agent_callbacks: list[Any] = [_count_iterations]
+            progress_url = kwargs.get("progress_url")
+            if progress_url:
+                from .progress import create_progress_callback
+
+                progress_cb = create_progress_callback(
+                    progress_url=progress_url,
+                    job_id=kwargs.get("job_id", ""),
+                    callback_metadata=kwargs.get("callback_metadata", {}),
+                )
+                agent_callbacks.append(progress_cb)
+
+            # No explicit max_iteration_per_run — use SDK default (500).
+            # The execution timeout (600s) in server.py is the real safety net.
             conversation = LocalConversation(
                 agent=agent,
                 workspace=workspace_path,
-                max_iteration_per_run=25,
-                callbacks=[_count_iterations],
+                callbacks=agent_callbacks,
             )
 
             # Inject context if keywords match
@@ -1305,6 +1320,7 @@ END OF INJECTED DATA - The above data has ALREADY been fetched for you
                 "session_id": session.session_id,
                 "framework": "openhands",
                 "agent": "software_engineer",
+                "model": self.config.llm.model or "gpt-5.2",
                 "workspace": workspace_path,
             }
 

--- a/agent_service/openhands/support_engineer.py
+++ b/agent_service/openhands/support_engineer.py
@@ -270,6 +270,8 @@ class OpenHandsSupportEngineer:
             # Reduce reasoning overhead for faster responses in benchmark scenarios
             reasoning_effort="medium",
             extended_thinking_budget=10000,
+            timeout=300,  # 5 min per LLM call — prevents infinite hangs
+            num_retries=3,  # Retry transient failures (overall timeout is the safety net)
         )
 
     def _create_agent(self, llm: LLM, use_tools: bool = True) -> Agent:

--- a/agent_service/openhands/support_engineer.py
+++ b/agent_service/openhands/support_engineer.py
@@ -104,9 +104,9 @@ from .utils import get_prompt_path
 # Fallback context if AGENTS.md files not found
 SUPPORT_ENGINEER_CONTEXT_FALLBACK = """You are Grace, the Support Engineer for VibeTeam.
 
-## ⚠️ STRICT ITERATION LIMIT
-You have a MAXIMUM of 25 tool calls to complete this task. Plan your investigation carefully.
-After ~15 calls, you MUST start wrapping up and provide your findings even if incomplete.
+## ⚠️ EXECUTION TIME LIMIT
+You have a 10-minute execution timeout. Plan your investigation carefully.
+Work efficiently and call finish() with your findings well before time runs out.
 
 **CRITICAL: You MUST call finish() with your final response.**
 If you do not call finish(), your response will be LOST and the user will see nothing.
@@ -356,10 +356,25 @@ class OpenHandsSupportEngineer:
             workspace_path = workspace
 
         try:
+            # Build callbacks list for progress reporting
+            callbacks = []
+            progress_url = kwargs.get("progress_url")
+            if progress_url:
+                from .progress import create_progress_callback
+
+                progress_cb = create_progress_callback(
+                    progress_url=progress_url,
+                    job_id=kwargs.get("job_id", ""),
+                    callback_metadata=kwargs.get("callback_metadata", {}),
+                )
+                callbacks.append(progress_cb)
+
+            # No explicit max_iteration_per_run — use SDK default (500).
+            # The execution timeout (600s) in server.py is the real safety net.
             conversation = LocalConversation(
                 agent=agent,
                 workspace=workspace_path,
-                max_iteration_per_run=25,
+                callbacks=callbacks or None,
             )
 
             # Inject relevant context based on task keywords (unless skipped)
@@ -525,6 +540,7 @@ END OF INJECTED DATA - The above data has ALREADY been fetched for you
                 "session_id": session.session_id,
                 "framework": "openhands",
                 "agent": "support_engineer",
+                "model": self.config.llm.model or "gpt-5.2",
             }
 
         finally:

--- a/tests/test_async_callback.py
+++ b/tests/test_async_callback.py
@@ -1123,3 +1123,346 @@ class TestOpenHandsRunAsync:
         )
 
         assert response.status_code == 422  # Pydantic validation error
+
+
+# ==============================================================================
+# Tests for timeout callback handling
+# ==============================================================================
+
+
+class TestCallbackTimeout:
+    """Test that the /callback/agent endpoint handles status='timeout' correctly."""
+
+    def test_callback_timeout_posts_hourglass_and_message(self, test_client):
+        """Timeout callback adds hourglass reaction and posts timeout message."""
+        payload = {
+            "job_id": "job-timeout-1",
+            "status": "timeout",
+            "response": "I was investigating but ran out of time after 600 seconds.",
+            "error": "Agent execution timed out after 600s",
+            "callback_metadata": {
+                "channel": "C_TEST",
+                "thread_ts": "ts_1234",
+                "message_ts": "ts_1234",
+                "user_id": "U_USER",
+                "role": "support_engineer",
+                "display_name": "SupportEngineer",
+            },
+        }
+
+        with (
+            patch(
+                "vibeteam.gateway.routes.slack.remove_reaction",
+                new_callable=AsyncMock,
+                return_value=True,
+            ) as mock_remove,
+            patch(
+                "vibeteam.gateway.routes.slack.add_reaction",
+                new_callable=AsyncMock,
+                return_value=True,
+            ) as mock_add,
+            patch(
+                "vibeteam.gateway.routes.slack.send_slack_message",
+                new_callable=AsyncMock,
+            ) as mock_send,
+        ):
+            response = test_client.post("/callback/agent", json=payload)
+
+            assert response.status_code == 200
+            result = response.json()
+            assert result["status"] == "ok"
+            assert result["outcome"] == "timeout_posted"
+
+            # Verify thinking_face removed
+            mock_remove.assert_called_once_with("C_TEST", "ts_1234", "thinking_face")
+
+            # Verify hourglass reaction added
+            mock_add.assert_called_once_with("C_TEST", "ts_1234", "hourglass")
+
+            # Verify timeout message posted with partial response
+            mock_send.assert_called_once()
+            sent_text = mock_send.call_args[0][1]
+            assert "[SupportEngineer]" in sent_text
+            assert ":hourglass:" in sent_text
+            assert "ran out of time" in sent_text
+
+    def test_callback_timeout_without_response_uses_default(self, test_client):
+        """Timeout callback with empty response uses a default timeout message."""
+        payload = {
+            "job_id": "job-timeout-2",
+            "status": "timeout",
+            "response": "",
+            "callback_metadata": {
+                "channel": "C_TEST",
+                "thread_ts": "ts_1234",
+                "message_ts": "ts_1234",
+                "role": "release_engineer",
+                "display_name": "ReleaseEngineer",
+            },
+        }
+
+        with (
+            patch(
+                "vibeteam.gateway.routes.slack.remove_reaction",
+                new_callable=AsyncMock,
+                return_value=True,
+            ),
+            patch(
+                "vibeteam.gateway.routes.slack.add_reaction",
+                new_callable=AsyncMock,
+                return_value=True,
+            ),
+            patch(
+                "vibeteam.gateway.routes.slack.send_slack_message",
+                new_callable=AsyncMock,
+            ) as mock_send,
+        ):
+            response = test_client.post("/callback/agent", json=payload)
+
+            assert response.status_code == 200
+            assert response.json()["outcome"] == "timeout_posted"
+
+            sent_text = mock_send.call_args[0][1]
+            assert "ran out of time" in sent_text
+            assert "try again" in sent_text
+
+
+# ==============================================================================
+# Tests for /callback/agent/progress endpoint
+# ==============================================================================
+
+
+class TestProgressEndpoint:
+    """Test the POST /callback/agent/progress endpoint."""
+
+    def test_progress_posts_to_slack(self, test_client):
+        """Progress update posts a formatted message to Slack thread."""
+        payload = {
+            "job_id": "job-prog-1",
+            "step_number": 3,
+            "step_summary": "Running kubectl get pods",
+            "elapsed_seconds": 45,
+            "callback_metadata": {
+                "channel": "C_TEST",
+                "thread_ts": "ts_1234",
+                "display_name": "SupportEngineer",
+            },
+        }
+
+        with patch(
+            "vibeteam.gateway.routes.slack.send_slack_message",
+            new_callable=AsyncMock,
+        ) as mock_send:
+            response = test_client.post("/callback/agent/progress", json=payload)
+
+            assert response.status_code == 200
+            result = response.json()
+            assert result["status"] == "ok"
+
+            # Verify progress message sent
+            mock_send.assert_called_once()
+            sent_text = mock_send.call_args[0][1]
+            assert "Step 3" in sent_text
+            assert "kubectl get pods" in sent_text
+            assert "45s" in sent_text
+            # Should be italic (wrapped in underscores)
+            assert sent_text.startswith("_")
+            assert sent_text.endswith("_")
+
+    def test_progress_formats_minutes(self, test_client):
+        """Progress with elapsed > 60s formats as Xm YYs."""
+        payload = {
+            "job_id": "job-prog-2",
+            "step_number": 10,
+            "step_summary": "Analyzing Sentry errors",
+            "elapsed_seconds": 125,  # 2m05s
+            "callback_metadata": {
+                "channel": "C_TEST",
+                "thread_ts": "ts_1234",
+                "display_name": "SupportEngineer",
+            },
+        }
+
+        with patch(
+            "vibeteam.gateway.routes.slack.send_slack_message",
+            new_callable=AsyncMock,
+        ) as mock_send:
+            response = test_client.post("/callback/agent/progress", json=payload)
+
+            assert response.status_code == 200
+            sent_text = mock_send.call_args[0][1]
+            assert "2m05s" in sent_text
+
+    def test_progress_missing_channel_ignored(self, test_client):
+        """Progress without channel is ignored gracefully."""
+        payload = {
+            "job_id": "job-prog-3",
+            "step_number": 1,
+            "step_summary": "Starting",
+            "elapsed_seconds": 5,
+            "callback_metadata": {},  # No channel
+        }
+
+        response = test_client.post("/callback/agent/progress", json=payload)
+        assert response.status_code == 200
+        assert response.json()["status"] == "ignored"
+
+    def test_progress_missing_summary_ignored(self, test_client):
+        """Progress without step_summary is ignored."""
+        payload = {
+            "job_id": "job-prog-4",
+            "step_number": 1,
+            "step_summary": "",
+            "elapsed_seconds": 5,
+            "callback_metadata": {
+                "channel": "C_TEST",
+                "thread_ts": "ts_1234",
+            },
+        }
+
+        response = test_client.post("/callback/agent/progress", json=payload)
+        assert response.status_code == 200
+        assert response.json()["status"] == "ignored"
+
+    def test_progress_rejects_invalid_secret(self, test_client):
+        """Progress with wrong secret is rejected when CALLBACK_SECRET is set."""
+        payload = {
+            "job_id": "job-prog-bad",
+            "step_number": 1,
+            "step_summary": "Checking pods",
+            "elapsed_seconds": 10,
+            "callback_metadata": {
+                "channel": "C_TEST",
+                "thread_ts": "ts_1234",
+                "display_name": "SupportEngineer",
+                "callback_secret": "wrong-secret",
+            },
+        }
+
+        with patch("vibeteam.gateway.routes.slack.config") as mock_config:
+            mock_config.CALLBACK_SECRET = "correct-secret"
+
+            response = test_client.post("/callback/agent/progress", json=payload)
+            assert response.status_code == 403
+
+    def test_progress_invalid_json_returns_400(self, test_client):
+        """Progress with invalid JSON returns 400."""
+        response = test_client.post(
+            "/callback/agent/progress",
+            content="not json",
+            headers={"Content-Type": "application/json"},
+        )
+        assert response.status_code == 400
+
+
+# ==============================================================================
+# Tests for progress_url flowing through async pipeline
+# ==============================================================================
+
+
+class TestProgressUrlFlow:
+    """Test that progress_url is correctly wired through the async pipeline."""
+
+    @pytest.mark.asyncio
+    async def test_submit_passes_progress_url(self):
+        """_submit_agent_async passes progress_url to call_agent_service_async."""
+        from vibeteam.gateway.routes.slack import _submit_agent_async
+
+        with (
+            patch(
+                "vibeteam.gateway.routes.slack.add_reaction",
+                new_callable=AsyncMock,
+                return_value=True,
+            ),
+            patch(
+                "vibeteam.gateway.routes.slack.remove_reaction",
+                new_callable=AsyncMock,
+                return_value=True,
+            ),
+            patch(
+                "vibeteam.gateway.routes.slack.call_agent_service_async",
+                new_callable=AsyncMock,
+                return_value={"job_id": "test-job-progress", "status": "accepted"},
+            ) as mock_call,
+            patch("vibeteam.gateway.routes.slack.config") as mock_config,
+        ):
+            mock_config.GATEWAY_URL = "http://vibeteam-gateway:8080"
+            mock_config.CALLBACK_SECRET = ""
+
+            await _submit_agent_async(
+                role="support_engineer",
+                display_name="SupportEngineer",
+                user_message="check the errors",
+                channel="C_TEST",
+                thread_ts="ts_1234",
+                message_ts="msg_ts_1234",
+                user_id="U_USER",
+            )
+
+            mock_call.assert_called_once()
+            call_kwargs = mock_call.call_args[1]
+            # Verify progress_url was passed
+            assert "progress_url" in call_kwargs
+            assert "callback/agent/progress" in call_kwargs["progress_url"]
+
+
+# ==============================================================================
+# Tests for _execute_and_callback timeout behavior
+# ==============================================================================
+
+
+@pytest.mark.skipif(not _has_sqlalchemy, reason="sqlalchemy not installed")
+class TestExecuteAndCallbackTimeout:
+    """Test timeout behavior in _execute_and_callback."""
+
+    @pytest.mark.asyncio
+    async def test_timeout_sends_timeout_callback(self):
+        """When agent execution exceeds timeout, a timeout callback is sent."""
+        from agent_service.openhands.server import AsyncRunRequest, _execute_and_callback
+
+        request = AsyncRunRequest(
+            task="investigate the issue",
+            role="support_engineer",
+            context_type="slack",
+            context_id="C123:ts_456",
+            callback_url="http://gateway:8080/callback/agent",
+            callback_metadata={"channel": "C123", "thread_ts": "ts_456"},
+            execution_timeout=1,  # 1 second timeout for test
+        )
+
+        # Mock agent.run to take longer than timeout
+        async def slow_agent(*args, **kwargs):
+            import asyncio
+
+            await asyncio.sleep(10)
+            return {"response": "should never reach here"}
+
+        with (
+            patch("agent_service.openhands.server.get_team") as mock_team,
+            patch("httpx.AsyncClient") as mock_client_cls,
+        ):
+            mock_agent = MagicMock()
+            mock_agent.run.side_effect = lambda *a, **kw: __import__("time").sleep(10)
+            mock_team.return_value._get_agent.return_value = mock_agent
+
+            mock_client = AsyncMock()
+            mock_response = MagicMock()
+            mock_response.status_code = 200
+            mock_client.post.return_value = mock_response
+            mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+            mock_client.__aexit__ = AsyncMock(return_value=False)
+            mock_client_cls.return_value = mock_client
+
+            await _execute_and_callback("job-timeout-test", request)
+
+            # Verify callback was sent with timeout status
+            mock_client.post.assert_called_once()
+            call_args = mock_client.post.call_args
+            callback_url = call_args[0][0]
+            assert callback_url == "http://gateway:8080/callback/agent"
+
+            payload = call_args[1]["json"]
+            assert payload["status"] == "timeout"
+            assert payload["job_id"] == "job-timeout-test"
+            assert "timed out" in payload["error"]
+            assert payload["callback_metadata"]["channel"] == "C123"

--- a/tests/test_async_callback.py
+++ b/tests/test_async_callback.py
@@ -2,9 +2,9 @@
 Tests for the async agent callback architecture.
 
 Tests the complete async flow:
-1. Slack event -> gateway adds eyes reaction -> submits /run/async
+1. Slack event -> gateway adds thinking_face reaction -> submits /run/async
 2. Agent completes -> POSTs to /callback/agent
-3. Gateway removes spinner, posts response, adds checkmark
+3. Gateway removes thinking_face, posts response, adds checkmark
 4. Handoffs in callback submit new async jobs
 """
 
@@ -236,8 +236,8 @@ class TestCallbackEndpoint:
             assert result["status"] == "ok"
             assert result["outcome"] == "response_posted"
 
-            # Verify spinner removed
-            mock_remove.assert_called_once_with("C_TEST", "ts_1234", "arrows_counterclockwise")
+            # Verify thinking_face removed
+            mock_remove.assert_called_once_with("C_TEST", "ts_1234", "thinking_face")
 
             # Verify checkmark added
             mock_add.assert_called_once_with("C_TEST", "ts_1234", "white_check_mark")
@@ -699,9 +699,9 @@ class TestSubmitAgentAsync:
                 user_id="U_USER",
             )
 
-            # Verify reaction lifecycle: add spinner, remove eyes
-            mock_add.assert_called_once_with("C_TEST", "msg_ts_1234", "arrows_counterclockwise")
-            mock_remove.assert_called_once_with("C_TEST", "msg_ts_1234", "eyes")
+            # Verify no reaction lifecycle on success submit (thinking_face already added by event handler)
+            mock_add.assert_not_called()
+            mock_remove.assert_not_called()
 
             # Verify async service was called with callback URL
             mock_call.assert_called_once()
@@ -763,7 +763,7 @@ class TestSubmitAgentAsync:
                 "vibeteam.gateway.routes.slack.remove_reaction",
                 new_callable=AsyncMock,
                 return_value=True,
-            ),
+            ) as mock_remove,
             patch(
                 "vibeteam.gateway.routes.slack.call_agent_service_async",
                 new_callable=AsyncMock,
@@ -772,13 +772,8 @@ class TestSubmitAgentAsync:
             patch(
                 "vibeteam.gateway.routes.slack.send_slack_message",
                 new_callable=AsyncMock,
-                return_value="thinking_ts_123",
+                return_value="msg_ts_new",
             ) as mock_send,
-            patch(
-                "vibeteam.gateway.routes.slack.update_slack_message",
-                new_callable=AsyncMock,
-                return_value=True,
-            ) as mock_update,
             patch("vibeteam.gateway.routes.slack.config") as mock_config,
         ):
             mock_config.GATEWAY_URL = "http://vibeteam-gateway:8080"
@@ -794,15 +789,16 @@ class TestSubmitAgentAsync:
                 user_id="U_USER",
             )
 
-            # Should remove spinner and add X on failure
+            # Should remove thinking_face and add X on failure
+            remove_calls = [call[0] for call in mock_remove.call_args_list]
+            assert ("C_TEST", "msg_ts_1234", "thinking_face") in remove_calls
             add_calls = [call[0] for call in mock_add.call_args_list]
-            assert ("C_TEST", "msg_ts_1234", "arrows_counterclockwise") in add_calls
             assert ("C_TEST", "msg_ts_1234", "x") in add_calls
 
-            # Should update the thinking message with the error
-            mock_update.assert_called_once()
-            updated_text = mock_update.call_args[0][2]
-            assert "couldn't reach" in updated_text.lower() or "error" in updated_text.lower()
+            # Should post error as a new message (not update thinking message)
+            mock_send.assert_called_once()
+            sent_text = mock_send.call_args[0][1]
+            assert "couldn't reach" in sent_text.lower() or "error" in sent_text.lower()
 
 
 # ==============================================================================

--- a/tests/test_module_paths.py
+++ b/tests/test_module_paths.py
@@ -23,7 +23,6 @@ exactly as production would resolve paths.
 
 from __future__ import annotations
 
-import os
 import re
 from pathlib import Path
 
@@ -153,9 +152,7 @@ class TestModulePathConsistency:
     def test_agent_service_openhands_is_a_package(self):
         """agent_service/openhands/ must have __init__.py."""
         init = REPO_ROOT / "agent_service" / "openhands" / "__init__.py"
-        assert init.is_file(), (
-            "agent_service/openhands/__init__.py is missing."
-        )
+        assert init.is_file(), "agent_service/openhands/__init__.py is missing."
 
     @pytest.mark.parametrize(
         "filepath,description",
@@ -229,8 +226,8 @@ class TestNoStaleAgentsOpenhands:
 
     # Patterns that indicate a stale reference (Python module or dir path)
     STALE_PATTERNS = [
-        (r'\bagents\.openhands\.', "Python module path 'agents.openhands.'"),
-        (r'\bagents/openhands/', "Directory path 'agents/openhands/'"),
+        (r"\bagents\.openhands\.", "Python module path 'agents.openhands.'"),
+        (r"\bagents/openhands/", "Directory path 'agents/openhands/'"),
         (r'"agents",\s*"openhands"', 'os.path.join segment "agents", "openhands"'),
     ]
 

--- a/tests/test_system_prompt.py
+++ b/tests/test_system_prompt.py
@@ -554,8 +554,8 @@ class TestSoftwareEngineerIterationBudget:
     The github_issue eval fails when the SWE agent exhausts all iterations
     searching code without calling finish(). These tests ensure:
     1. The prompt has a FINAL REMINDER at the end about calling finish()
-    2. The iteration limit numbers are consistent (25 max, wrap up at 12)
-    3. max_iteration_per_run is set to 25 with iteration warning callbacks
+    2. The prompt mentions the execution time limit
+    3. No explicit max_iteration_per_run — SDK default (500) used, execution timeout is the safety net
     4. The GitHub Issue workflow includes an iteration check step
     5. FORBIDDEN ACTIONS section prevents sequential file reading
     6. ITERATION_WARNINGS dict and _inject_warning() exist at module level
@@ -625,46 +625,46 @@ class TestSoftwareEngineerIterationBudget:
             "FINAL REMINDER must escalate urgency for high iteration counts"
         )
 
-    def test_iteration_limit_is_25_in_prompt(self):
-        """The STRICT ITERATION LIMIT section must say 25, not 35."""
+    def test_execution_time_limit_in_prompt(self):
+        """The EXECUTION TIME LIMIT section must exist and mention time/timeout."""
         content = self._read_swe_context()
         ctx_start = content.find('SOFTWARE_ENGINEER_CONTEXT = """')
         ctx_end = content.find('"""', ctx_start + 30)
         assert ctx_start != -1 and ctx_end != -1, "SOFTWARE_ENGINEER_CONTEXT not found"
         ctx = content[ctx_start:ctx_end]
 
-        # Find the STRICT ITERATION LIMIT section
-        limit_start = ctx.find("STRICT ITERATION LIMIT")
-        assert limit_start != -1, "STRICT ITERATION LIMIT section not found"
+        # Find the EXECUTION TIME LIMIT section
+        limit_start = ctx.find("EXECUTION TIME LIMIT")
+        assert limit_start != -1, "EXECUTION TIME LIMIT section not found"
         # Get the next ~200 chars
         limit_section = ctx[limit_start : limit_start + 200]
 
-        assert "25" in limit_section, (
-            f"STRICT ITERATION LIMIT must mention 25 max iterations. Found: {limit_section[:100]}"
+        assert "10-minute" in limit_section or "timeout" in limit_section, (
+            f"EXECUTION TIME LIMIT must mention the time limit. Found: {limit_section[:100]}"
         )
 
-    def test_wrap_up_at_12_iterations(self):
-        """The prompt must tell the agent to wrap up at ~12 iterations."""
+    def test_prompt_mentions_finish_before_timeout(self):
+        """The prompt must tell the agent to call finish() before time runs out."""
         content = self._read_swe_context()
         ctx_start = content.find('SOFTWARE_ENGINEER_CONTEXT = """')
         ctx_end = content.find('"""', ctx_start + 30)
         ctx = content[ctx_start:ctx_end]
 
-        limit_start = ctx.find("STRICT ITERATION LIMIT")
+        limit_start = ctx.find("EXECUTION TIME LIMIT")
         assert limit_start != -1
         limit_section = ctx[limit_start : limit_start + 200]
 
-        assert "12" in limit_section, (
-            f"STRICT ITERATION LIMIT must tell agent to wrap up at ~12 calls. "
+        assert "finish()" in limit_section or "finish()" in ctx[limit_start:], (
+            f"EXECUTION TIME LIMIT must tell agent to call finish() before timeout. "
             f"Found: {limit_section[:100]}"
         )
 
-    def test_max_iteration_per_run_is_25(self):
-        """max_iteration_per_run must be set to 25 for SWE agent (with warning callbacks)."""
+    def test_no_explicit_max_iteration_per_run(self):
+        """max_iteration_per_run should NOT be set — rely on SDK default (500) and execution timeout."""
         content = self._read_swe_context()
-        assert "max_iteration_per_run=25" in content, (
-            "SWE agent must use max_iteration_per_run=25 with iteration warning callbacks. "
-            "Warnings at 12/17/20 replace the need for 35 iterations."
+        assert "max_iteration_per_run=" not in content, (
+            "SWE agent should not set max_iteration_per_run explicitly. "
+            "The SDK default (500) is used; the execution timeout (600s) is the real safety net."
         )
 
     def test_github_issue_workflow_has_iteration_check(self):
@@ -682,9 +682,9 @@ class TestSoftwareEngineerIterationBudget:
             "GitHub Issue workflow must include an iteration budget check step"
         )
 
-    def test_other_agents_still_use_25_iterations(self):
-        """SupportEngineer should use max_iteration_per_run=25, ReleaseEngineer uses 15."""
-        # SupportEngineer uses 25 iterations
+    def test_other_agents_no_explicit_max_iteration(self):
+        """SupportEngineer and ReleaseEngineer should NOT set explicit max_iteration_per_run."""
+        # SupportEngineer — uses SDK default (500), execution timeout is the safety net
         se_filepath = os.path.join(
             os.path.dirname(__file__),
             os.pardir,
@@ -694,11 +694,12 @@ class TestSoftwareEngineerIterationBudget:
         )
         with open(se_filepath) as f:
             se_content = f.read()
-        assert "max_iteration_per_run=25" in se_content, (
-            "support_engineer.py should use max_iteration_per_run=25."
+        assert "max_iteration_per_run=" not in se_content, (
+            "support_engineer.py should not set max_iteration_per_run explicitly. "
+            "The SDK default (500) is used; execution timeout is the real safety net."
         )
 
-        # ReleaseEngineer uses 15 iterations (reduced to prevent timeout)
+        # ReleaseEngineer — uses SDK default (500), execution timeout is the safety net
         re_filepath = os.path.join(
             os.path.dirname(__file__),
             os.pardir,
@@ -708,8 +709,9 @@ class TestSoftwareEngineerIterationBudget:
         )
         with open(re_filepath) as f:
             re_content = f.read()
-        assert "max_iteration_per_run=15" in re_content, (
-            "release_engineer.py should use max_iteration_per_run=15."
+        assert "max_iteration_per_run=" not in re_content, (
+            "release_engineer.py should not set max_iteration_per_run explicitly. "
+            "The SDK default (500) is used; execution timeout is the real safety net."
         )
 
     def test_has_forbidden_actions_section(self):
@@ -842,9 +844,9 @@ class TestSoftwareEngineerIterationBudget:
         assert "ITERATION_WARNING_THRESHOLDS" in content, (
             "ITERATION_WARNING_THRESHOLDS dict must be defined"
         )
-        # Verify thresholds match prompt (12, 17, 20)
-        assert "12:" in content and "17:" in content and "20:" in content, (
-            "ITERATION_WARNING_THRESHOLDS must have entries for 12, 17, and 20"
+        # Verify thresholds exist (50, 75, 100 — high limits since execution timeout is the real safety net)
+        assert "50:" in content and "75:" in content and "100:" in content, (
+            "ITERATION_WARNING_THRESHOLDS must have entries for 50, 75, and 100"
         )
 
     def test_inject_warning_function_exists(self):
@@ -898,7 +900,7 @@ class TestSoftwareEngineerIterationBudget:
         )
 
     def test_warning_thresholds_match_prompt(self):
-        """Warning thresholds (12, 17, 20) must match FINAL REMINDER section."""
+        """Warning guidance in FINAL REMINDER must use time-based language, not specific iteration counts."""
         content = self._read_swe_context()
         ctx_start = content.find('SOFTWARE_ENGINEER_CONTEXT = """')
         ctx_end = content.find('"""', ctx_start + 30)
@@ -908,15 +910,10 @@ class TestSoftwareEngineerIterationBudget:
         assert reminder_start != -1
         reminder_section = ctx[reminder_start:]
 
-        # Verify the same thresholds appear in both the prompt and the code
-        assert "12 tool calls" in reminder_section, (
-            "FINAL REMINDER must reference 12 tool calls (matches wrap_up threshold)"
-        )
-        assert "17 tool calls" in reminder_section, (
-            "FINAL REMINDER must reference 17 tool calls (matches emergency threshold)"
-        )
-        assert "20 tool calls" in reminder_section, (
-            "FINAL REMINDER must reference 20 tool calls (matches critical threshold)"
+        # Verify the FINAL REMINDER uses time-based guidance and mentions warnings
+        assert "finish()" in reminder_section, "FINAL REMINDER must tell agent to call finish()"
+        assert "warning" in reminder_section.lower(), (
+            "FINAL REMINDER must reference the injected warnings"
         )
 
     def test_prompt_mentions_system_warnings(self):

--- a/vibeteam/gateway/routes/slack.py
+++ b/vibeteam/gateway/routes/slack.py
@@ -249,20 +249,6 @@ async def update_slack_message(
         return False
 
 
-async def send_thinking_message(
-    channel: str,
-    display_name: str,
-    thread_ts: str | None = None,
-) -> str | None:
-    """Post a temporary 'thinking' message and return its ts.
-
-    The returned ts can later be passed to update_slack_message() to replace
-    the thinking indicator with the real agent response.
-    """
-    text = f":hourglass_flowing_sand: [{display_name}] Thinking..."
-    return await send_slack_message(channel, text, thread_ts)
-
-
 async def add_reaction(
     channel: str,
     timestamp: str,
@@ -781,7 +767,7 @@ async def _submit_agent_async(
 ) -> None:
     """Submit an agent task asynchronously via /run/async.
 
-    Posts a "Thinking..." indicator, transitions reactions (eyes → spinner),
+    Uses a :thinking_face: reaction as typing indicator (added by event handler),
     submits the task, and returns immediately.
     The agent service will POST results to /callback/agent when done.
     """
@@ -792,13 +778,6 @@ async def _submit_agent_async(
         channel=channel,
         thread_ts=thread_ts,
     )
-
-    # Post thinking indicator to the thread
-    thinking_ts = await send_thinking_message(channel, display_name, thread_ts)
-
-    # Transition reactions: add spinner, remove eyes
-    await add_reaction(channel, message_ts, "arrows_counterclockwise")
-    await remove_reaction(channel, message_ts, "eyes")
 
     # Build callback URL
     callback_url = f"{config.GATEWAY_URL}/callback/agent"
@@ -820,8 +799,6 @@ async def _submit_agent_async(
             "user_message": user_message,
             "max_handoff_depth": max_handoff_depth,
             "current_depth": current_depth,
-            # ts of the "Thinking..." message so callback can update it
-            "thinking_ts": thinking_ts,
             # Include callback secret for authentication
             # Agent service echoes this back; gateway verifies on receipt
             "callback_secret": config.CALLBACK_SECRET,
@@ -829,17 +806,13 @@ async def _submit_agent_async(
     )
 
     if "error" in result:
-        # Remove spinner, add X
-        await remove_reaction(channel, message_ts, "arrows_counterclockwise")
+        # Remove thinking face, add X
+        await remove_reaction(channel, message_ts, "thinking_face")
         await add_reaction(channel, message_ts, "x")
         error_text = (
             f"[{display_name}] Sorry, I couldn't reach the agent service: {result['error']}"
         )
-        # Update thinking message with error, or post new if thinking failed
-        if thinking_ts:
-            await update_slack_message(channel, thinking_ts, error_text)
-        else:
-            await send_slack_message(channel, error_text, thread_ts)
+        await send_slack_message(channel, error_text, thread_ts)
         logger.error(f"[ASYNC] Failed to submit task for {role}: {result['error']}")
     else:
         job_id = result.get("job_id", "unknown")
@@ -911,6 +884,7 @@ async def run_agent_for_slack(
                 channel=channel,
                 thread_ts=thread_ts,
                 user_id=user_id,
+                message_ts=effective_message_ts or None,
             )
 
 
@@ -921,6 +895,7 @@ async def _run_agent_and_respond(
     channel: str,
     thread_ts: str | None,
     user_id: str,
+    message_ts: str | None = None,
     max_handoff_depth: int = 3,
     current_depth: int = 0,
 ) -> None:
@@ -928,6 +903,8 @@ async def _run_agent_and_respond(
 
     This is the sync path — used by /slack/trigger and as fallback when
     message_ts is unavailable for async reaction management.
+
+    Uses :thinking_face: reaction as typing indicator (added by event handler).
 
     Supports synchronous handoffs: if the agent mentions /RoleName in its response,
     that agent is immediately invoked (up to max_handoff_depth to prevent infinite loops).
@@ -939,9 +916,6 @@ async def _run_agent_and_respond(
         channel=channel,
         thread_ts=thread_ts,
     )
-
-    # Post thinking indicator before calling agent
-    thinking_ts = await send_thinking_message(channel, display_name, thread_ts)
 
     agent_start_time = time.time()
     logger.info(f"[TIMING] Starting agent {role} (depth={current_depth})")
@@ -959,12 +933,17 @@ async def _run_agent_and_respond(
 
         if "error" in result:
             error_text = f"[{display_name}] Sorry, I encountered an error: {result['error']}"
-            if thinking_ts:
-                await update_slack_message(channel, thinking_ts, error_text)
-            else:
-                await send_slack_message(channel, error_text, thread_ts)
+            if message_ts:
+                await remove_reaction(channel, message_ts, "thinking_face")
+                await add_reaction(channel, message_ts, "x")
+            await send_slack_message(channel, error_text, thread_ts)
         else:
             response = result.get("response", "I completed the task but have no output to share.")
+
+            # Remove thinking face, add checkmark
+            if message_ts:
+                await remove_reaction(channel, message_ts, "thinking_face")
+                await add_reaction(channel, message_ts, "white_check_mark")
 
             # Split long responses into multiple messages instead of truncating
             # This preserves handoff mentions that might be at the end
@@ -973,14 +952,8 @@ async def _run_agent_and_respond(
             # Send each chunk as a separate message
             for i, chunk in enumerate(chunks):
                 if i == 0:
-                    # First chunk: update thinking message or post new
                     formatted_chunk = f"[{display_name}] {chunk}"
-                    if thinking_ts:
-                        await update_slack_message(channel, thinking_ts, formatted_chunk)
-                    else:
-                        await send_slack_message(channel, formatted_chunk, thread_ts)
                 else:
-                    # Continuation chunks are always new messages
                     formatted_chunk = f"[{display_name} (cont.)] {chunk}"
                 await send_slack_message(channel, formatted_chunk, thread_ts)
 
@@ -1033,10 +1006,10 @@ async def _run_agent_and_respond(
         error_text = (
             f"[{display_name}] Sorry, I encountered an unexpected error. Please try again later."
         )
-        if thinking_ts:
-            await update_slack_message(channel, thinking_ts, error_text)
-        else:
-            await send_slack_message(channel, error_text, thread_ts)
+        if message_ts:
+            await remove_reaction(channel, message_ts, "thinking_face")
+            await add_reaction(channel, message_ts, "x")
+        await send_slack_message(channel, error_text, thread_ts)
 
 
 # ==============================================================================
@@ -1053,8 +1026,8 @@ async def handle_agent_callback(request: Request) -> dict[str, Any]:
     - callback_metadata (Slack context: channel, thread_ts, message_ts, role, etc.)
 
     This endpoint:
-    1. Removes the spinner reaction
-    2. Posts the response (or error) to Slack
+    1. Removes the :thinking_face: reaction
+    2. Posts the response (or error) to Slack as a new message
     3. Checks for handoff mentions and submits new async jobs if needed
     """
     try:
@@ -1077,7 +1050,6 @@ async def handle_agent_callback(request: Request) -> dict[str, Any]:
     user_id = meta.get("user_id", "")
     max_handoff_depth = meta.get("max_handoff_depth", 3)
     current_depth = meta.get("current_depth", 0)
-    thinking_ts = meta.get("thinking_ts")
 
     logger.info(f"[CALLBACK] Received callback for job {job_id}: status={status}, role={role}")
 
@@ -1093,9 +1065,9 @@ async def handle_agent_callback(request: Request) -> dict[str, Any]:
         logger.error(f"[CALLBACK] Missing channel in callback_metadata for job {job_id}")
         return {"status": "error", "detail": "missing channel in callback_metadata"}
 
-    # Remove spinner reaction
+    # Remove thinking_face reaction
     if message_ts:
-        await remove_reaction(channel, message_ts, "arrows_counterclockwise")
+        await remove_reaction(channel, message_ts, "thinking_face")
 
     if status == "failed" or error:
         # Failure path
@@ -1103,11 +1075,7 @@ async def handle_agent_callback(request: Request) -> dict[str, Any]:
             await add_reaction(channel, message_ts, "x")
         error_msg = error or "Unknown error"
         error_text = f"[{display_name}] Sorry, I encountered an error: {error_msg}"
-        # Update thinking message with error, or post new if thinking failed
-        if thinking_ts:
-            await update_slack_message(channel, thinking_ts, error_text)
-        else:
-            await send_slack_message(channel, error_text, thread_ts)
+        await send_slack_message(channel, error_text, thread_ts)
         return {"status": "ok", "job_id": job_id, "outcome": "error_posted"}
 
     # Success path
@@ -1122,15 +1090,9 @@ async def handle_agent_callback(request: Request) -> dict[str, Any]:
     for i, chunk in enumerate(chunks):
         if i == 0:
             formatted_chunk = f"[{display_name}] {chunk}"
-            # Update thinking message with first chunk, or post new if no thinking msg
-            if thinking_ts:
-                await update_slack_message(channel, thinking_ts, formatted_chunk)
-            else:
-                await send_slack_message(channel, formatted_chunk, thread_ts)
         else:
-            # Continuation chunks are always new messages
             formatted_chunk = f"[{display_name} (cont.)] {chunk}"
-            await send_slack_message(channel, formatted_chunk, thread_ts)
+        await send_slack_message(channel, formatted_chunk, thread_ts)
 
     # Check for handoffs in the response
     message_router = get_message_router()
@@ -1232,8 +1194,8 @@ async def handle_slack_events(
         # Remove the bot mention from the text
         clean_text = re.sub(r"<@[A-Z0-9]+>\s*", "", text).strip()
 
-        # React with eyes to show we're looking at the message
-        await add_reaction(channel, message_ts, "eyes")
+        # React with thinking face to show we're working on it
+        await add_reaction(channel, message_ts, "thinking_face")
 
         # Process in background
         asyncio.create_task(
@@ -1250,8 +1212,8 @@ async def handle_slack_events(
         message_ts = event.get("ts", "")
         thread_ts = event.get("thread_ts") or message_ts
 
-        # React with eyes to show we're looking at the message
-        await add_reaction(channel, message_ts, "eyes")
+        # React with thinking face to show we're working on it
+        await add_reaction(channel, message_ts, "thinking_face")
 
         # Process in background
         asyncio.create_task(
@@ -1316,7 +1278,7 @@ async def handle_slack_events(
                     f"{[s.agent_role for s in subscriptions]}. Processing message."
                 )
 
-            await add_reaction(channel, message_ts, "eyes")
+            await add_reaction(channel, message_ts, "thinking_face")
 
             asyncio.create_task(
                 run_agent_for_slack(text, channel, thread_ts, user_id, message_ts=message_ts)
@@ -1333,8 +1295,8 @@ async def handle_slack_events(
         thread_ts = event.get("thread_ts") or message_ts
         user_id = event.get("bot_id", "bot")  # Use bot_id as user_id for bot messages
 
-        # React with eyes to show we're processing the message
-        await add_reaction(channel, message_ts, "eyes")
+        # React with thinking face to show we're processing the message
+        await add_reaction(channel, message_ts, "thinking_face")
 
         # Process in background
         asyncio.create_task(

--- a/vibeteam/gateway/routes/slack.py
+++ b/vibeteam/gateway/routes/slack.py
@@ -781,6 +781,7 @@ async def _submit_agent_async(
 
     # Build callback URL
     callback_url = f"{config.GATEWAY_URL}/callback/agent"
+    progress_url = f"{config.GATEWAY_URL}/callback/agent/progress"
 
     # Submit async task
     result = await call_agent_service_async(
@@ -789,6 +790,7 @@ async def _submit_agent_async(
         context_type="slack",
         context_id=f"{channel}:{thread_ts or 'new'}",
         callback_url=callback_url,
+        progress_url=progress_url,
         callback_metadata={
             "channel": channel,
             "thread_ts": thread_ts,
@@ -1069,6 +1071,19 @@ async def handle_agent_callback(request: Request) -> dict[str, Any]:
     if message_ts:
         await remove_reaction(channel, message_ts, "thinking_face")
 
+    if status == "timeout":
+        # Timeout path — agent ran out of time
+        if message_ts:
+            await add_reaction(channel, message_ts, "hourglass")
+        # Post partial response if available, otherwise generic timeout message
+        timeout_response = response_text or (
+            "Sorry, I ran out of time working on this task. "
+            "Please try again or break the request into smaller steps."
+        )
+        timeout_text = f"[{display_name}] :hourglass: {timeout_response}"
+        await send_slack_message(channel, timeout_text, thread_ts)
+        return {"status": "ok", "job_id": job_id, "outcome": "timeout_posted"}
+
     if status == "failed" or error:
         # Failure path
         if message_ts:
@@ -1127,6 +1142,62 @@ async def handle_agent_callback(request: Request) -> dict[str, Any]:
         )
 
     return {"status": "ok", "job_id": job_id, "outcome": "response_posted"}
+
+
+# ==============================================================================
+# Progress callback endpoint for agent intermediate updates
+# ==============================================================================
+
+
+@router.post("/callback/agent/progress")
+async def handle_agent_progress(request: Request) -> dict[str, Any]:
+    """Handle progress updates from agent service while agent is working.
+
+    The agent service POSTs here periodically with:
+    - job_id, step_number, step_summary, elapsed_seconds
+    - callback_metadata (Slack context: channel, thread_ts, etc.)
+
+    This endpoint posts a progress message to the Slack thread so users
+    can see what the agent is doing instead of just seeing :thinking_face:.
+    """
+    try:
+        payload = await request.json()
+    except Exception:
+        raise HTTPException(status_code=400, detail="Invalid JSON body") from None
+
+    job_id = payload.get("job_id", "unknown")
+    step_number = payload.get("step_number", 0)
+    step_summary = payload.get("step_summary", "")
+    elapsed_seconds = payload.get("elapsed_seconds", 0)
+    meta = payload.get("callback_metadata", {})
+
+    channel = meta.get("channel", "")
+    thread_ts = meta.get("thread_ts")
+    display_name = meta.get("display_name", meta.get("role", "Agent"))
+
+    if not channel or not step_summary:
+        return {"status": "ignored", "reason": "missing channel or step_summary"}
+
+    # Verify callback authentication
+    if config.CALLBACK_SECRET:
+        callback_secret = meta.get("callback_secret", "")
+        if callback_secret != config.CALLBACK_SECRET:
+            logger.warning(f"[PROGRESS] Invalid callback_secret for job {job_id}")
+            raise HTTPException(status_code=403, detail="Invalid callback secret")
+
+    # Format elapsed time
+    mins, secs = divmod(elapsed_seconds, 60)
+    time_str = f"{mins}m{secs:02d}s" if mins > 0 else f"{secs}s"
+
+    # Post progress as a subtle update
+    progress_text = f"_[{display_name}] Step {step_number} ({time_str}): {step_summary}_"
+    await send_slack_message(channel, progress_text, thread_ts)
+
+    logger.info(
+        f"[PROGRESS] job={job_id} step={step_number} elapsed={time_str}: {step_summary[:80]}"
+    )
+
+    return {"status": "ok", "job_id": job_id}
 
 
 # ==============================================================================

--- a/vibeteam/gateway/routes/slack.py
+++ b/vibeteam/gateway/routes/slack.py
@@ -947,6 +947,13 @@ async def _run_agent_and_respond(
                 await remove_reaction(channel, message_ts, "thinking_face")
                 await add_reaction(channel, message_ts, "white_check_mark")
 
+            # Build display prefix with model info if available
+            model_name = result.get("model", "")
+            if model_name:
+                agent_prefix = f"[{display_name}:{model_name}]"
+            else:
+                agent_prefix = f"[{display_name}]"
+
             # Split long responses into multiple messages instead of truncating
             # This preserves handoff mentions that might be at the end
             chunks = split_long_message(response)
@@ -954,9 +961,9 @@ async def _run_agent_and_respond(
             # Send each chunk as a separate message
             for i, chunk in enumerate(chunks):
                 if i == 0:
-                    formatted_chunk = f"[{display_name}] {chunk}"
+                    formatted_chunk = f"{agent_prefix} {chunk}"
                 else:
-                    formatted_chunk = f"[{display_name} (cont.)] {chunk}"
+                    formatted_chunk = f"{agent_prefix} (cont.) {chunk}"
                 await send_slack_message(channel, formatted_chunk, thread_ts)
 
             # Check for handoffs in the response and execute them synchronously
@@ -1099,14 +1106,22 @@ async def handle_agent_callback(request: Request) -> dict[str, Any]:
 
     response = response_text or "I completed the task but have no output to share."
 
+    # Build display prefix with model info if available
+    result_metadata = payload.get("metadata", {})
+    model_name = result_metadata.get("model", "")
+    if model_name:
+        agent_prefix = f"[{display_name}:{model_name}]"
+    else:
+        agent_prefix = f"[{display_name}]"
+
     # Split long responses into multiple messages
     chunks = split_long_message(response)
 
     for i, chunk in enumerate(chunks):
         if i == 0:
-            formatted_chunk = f"[{display_name}] {chunk}"
+            formatted_chunk = f"{agent_prefix} {chunk}"
         else:
-            formatted_chunk = f"[{display_name} (cont.)] {chunk}"
+            formatted_chunk = f"{agent_prefix} (cont.) {chunk}"
         await send_slack_message(channel, formatted_chunk, thread_ts)
 
     # Check for handoffs in the response

--- a/vibeteam/gateway/server.py
+++ b/vibeteam/gateway/server.py
@@ -284,6 +284,7 @@ async def call_agent_service_async(
     context_id: str | None = None,
     callback_url: str = "",
     callback_metadata: dict[str, Any] | None = None,
+    progress_url: str | None = None,
 ) -> dict[str, Any]:
     """
     Submit a task to the agent service asynchronously.
@@ -300,6 +301,7 @@ async def call_agent_service_async(
         context_id: Context ID for session tracking
         callback_url: URL where agent should POST results
         callback_metadata: Opaque data passed through to callback
+        progress_url: URL where agent should POST progress updates (optional)
 
     Returns:
         {"job_id": "...", "status": "accepted"} or {"error": "..."}
@@ -328,6 +330,10 @@ async def call_agent_service_async(
     if fw == "openhands":
         payload["use_tools"] = True
         payload["skip_context_injection"] = False
+
+    # Pass progress_url so agent service can send intermediate updates
+    if progress_url:
+        payload["progress_url"] = progress_url
 
     try:
         client = get_http_client()


### PR DESCRIPTION
## Summary

- Add execution timeout (default 600s) to prevent agents from hanging indefinitely when LLM inference gets stuck
- Add `/callback/agent/progress` endpoint for intermediate progress updates from agents to Slack
- Wire `progress_url` through gateway → agent service for future progress reporting
- Handle `status="timeout"` in gateway callback (hourglass reaction + user notification)
- Set explicit `timeout=300, num_retries=3` on all 5 agent `AzureLLM()` constructors

## Root Cause

A production incident showed the ReleaseEngineer agent hung after 15 tool actions — the 16th LLM inference call hung indefinitely with no timeout, no error, and no callback. The "Thinking..." indicator stayed forever. Both pods had restarted ~15 minutes prior (git-sync rollout), possibly causing Azure OpenAI connection instability.

## Changes

### Agent Service (`agent_service/openhands/server.py`)
- `AsyncRunRequest`: Added `execution_timeout` (default 600s) and `progress_url` fields
- `ProgressPayload`: New model for progress updates
- `_send_progress()`: Helper to POST progress updates (best-effort)
- `_execute_and_callback()`: Wrapped both `role` and `team.run_async` paths in `asyncio.wait_for(..., timeout=execution_timeout)` — on `TimeoutError`, sends callback with `status="timeout"` and partial response

### Gateway (`vibeteam/gateway/routes/slack.py`)
- Callback handler: Handles `status == "timeout"` — adds `:hourglass:` reaction, posts timeout message with partial response
- New `POST /callback/agent/progress` endpoint: Receives progress updates, posts italicized progress messages to Slack thread
- `_submit_agent_async`: Builds and passes `progress_url`

### Gateway Server (`vibeteam/gateway/server.py`)
- `call_agent_service_async()`: Accepts and forwards `progress_url` in payload

### All Agent Files
- `release_engineer.py`, `support_engineer.py`, `software_engineer.py`, `marketing_manager.py`, `product_manager.py`: Explicit `timeout=300, num_retries=3` on `AzureLLM()` constructor

### Tests (`tests/test_async_callback.py`)
- 8 new test cases: timeout callback handling, progress endpoint (auth, posting, metadata), progress_url wiring, execute_and_callback timeout behavior

## Testing

All 608 unit tests pass, 0 failures.