### PR TITLE
fix: prevent duplicate handoff execution, add concurrency controls (#105)

### DIFF
--- a/agent_service/openhands/server.py
+++ b/agent_service/openhands/server.py
@@ -28,6 +28,21 @@ from .team import OpenHandsTeam, create_team
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
 
+# Concurrency control: limit the number of simultaneous agent executions
+# to prevent resource exhaustion when multiple jobs arrive concurrently.
+# Default: 3 concurrent jobs (configurable via MAX_CONCURRENT_JOBS env var).
+MAX_CONCURRENT_JOBS = int(os.environ.get("MAX_CONCURRENT_JOBS", "3"))
+_job_semaphore: asyncio.Semaphore | None = None
+
+
+def _get_semaphore() -> asyncio.Semaphore:
+    """Lazily create the semaphore (must be created inside event loop)."""
+    global _job_semaphore
+    if _job_semaphore is None:
+        _job_semaphore = asyncio.Semaphore(MAX_CONCURRENT_JOBS)
+        logger.info(f"Initialized job semaphore with max_concurrent_jobs={MAX_CONCURRENT_JOBS}")
+    return _job_semaphore
+
 
 # Request/Response Models
 class RunRequest(BaseModel):
@@ -345,206 +360,230 @@ async def _execute_and_callback(
     - Overall execution timeout (default 600s / 10 min) prevents infinite hangs
     - On timeout, extracts partial results from whatever events exist
     - Sends progress updates to request.progress_url if provided
+    - Concurrency limited by semaphore to prevent resource exhaustion
     """
     import httpx
 
-    start_time = time.time()
-    context_id = request.context_id or str(uuid.uuid4())[:8]
-    execution_timeout = request.execution_timeout
+    semaphore = _get_semaphore()
+    logger.info(
+        f"[job={job_id}] Waiting for semaphore "
+        f"(active={MAX_CONCURRENT_JOBS - semaphore._value}/{MAX_CONCURRENT_JOBS})"
+    )
 
-    try:
-        team = get_team()
-        role = request.role
+    async with semaphore:
+        start_time = time.time()
+        context_id = request.context_id or str(uuid.uuid4())[:8]
+        execution_timeout = request.execution_timeout
 
-        logger.info(
-            f"[job={job_id}] Starting agent execution: role={role}, timeout={execution_timeout}s"
-        )
-
-        if role:
-            agent = team._get_agent(role)
-            # Wrap agent.run in asyncio.wait_for to enforce overall timeout.
-            # This prevents the agent from hanging forever if an LLM call gets stuck.
-            try:
-                result = await asyncio.wait_for(
-                    asyncio.to_thread(
-                        agent.run,
-                        task=request.task,
-                        context_type=request.context_type,
-                        context_id=context_id,
-                        workspace=request.workspace,
-                        use_tools=request.use_tools,
-                        skip_context_injection=request.skip_context_injection,
-                        # Progress callback params — agents use these to send
-                        # real-time updates to the gateway while working
-                        progress_url=request.progress_url,
-                        job_id=job_id,
-                        callback_metadata=request.callback_metadata,
-                    ),
-                    timeout=execution_timeout,
-                )
-            except asyncio.TimeoutError:
-                elapsed = int(time.time() - start_time)
-                logger.error(
-                    f"[job={job_id}] Agent execution timed out after {elapsed}s "
-                    f"(limit={execution_timeout}s)"
-                )
-                agent_role = role or "team"
-
-                # Send timeout callback
-                payload = CallbackPayload(
-                    job_id=job_id,
-                    status="timeout",
-                    error=f"Agent execution timed out after {elapsed}s",
-                    response=(
-                        f"I was working on this task but ran out of time after "
-                        f"{elapsed} seconds. The operation was cancelled. "
-                        f"Please try again or break the task into smaller steps."
-                    ),
-                    agents_used=[agent_role],
-                    metadata={
-                        "latency_ms": elapsed * 1000,
-                        "timeout_seconds": execution_timeout,
-                        "timed_out": True,
-                    },
-                    callback_metadata=request.callback_metadata,
-                )
-                # Jump to callback sending
-                try:
-                    async with httpx.AsyncClient() as client:
-                        cb_response = await client.post(
-                            request.callback_url,
-                            json=payload.model_dump(),
-                            timeout=30.0,
-                        )
-                        logger.info(
-                            f"[job={job_id}] Timeout callback sent: "
-                            f"status={cb_response.status_code}"
-                        )
-                except Exception as e:
-                    logger.error(f"[job={job_id}] Failed to send timeout callback: {e}")
-                return
-        else:
-            try:
-                result = await asyncio.wait_for(
-                    team.run_async(
-                        task=request.task,
-                        context_type=request.context_type,
-                        context_id=context_id,
-                        workspace=request.workspace,
-                    ),
-                    timeout=execution_timeout,
-                )
-            except asyncio.TimeoutError:
-                elapsed = int(time.time() - start_time)
-                logger.error(f"[job={job_id}] Team execution timed out after {elapsed}s")
-                payload = CallbackPayload(
-                    job_id=job_id,
-                    status="timeout",
-                    error=f"Agent execution timed out after {elapsed}s",
-                    response=(
-                        f"I was working on this task but ran out of time after "
-                        f"{elapsed} seconds. The operation was cancelled. "
-                        f"Please try again or break the task into smaller steps."
-                    ),
-                    agents_used=["team"],
-                    metadata={
-                        "latency_ms": elapsed * 1000,
-                        "timeout_seconds": execution_timeout,
-                        "timed_out": True,
-                    },
-                    callback_metadata=request.callback_metadata,
-                )
-                try:
-                    async with httpx.AsyncClient() as client:
-                        cb_response = await client.post(
-                            request.callback_url,
-                            json=payload.model_dump(),
-                            timeout=30.0,
-                        )
-                        logger.info(
-                            f"[job={job_id}] Timeout callback sent: "
-                            f"status={cb_response.status_code}"
-                        )
-                except Exception as e:
-                    logger.error(f"[job={job_id}] Failed to send timeout callback: {e}")
-                return
-
-        latency_ms = int((time.time() - start_time) * 1000)
-        agent_role = result.get("agent", role or "team")
-        session_key = f"openhands:{agent_role}:{request.context_type}:{context_id}"
-
-        # Save to PostgreSQL
         try:
-            store = get_postgres_store()
-            await store.save(
-                {
-                    "key": session_key,
-                    "framework": "openhands",
-                    "role": agent_role,
-                    "context_type": request.context_type,
-                    "context_id": context_id,
-                    "messages": [
-                        {
-                            "role": "user",
-                            "content": request.task,
-                            "timestamp": datetime.now(timezone.utc).isoformat(),
-                        },
-                        {
-                            "role": "assistant",
-                            "content": result.get("response", ""),
-                            "timestamp": datetime.now(timezone.utc).isoformat(),
-                        },
-                    ],
-                }
-            )
-        except Exception as e:
-            logger.warning(f"[job={job_id}] Failed to save session to PostgreSQL: {e}")
+            team = get_team()
+            role = request.role
 
-        # Build callback payload
-        payload = CallbackPayload(
-            job_id=job_id,
-            status="completed",
-            response=result.get("response", ""),
-            session_id=result.get("session_id", context_id),
-            session_key=session_key,
-            agents_used=[agent_role],
-            metadata={
-                "latency_ms": latency_ms,
-                "message_count": 2,
-                "workspace": request.workspace,
-                "model": result.get("model", ""),
-            },
-            callback_metadata=request.callback_metadata,
-        )
-
-        logger.info(
-            f"[job={job_id}] Agent completed in {latency_ms}ms, "
-            f"response_len={len(payload.response)}, sending callback"
-        )
-
-    except Exception as e:
-        logger.error(f"[job={job_id}] Agent execution failed: {e}")
-        payload = CallbackPayload(
-            job_id=job_id,
-            status="failed",
-            error=str(e),
-            callback_metadata=request.callback_metadata,
-        )
-
-    # POST result to callback URL
-    try:
-        async with httpx.AsyncClient() as client:
-            cb_response = await client.post(
-                request.callback_url,
-                json=payload.model_dump(),
-                timeout=30.0,
-            )
             logger.info(
-                f"[job={job_id}] Callback sent to {request.callback_url}: "
-                f"status={cb_response.status_code}"
+                f"[job={job_id}] Starting agent execution: role={role}, timeout={execution_timeout}s"
             )
-    except Exception as e:
-        logger.error(f"[job={job_id}] Failed to send callback to {request.callback_url}: {e}")
+
+            if role:
+                agent = team._get_agent(role)
+                # Wrap agent.run in asyncio.wait_for to enforce overall timeout.
+                # This prevents the agent from hanging forever if an LLM call gets stuck.
+                try:
+                    result = await asyncio.wait_for(
+                        asyncio.to_thread(
+                            agent.run,
+                            task=request.task,
+                            context_type=request.context_type,
+                            context_id=context_id,
+                            workspace=request.workspace,
+                            use_tools=request.use_tools,
+                            skip_context_injection=request.skip_context_injection,
+                            # Progress callback params — agents use these to send
+                            # real-time updates to the gateway while working
+                            progress_url=request.progress_url,
+                            job_id=job_id,
+                            callback_metadata=request.callback_metadata,
+                        ),
+                        timeout=execution_timeout,
+                    )
+                except asyncio.TimeoutError:
+                    elapsed = int(time.time() - start_time)
+                    logger.error(
+                        f"[job={job_id}] Agent execution timed out after {elapsed}s "
+                        f"(limit={execution_timeout}s)"
+                    )
+                    agent_role = role or "team"
+
+                    # Send timeout callback
+                    payload = CallbackPayload(
+                        job_id=job_id,
+                        status="timeout",
+                        error=f"Agent execution timed out after {elapsed}s",
+                        response=(
+                            f"I was working on this task but ran out of time after "
+                            f"{elapsed} seconds. The operation was cancelled. "
+                            f"Please try again or break the task into smaller steps."
+                        ),
+                        agents_used=[agent_role],
+                        metadata={
+                            "latency_ms": elapsed * 1000,
+                            "timeout_seconds": execution_timeout,
+                            "timed_out": True,
+                        },
+                        callback_metadata=request.callback_metadata,
+                    )
+                    # Jump to callback sending (with retry for resilience)
+                    for attempt in range(3):
+                        try:
+                            async with httpx.AsyncClient() as client:
+                                cb_response = await client.post(
+                                    request.callback_url,
+                                    json=payload.model_dump(),
+                                    timeout=30.0,
+                                )
+                                logger.info(
+                                    f"[job={job_id}] Timeout callback sent: "
+                                    f"status={cb_response.status_code}"
+                                )
+                            break  # Success — exit retry loop
+                        except Exception as e:
+                            logger.error(
+                                f"[job={job_id}] Failed to send timeout callback "
+                                f"(attempt {attempt + 1}/3): {repr(e)}"
+                            )
+                            if attempt < 2:
+                                await asyncio.sleep(2**attempt)  # Exponential backoff
+                    return
+            else:
+                try:
+                    result = await asyncio.wait_for(
+                        team.run_async(
+                            task=request.task,
+                            context_type=request.context_type,
+                            context_id=context_id,
+                            workspace=request.workspace,
+                        ),
+                        timeout=execution_timeout,
+                    )
+                except asyncio.TimeoutError:
+                    elapsed = int(time.time() - start_time)
+                    logger.error(f"[job={job_id}] Team execution timed out after {elapsed}s")
+                    payload = CallbackPayload(
+                        job_id=job_id,
+                        status="timeout",
+                        error=f"Agent execution timed out after {elapsed}s",
+                        response=(
+                            f"I was working on this task but ran out of time after "
+                            f"{elapsed} seconds. The operation was cancelled. "
+                            f"Please try again or break the task into smaller steps."
+                        ),
+                        agents_used=["team"],
+                        metadata={
+                            "latency_ms": elapsed * 1000,
+                            "timeout_seconds": execution_timeout,
+                            "timed_out": True,
+                        },
+                        callback_metadata=request.callback_metadata,
+                    )
+                    for attempt in range(3):
+                        try:
+                            async with httpx.AsyncClient() as client:
+                                cb_response = await client.post(
+                                    request.callback_url,
+                                    json=payload.model_dump(),
+                                    timeout=30.0,
+                                )
+                                logger.info(
+                                    f"[job={job_id}] Timeout callback sent: "
+                                    f"status={cb_response.status_code}"
+                                )
+                            break
+                        except Exception as e:
+                            logger.error(
+                                f"[job={job_id}] Failed to send timeout callback "
+                                f"(attempt {attempt + 1}/3): {repr(e)}"
+                            )
+                            if attempt < 2:
+                                await asyncio.sleep(2**attempt)
+                    return
+
+            latency_ms = int((time.time() - start_time) * 1000)
+            agent_role = result.get("agent", role or "team")
+            session_key = f"openhands:{agent_role}:{request.context_type}:{context_id}"
+
+            # Save to PostgreSQL
+            try:
+                store = get_postgres_store()
+                await store.save(
+                    {
+                        "key": session_key,
+                        "framework": "openhands",
+                        "role": agent_role,
+                        "context_type": request.context_type,
+                        "context_id": context_id,
+                        "messages": [
+                            {
+                                "role": "user",
+                                "content": request.task,
+                                "timestamp": datetime.now(timezone.utc).isoformat(),
+                            },
+                            {
+                                "role": "assistant",
+                                "content": result.get("response", ""),
+                                "timestamp": datetime.now(timezone.utc).isoformat(),
+                            },
+                        ],
+                    }
+                )
+            except Exception as e:
+                logger.warning(f"[job={job_id}] Failed to save session to PostgreSQL: {e}")
+
+            # Build callback payload
+            payload = CallbackPayload(
+                job_id=job_id,
+                status="completed",
+                response=result.get("response", ""),
+                session_id=result.get("session_id", context_id),
+                session_key=session_key,
+                agents_used=[agent_role],
+                metadata={
+                    "latency_ms": latency_ms,
+                    "message_count": 2,
+                    "workspace": request.workspace,
+                    "model": result.get("model", ""),
+                },
+                callback_metadata=request.callback_metadata,
+            )
+
+            logger.info(
+                f"[job={job_id}] Agent completed in {latency_ms}ms, "
+                f"response_len={len(payload.response)}, sending callback"
+            )
+
+        except Exception as e:
+            logger.error(f"[job={job_id}] Agent execution failed: {e}")
+            payload = CallbackPayload(
+                job_id=job_id,
+                status="failed",
+                error=str(e),
+                callback_metadata=request.callback_metadata,
+            )
+
+        # POST result to callback URL
+        try:
+            async with httpx.AsyncClient() as client:
+                cb_response = await client.post(
+                    request.callback_url,
+                    json=payload.model_dump(),
+                    timeout=30.0,
+                )
+                logger.info(
+                    f"[job={job_id}] Callback sent to {request.callback_url}: "
+                    f"status={cb_response.status_code}"
+                )
+        except Exception as e:
+            logger.error(
+                f"[job={job_id}] Failed to send callback to {request.callback_url}: {repr(e)}"
+            )
 
 
 @app.post("/run/async", response_model=AsyncRunResponse)

--- a/plan.md
+++ b/plan.md
@@ -3,47 +3,27 @@
 **Date:** 2026-02-13
 **Status:** NOT production ready -- 3 high-severity, 3 medium-severity issues
 
-## Evaluation Test Results
+## Current Task: Fix stripe_webhook_failure eval (Issue #105)
 
-Ran `support_400_errors` scenario against live cluster:
+### Goal
+Fix 3 bugs causing the `stripe_webhook_failure` eval to fail:
 
-| Metric | Score | Threshold | Result |
-|--------|-------|-----------|--------|
-| InvestigationQuality | 0.00 | 0.60 | FAIL |
-| EvidenceBasedDecision | 0.00 | 0.60 | FAIL |
-| HandoffCompletion | 0.00 | 0.60 | FAIL |
+1. [x] Duplicate handoff execution — bot messages re-processed by Slack event handler
+2. [x] Timeout callback error logging — `{e}` produces empty string, no retry
+3. [x] No concurrency controls — unlimited agent executions cause queue starvation
+4. [x] Tests pass (509/509)
+5. [ ] Deploy fixes to cluster
+6. [ ] Re-run stripe_webhook_failure eval and verify pass
+7. [ ] Create PR with results
 
-**Root cause of 0.00 scores:** The agent *did* produce a thorough investigation
-(Sentry queries, kubectl checks, curl tests, root cause analysis) but the eval
-script terminated after 15 seconds of "stable" message count, before the agent
-finished (~86 seconds). The "Thinking..." messages were never replaced in the
-eval's view because `chat.update` doesn't change message count.
-
-The agent's actual response (found in openhands-svc logs at 02:30:04) included:
-- Sentry findings (3 issues found)
-- kubectl pod status review
-- Gateway log analysis
-- Endpoint curl tests
-- Evidence-based root cause analysis
-- Actionable recommendations
-
-## Issues Found (Priority Order)
-
-### HIGH SEVERITY
-
-- [x] 1. PostgreSQL session persistence broken (UUID type mismatch)
-- [x] 2. Database schema drift (3 conflicting definitions)
-- [x] 3. Missing production K8s infrastructure
-
-### MEDIUM SEVERITY
-
-- [x] 4. Eval script timing bug (message counting vs content detection)
-- [x] 5. Gmail processor pods failing (missing secret)
-- [x] 6. AGENTS.md model reference stale
-
-### LOW SEVERITY
-
-- [x] 7. Discord integration incomplete (polling scripts only)
+### Changes Made
+- `vibeteam/gateway/routes/slack.py:1375-1417`: Skip self-posted bot messages that
+  contain role mentions (handoffs already handled by callback handler). Detects
+  own messages via `[DisplayName]` prefix pattern in thread replies.
+- `agent_service/openhands/server.py:27-45`: Added `MAX_CONCURRENT_JOBS` semaphore
+  (default 3, configurable via env var) to prevent resource exhaustion.
+- `agent_service/openhands/server.py:435+,488+`: Timeout callback retry with
+  exponential backoff (3 attempts), `repr(e)` for full error details.
 
 ---
 

--- a/vibeteam/gateway/routes/slack.py
+++ b/vibeteam/gateway/routes/slack.py
@@ -1373,13 +1373,41 @@ async def handle_slack_events(
             return {"status": "accepted", "event": "message.subscribed_thread"}
 
     # Handle bot messages with role mentions in channels (handoffs and eval)
-    # This handles cases where the bot posts /RoleName mentions (eval script or agent handoffs)
+    # IMPORTANT: Bot messages posted by OUR OWN bot (via callback handler) that
+    # contain @RoleName handoff mentions should NOT be re-processed here, because
+    # the callback handler (handle_agent_callback) already submits handoff jobs.
+    # Only process bot messages from OTHER bots (e.g., eval script trigger API)
+    # or external integrations.
     if event_type == "message" and is_bot_message:
         channel = event.get("channel", "")
         text = event.get("text", "")
         message_ts = event.get("ts", "")
         thread_ts = event.get("thread_ts") or message_ts
-        user_id = event.get("bot_id", "bot")  # Use bot_id as user_id for bot messages
+        bot_id = event.get("bot_id", "")
+
+        # Check if this message was posted by our own bot (self-posted handoff).
+        # Our bot's messages from the callback handler contain a "[RoleName]" prefix.
+        # The callback handler already processes handoffs in the response, so
+        # re-processing here would cause duplicate agent executions.
+        is_self_bot_message = False
+        if text:
+            # Our callback handler formats messages as "[DisplayName] ..." or
+            # "[DisplayName:model] ...". If the message starts with this pattern
+            # and is in a thread, it's a response we posted — not a new request.
+            import re as _re
+
+            self_bot_pattern = _re.match(r"^\[[\w:.\-]+\]\s", text)
+            if self_bot_pattern and thread_ts and thread_ts != message_ts:
+                is_self_bot_message = True
+                logger.info(
+                    f"Skipping self-posted bot message with role mention "
+                    f"(handoff already handled by callback): {text[:80]}..."
+                )
+
+        if is_self_bot_message:
+            return {"status": "ignored", "reason": "self_bot_handoff_already_handled"}
+
+        user_id = bot_id or "bot"
 
         # React with thinking face to show we're processing the message
         await add_reaction(channel, message_ts, "thinking_face")


### PR DESCRIPTION
## Summary

Fixes #105 — `stripe_webhook_failure` eval fails due to duplicate handoff execution, silent timeout callback failures, and queue starvation from unlimited concurrent jobs.

## Changes

### 1. Prevent duplicate handoff execution (`slack.py`)
- Bot messages posted by our own callback handler that contain `@RoleName` mentions were being re-processed by the Slack event handler, causing duplicate agent jobs
- Added detection: messages matching `[DisplayName] ...` prefix in threads are recognized as self-posted and skipped
- The callback handler already submits handoff jobs — no need for the event handler to do it again

### 2. Concurrency controls (`server.py`)
- Added `MAX_CONCURRENT_JOBS` semaphore (default 3, configurable via env var)
- Prevents resource exhaustion when multiple jobs arrive simultaneously
- Jobs wait for semaphore before starting execution

### 3. Timeout callback resilience (`server.py`)
- Added retry with exponential backoff (3 attempts, 1s/2s delays)
- Changed `str(e)` to `repr(e)` for full exception details in error logs (some exceptions produce empty strings with `str()`)

## Testing

- All 509 unit tests pass
- Eval re-run pending after deploy

## Files Changed

| File | Change |
|------|--------|
| `vibeteam/gateway/routes/slack.py` | Skip self-posted bot handoff messages |
| `agent_service/openhands/server.py` | Semaphore + timeout callback retry |
| `plan.md` | Track current task progress |