### PR TITLE
fix: health check agent behavior + enforce max_iterations on all agents

### DIFF
--- a/agent_service/openhands/marketing_manager.py
+++ b/agent_service/openhands/marketing_manager.py
@@ -245,9 +245,13 @@ class OpenHandsMarketingManager:
             workspace_path = workspace
 
         try:
+            # max_iterations caps the number of agent iterations (tool calls)
+            # to prevent runaway execution. Default is 30.
+            max_iterations = kwargs.get("max_iterations", 30)
             conversation = LocalConversation(
                 agent=agent,
                 workspace=workspace_path,
+                max_iteration_per_run=max_iterations,
             )
 
             # Inject browser context based on task keywords

--- a/agent_service/openhands/product_manager.py
+++ b/agent_service/openhands/product_manager.py
@@ -199,9 +199,13 @@ class OpenHandsProductManager:
             workspace_path = workspace
 
         try:
+            # max_iterations caps the number of agent iterations (tool calls)
+            # to prevent runaway execution. Default is 30.
+            max_iterations = kwargs.get("max_iterations", 30)
             conversation = LocalConversation(
                 agent=agent,
                 workspace=workspace_path,
+                max_iteration_per_run=max_iterations,
             )
 
             full_task = f"{PRODUCT_MANAGER_CONTEXT_FALLBACK}\n\nTask: {task}"

--- a/agent_service/openhands/release_engineer.py
+++ b/agent_service/openhands/release_engineer.py
@@ -285,6 +285,19 @@ Received handoff about [issue].
 @SupportEngineer Please confirm with customer that 400 errors have stopped.
 ```
 
+## HEALTH CHECK MODE
+
+When you receive a task labeled "Health Check Request" (NOT an incident or deployment):
+
+1. Determine the target namespace from the user message (see Namespace Map above).
+2. Check pod & deployment status in that ONE namespace only.
+3. Curl the health endpoint for that namespace.
+4. Report a concise summary: pod status, replica counts, health endpoint result, verdict.
+
+**Efficiency goal**: Complete in ≤ 7 tool calls. Do NOT deep-dive into logs, events,
+Sentry, TLS, or ingress config for a health check. If curl fails from the sandbox,
+note it as a sandbox limitation and move on — kubectl pod status is the primary indicator.
+
 ## CRITICAL: Communication is Handled By the System
 
 DO NOT try to use Slack/email tools. Your text response is automatically posted.

--- a/agent_service/openhands/release_engineer.py
+++ b/agent_service/openhands/release_engineer.py
@@ -421,12 +421,14 @@ class OpenHandsReleaseEngineer:
                 callbacks.append(progress_cb)
 
             # Create local conversation with required workspace
-            # No explicit max_iteration_per_run — use SDK default (500).
-            # The execution timeout (600s) in server.py is the real safety net.
+            # max_iterations caps the number of agent iterations (tool calls)
+            # to prevent runaway execution. Default is 30; health checks use 15.
+            max_iterations = kwargs.get("max_iterations", 30)
             conversation = LocalConversation(
                 agent=agent,
                 workspace=workspace_path,
                 callbacks=callbacks or None,
+                max_iteration_per_run=max_iterations,
             )
 
             # Inject relevant context (ReleaseEngineer almost always needs kubectl)

--- a/agent_service/openhands/server.py
+++ b/agent_service/openhands/server.py
@@ -107,6 +107,10 @@ class AsyncRunRequest(BaseModel):
         600,
         description="Overall execution timeout in seconds (default: 600 = 10 min)",
     )
+    max_iterations: int = Field(
+        30,
+        description="Maximum agent iterations (tool calls) before forced stop (default: 30)",
+    )
 
 
 class AsyncRunResponse(BaseModel):
@@ -397,6 +401,7 @@ async def _execute_and_callback(
                             workspace=request.workspace,
                             use_tools=request.use_tools,
                             skip_context_injection=request.skip_context_injection,
+                            max_iterations=request.max_iterations,
                             # Progress callback params — agents use these to send
                             # real-time updates to the gateway while working
                             progress_url=request.progress_url,

--- a/agent_service/openhands/software_engineer.py
+++ b/agent_service/openhands/software_engineer.py
@@ -1245,12 +1245,14 @@ code matches. Use `gh search code` and `gh api` for further investigation:
                 )
                 agent_callbacks.append(progress_cb)
 
-            # No explicit max_iteration_per_run — use SDK default (500).
-            # The execution timeout (600s) in server.py is the real safety net.
+            # max_iterations caps the number of agent iterations (tool calls)
+            # to prevent runaway execution. Default is 30.
+            max_iterations = kwargs.get("max_iterations", 30)
             conversation = LocalConversation(
                 agent=agent,
                 workspace=workspace_path,
                 callbacks=agent_callbacks,
+                max_iteration_per_run=max_iterations,
             )
 
             # Inject context if keywords match

--- a/agent_service/openhands/support_engineer.py
+++ b/agent_service/openhands/support_engineer.py
@@ -369,12 +369,14 @@ class OpenHandsSupportEngineer:
                 )
                 callbacks.append(progress_cb)
 
-            # No explicit max_iteration_per_run — use SDK default (500).
-            # The execution timeout (600s) in server.py is the real safety net.
+            # max_iterations caps the number of agent iterations (tool calls)
+            # to prevent runaway execution. Default is 30.
+            max_iterations = kwargs.get("max_iterations", 30)
             conversation = LocalConversation(
                 agent=agent,
                 workspace=workspace_path,
                 callbacks=callbacks or None,
+                max_iteration_per_run=max_iterations,
             )
 
             # Inject relevant context based on task keywords (unless skipped)

--- a/agents/ReleaseEngineer/AGENTS.md
+++ b/agents/ReleaseEngineer/AGENTS.md
@@ -225,6 +225,32 @@ After deploying:
 - [ ] Monitor error rates in Sentry (first 15 min)
 - [ ] Update release notes if needed
 
+## Health Check Mode
+
+When you receive a task labeled "Health Check Request" (as opposed to an incident
+investigation or deployment), switch to **focused health-check mode**:
+
+1. **Determine the target namespace** from the user message (see Namespace Map above).
+   - "production" / "prod" / "api" → `vibe`
+   - "staging" / "dev" → `vibe-dev`
+   - "agents" / "vibeteam" / "gateway" → `vibeteam`
+2. **Check pod & deployment status** in that ONE namespace only.
+3. **Curl the health endpoint** for that namespace:
+   - `vibe` → `https://api.vibebrowser.app/health/readiness`
+   - `vibe-dev` → `https://api-dev.vibebrowser.app/health/readiness`
+   - `vibeteam` → `https://webhook.team.vibebrowser.app/health`
+4. **Report a concise summary**: pod status, replica counts, health endpoint result,
+   overall verdict (Healthy / Unhealthy).
+
+**Efficiency goal**: Complete in ≤ 7 tool calls. Do NOT deep-dive into logs, events,
+Sentry, TLS, or ingress config for a health check. If curl fails from the sandbox,
+note it and move on — kubectl pod status is the primary health indicator.
+
+**Important**: If curl returns HTTP 000 or times out, this is a known sandbox
+networking limitation, NOT a production issue. Do NOT debug DNS, TLS, Traefik,
+or try alternative curl flags. Simply note "could not verify from sandbox" and
+base your verdict on kubectl output.
+
 ## Health Endpoints
 
 | Endpoint | Expected | Action if Failing |

--- a/scripts/eval_slack_e2e.py
+++ b/scripts/eval_slack_e2e.py
@@ -484,6 +484,80 @@ SCENARIOS = {
         },
         "threshold": 0.70,
     },
+    "release_health_check": {
+        "name": "Release Engineer - Production Health Check",
+        "message": (
+            "@ReleaseEngineer check out health and production readiness of our production api"
+        ),
+        "expected_agent": "release_engineer",
+        "evaluation_criteria": {
+            "ResponseEfficiency": (
+                "Was the health check focused and concise, avoiding unnecessary scope creep? "
+                "REQUIRED FOR HIGH SCORE: "
+                "(1) Agent checked only the correct namespace (vibe for production); "
+                "(2) Agent completed the task and produced a final summary (not timed out); "
+                "(3) Agent did NOT check multiple unrelated namespaces, dig into Sentry/Langfuse, "
+                "or run an exhaustive investigation when a simple health check was requested. "
+                "SCORING: "
+                "Score 0.0-0.3: Agent timed out without producing a final report, or ran >20 tool calls. "
+                "Score 0.3-0.5: Unfocused — checked multiple namespaces or deep-dived into TLS/ingress/Traefik. "
+                "Score 0.5-0.7: Completed but with significant scope creep (>12 tool calls or checked unrelated services). "
+                "Score 0.7-0.9: Focused check of the right namespace with a clear summary, ≤12 tool calls. "
+                "Score 0.9-1.0: Highly efficient — ≤7 tool calls, right namespace, concise report."
+            ),
+            "TaskCompletion": (
+                "Did the agent actually report on the health and production readiness? "
+                "REQUIRED FOR HIGH SCORE: "
+                "(1) Reported pod status (Running / not Running); "
+                "(2) Reported deployment replica status (ready/desired); "
+                "(3) Tested a health endpoint with curl and reported the HTTP status; "
+                "(4) Gave a clear overall verdict (healthy or unhealthy). "
+                "SCORING: "
+                "Score 0.0-0.3: No health information reported, or just generic text without evidence. "
+                "Score 0.3-0.5: Some kubectl output but no synthesis or verdict. "
+                "Score 0.5-0.7: Reported pod/deployment status but missed health endpoint test. "
+                "Score 0.7-0.9: Reported pods, deployments, and health endpoint with clear verdict. "
+                "Score 0.9-1.0: Complete health report with evidence and concise verdict."
+            ),
+            "CorrectNamespace": (
+                "Did the agent check the CORRECT Kubernetes namespace for 'production api'? "
+                "CRITICAL: The production API lives in namespace `vibe`, NOT `vibeteam`. "
+                "`vibeteam` is the internal agent infrastructure namespace. "
+                "REQUIRED FOR HIGH SCORE: "
+                "(1) Agent used `-n vibe` for kubectl commands (production API namespace); "
+                "(2) Agent curled the production endpoint (api.vibebrowser.app), not the internal gateway. "
+                "SCORING: "
+                "Score 0.0-0.3: Only checked `vibeteam` namespace (wrong namespace entirely). "
+                "Score 0.3-0.5: Checked `vibeteam` AND `vibe` (unnecessary extra work). "
+                "Score 0.5-0.7: Checked `vibe` but also checked unrelated namespaces. "
+                "Score 0.7-0.9: Correctly focused on `vibe` namespace. "
+                "Score 0.9-1.0: Only checked `vibe` namespace and production endpoint — perfect targeting."
+            ),
+        },
+        "evaluation_steps": {
+            "ResponseEfficiency": [
+                "Check if the agent produced a final summary report (not timed out)",
+                "Count the number of tool calls / kubectl commands the agent ran",
+                "Check if the agent only checked the requested namespace (vibe for production)",
+                "Check if the agent avoided deep-diving into Sentry, Langfuse, TLS, Traefik, or extensive log analysis",
+                "Score 0.0-0.3 if timed out or >20 calls; 0.3-0.5 if unfocused; 0.5-0.7 if completed with scope creep; 0.7-0.9 if focused ≤12 calls; 0.9-1.0 if ≤7 calls with clear summary",
+            ],
+            "TaskCompletion": [
+                "Check if the agent reported pod status from kubectl output",
+                "Check if the agent reported deployment replica counts",
+                "Check if the agent tested a health endpoint with curl and reported the HTTP status code",
+                "Check if the agent gave a clear overall verdict (healthy/unhealthy)",
+                "Score 0.0-0.3 if no health data; 0.3-0.5 if raw output only; 0.5-0.7 if partial; 0.7-0.9 if complete; 0.9-1.0 if concise and complete",
+            ],
+            "CorrectNamespace": [
+                "Check if kubectl commands used -n vibe (production namespace)",
+                "Check if curl targeted api.vibebrowser.app (production endpoint)",
+                "Check if the agent did NOT only check vibeteam namespace (internal agents)",
+                "Score 0.0-0.3 if only vibeteam; 0.3-0.5 if mixed; 0.7-0.9 if correctly vibe; 0.9-1.0 if only vibe",
+            ],
+        },
+        "threshold": 0.70,
+    },
 }
 
 # Role display names

--- a/tests/test_system_prompt.py
+++ b/tests/test_system_prompt.py
@@ -660,11 +660,13 @@ class TestSoftwareEngineerIterationBudget:
         )
 
     def test_no_explicit_max_iteration_per_run(self):
-        """max_iteration_per_run should NOT be set — rely on SDK default (500) and execution timeout."""
+        """max_iteration_per_run should be set via kwargs, not hardcoded in the source."""
         content = self._read_swe_context()
-        assert "max_iteration_per_run=" not in content, (
-            "SWE agent should not set max_iteration_per_run explicitly. "
-            "The SDK default (500) is used; the execution timeout (600s) is the real safety net."
+        # The agent should read max_iterations from kwargs and pass to LocalConversation.
+        # It should NOT hardcode a specific value — the gateway controls the limit.
+        assert "max_iterations" in content, (
+            "SWE agent must read max_iterations from kwargs and pass to LocalConversation. "
+            "This prevents runaway execution when asyncio.wait_for timeout cannot kill the thread."
         )
 
     def test_github_issue_workflow_has_iteration_check(self):
@@ -683,8 +685,8 @@ class TestSoftwareEngineerIterationBudget:
         )
 
     def test_other_agents_no_explicit_max_iteration(self):
-        """SupportEngineer and ReleaseEngineer should NOT set explicit max_iteration_per_run."""
-        # SupportEngineer — uses SDK default (500), execution timeout is the safety net
+        """SupportEngineer and ReleaseEngineer must use max_iterations from kwargs."""
+        # SupportEngineer — reads max_iterations from kwargs, passes to LocalConversation
         se_filepath = os.path.join(
             os.path.dirname(__file__),
             os.pardir,
@@ -694,12 +696,13 @@ class TestSoftwareEngineerIterationBudget:
         )
         with open(se_filepath) as f:
             se_content = f.read()
-        assert "max_iteration_per_run=" not in se_content, (
-            "support_engineer.py should not set max_iteration_per_run explicitly. "
-            "The SDK default (500) is used; execution timeout is the real safety net."
+        assert "max_iterations" in se_content, (
+            "support_engineer.py must read max_iterations from kwargs. "
+            "asyncio.wait_for timeout cannot kill the agent thread; "
+            "max_iteration_per_run is the real safety net."
         )
 
-        # ReleaseEngineer — uses SDK default (500), execution timeout is the safety net
+        # ReleaseEngineer — reads max_iterations from kwargs, passes to LocalConversation
         re_filepath = os.path.join(
             os.path.dirname(__file__),
             os.pardir,
@@ -709,9 +712,10 @@ class TestSoftwareEngineerIterationBudget:
         )
         with open(re_filepath) as f:
             re_content = f.read()
-        assert "max_iteration_per_run=" not in re_content, (
-            "release_engineer.py should not set max_iteration_per_run explicitly. "
-            "The SDK default (500) is used; execution timeout is the real safety net."
+        assert "max_iterations" in re_content, (
+            "release_engineer.py must read max_iterations from kwargs. "
+            "asyncio.wait_for timeout cannot kill the agent thread; "
+            "max_iteration_per_run is the real safety net."
         )
 
     def test_has_forbidden_actions_section(self):

--- a/tests/test_task_routing.py
+++ b/tests/test_task_routing.py
@@ -259,6 +259,100 @@ class TestEdgeCases:
         assert result == "deployment"
 
 
+class TestHealthCheckDetection:
+    """Test that health/readiness check requests are correctly routed to health_check template."""
+
+    def test_health_and_readiness(self):
+        """The original failing scenario: 'check out health and production readiness'."""
+        result = classify_task_template(
+            "release_engineer",
+            "@ReleaseEngineer, check out health and production readiness of our production api",
+        )
+        assert result == "health_check"
+
+    def test_check_health(self):
+        result = classify_task_template(
+            "release_engineer",
+            "@ReleaseEngineer check the health of production.",
+        )
+        assert result == "health_check"
+
+    def test_status_check(self):
+        result = classify_task_template(
+            "release_engineer",
+            "@ReleaseEngineer what's the status of the production API?",
+        )
+        assert result == "health_check"
+
+    def test_readiness_check(self):
+        result = classify_task_template(
+            "release_engineer",
+            "@ReleaseEngineer is the production API ready?",
+        )
+        assert result == "health_check"
+
+    def test_uptime_check(self):
+        result = classify_task_template(
+            "release_engineer",
+            "@ReleaseEngineer check the uptime of the staging environment.",
+        )
+        assert result == "health_check"
+
+    def test_liveness_check(self):
+        result = classify_task_template(
+            "release_engineer",
+            "@ReleaseEngineer run a liveness check on production.",
+        )
+        assert result == "health_check"
+
+    def test_health_with_error_becomes_investigation(self):
+        """Health + negative indicator (error) → investigation, not health_check."""
+        result = classify_task_template(
+            "release_engineer",
+            "@ReleaseEngineer check the health, there might be an error.",
+        )
+        assert result == "investigation"
+
+    def test_health_with_down_becomes_investigation(self):
+        """Health + 'down' → investigation."""
+        result = classify_task_template(
+            "release_engineer",
+            "@ReleaseEngineer check health, the service seems to be down.",
+        )
+        assert result == "investigation"
+
+    def test_health_with_crash_becomes_investigation(self):
+        result = classify_task_template(
+            "release_engineer",
+            "@ReleaseEngineer check health — pods are crashing.",
+        )
+        assert result == "investigation"
+
+    def test_non_release_engineer_health_becomes_investigation(self):
+        """Only release_engineer gets health_check template."""
+        result = classify_task_template(
+            "support_engineer",
+            "@SupportEngineer check the health of production.",
+        )
+        assert result == "investigation"
+
+    def test_swe_health_becomes_investigation(self):
+        result = classify_task_template(
+            "software_engineer",
+            "@SoftwareEngineer what's the status of the API?",
+        )
+        assert result == "investigation"
+
+    def test_health_check_in_thread_still_health_check(self):
+        """Thread follow-up with health keywords for RE → health_check, not conversational."""
+        result = classify_task_template(
+            "release_engineer",
+            "check the health of staging",
+            is_thread_reply=True,
+        )
+        assert result == "health_check"
+
+
 class TestHandoffPassthrough:
     """Handoff messages are forwarded as-is — the gateway doesn't add special templates.
 

--- a/vibeteam/gateway/routes/slack.py
+++ b/vibeteam/gateway/routes/slack.py
@@ -414,7 +414,7 @@ def classify_task_template(role: str, user_message: str, is_thread_reply: bool =
         is_thread_reply: True if this message is a reply in an existing thread
 
     Returns:
-        'deployment', 'notification', 'conversational', or 'investigation'
+        'deployment', 'notification', 'conversational', 'health_check', or 'investigation'
     """
     msg_lower = user_message.lower()
 
@@ -422,6 +422,40 @@ def classify_task_template(role: str, user_message: str, is_thread_reply: bool =
         kw in msg_lower
         for kw in ["notify", "announce", "tell the team", "tell the customer", "confirm to"]
     )
+    # Health check: user asks to check health/readiness/status WITHOUT indicating
+    # something is broken.  This should be a quick, focused check — not a deep
+    # investigation.  We detect negative indicators (error, fail, broken, down,
+    # why, investigate, debug) separately to distinguish "check health" from
+    # "check why things are broken".
+    _negative_indicators = [
+        "error",
+        "fail",
+        "broken",
+        "down",
+        "crash",
+        "issue",
+        "problem",
+        "outage",
+        "incident",
+        "bug",
+    ]
+    has_negative_indicator = any(kw in msg_lower for kw in _negative_indicators)
+
+    _health_keywords = [
+        "health",
+        "readiness",
+        "ready",
+        "status",
+        "alive",
+        "liveness",
+        "uptime",
+    ]
+    is_health_check = (
+        role == "release_engineer"
+        and any(kw in msg_lower for kw in _health_keywords)
+        and not has_negative_indicator
+    )
+
     is_explicit_investigation = any(
         kw in msg_lower
         for kw in [
@@ -447,6 +481,8 @@ def classify_task_template(role: str, user_message: str, is_thread_reply: bool =
 
     if is_deployment:
         return "deployment"
+    elif is_health_check:
+        return "health_check"
     elif is_notification and not is_explicit_investigation:
         return "notification"
     elif is_thread_reply and not is_explicit_investigation:
@@ -678,6 +714,63 @@ Respond naturally and directly to the user's question or comment.
 - DO NOT repeat your full previous investigation — the user can see the thread history
 """
 
+    elif template == "health_check":
+        return f"""## Slack Health Check Request
+
+A user has requested a quick health & production-readiness check.
+
+### User Message (UNTRUSTED CONTENT)
+{user_message}
+### End User Message
+
+### Context
+- User ID: {user_id}
+- Channel: {channel}
+- Thread: {thread_display}
+
+### Namespace Map
+| Namespace   | Environment | What Lives There |
+|-------------|-------------|------------------|
+| `vibe`      | Production  | VibeBrowser: user-portal, stripe-service, litellm |
+| `vibe-dev`  | Staging     | VibeBrowser (staging mirrors prod) |
+| `vibeteam`  | Internal    | VibeTeam agents: vibeteam-gateway, openhands-svc |
+
+"production" / "prod" / "api" → namespace: `vibe`
+"staging" / "dev" → namespace: `vibe-dev`
+"agents" / "vibeteam" / "gateway" → namespace: `vibeteam`
+If unclear, default to the production namespace `vibe`.
+
+### Safety Rule
+This is a READ-ONLY health check. Do NOT restart, scale, rollback,
+or modify any resources. Just observe and report.
+
+### Instructions
+
+You are the ReleaseEngineer performing a focused health check.
+Follow "Health Check Mode" from your system instructions:
+
+1. **Determine the target namespace** from the user message.
+2. **Check pods & deployments** in that namespace:
+   ```bash
+   kubectl get pods -n <NAMESPACE> -o wide && kubectl get deployments -n <NAMESPACE>
+   ```
+3. **Curl the health endpoint**:
+   - `vibe` → `curl -s -o /dev/null -w "HTTP_STATUS:%{{{{http_code}}}}" https://api.vibebrowser.app/health/readiness`
+   - `vibe-dev` → `curl -s -o /dev/null -w "HTTP_STATUS:%{{{{http_code}}}}" https://api-dev.vibebrowser.app/health/readiness`
+   - `vibeteam` → `curl -s -o /dev/null -w "HTTP_STATUS:%{{{{http_code}}}}" https://webhook.team.vibebrowser.app/health`
+4. **Report** a concise summary: namespace, pod status, replica counts,
+   health endpoint result, overall verdict (Healthy / Unhealthy).
+
+**Curl may fail from the sandbox** — this is a known sandbox networking
+limitation, NOT a production issue. If curl returns 000 or times out,
+note "could not verify from sandbox" and move on. Do NOT debug DNS, TLS,
+Traefik, or try alternative curl flags. kubectl status is the primary indicator.
+
+**Efficiency goal**: Complete in ≤ 7 tool calls. Avoid deep-diving into logs,
+events, Sentry, TLS certificates, or ingress config. Check only the namespace
+the user asked about.
+"""
+
     else:
         # Investigation (default)
         return f"""## Slack Request
@@ -779,6 +872,14 @@ async def _submit_agent_async(
         thread_ts=thread_ts,
     )
 
+    # Determine if we should skip heavy context injection.
+    # Health checks are self-contained — the template has all instructions.
+    # Pre-fetched context (logs, events from all namespaces) causes the agent
+    # to rabbit-hole into investigating every anomaly it sees.
+    is_thread_reply = thread_ts is not None
+    template = classify_task_template(role, user_message, is_thread_reply=is_thread_reply)
+    skip_context = template == "health_check"
+
     # Build callback URL
     callback_url = f"{config.GATEWAY_URL}/callback/agent"
     progress_url = f"{config.GATEWAY_URL}/callback/agent/progress"
@@ -791,6 +892,7 @@ async def _submit_agent_async(
         context_id=f"{channel}:{thread_ts or 'new'}",
         callback_url=callback_url,
         progress_url=progress_url,
+        skip_context_injection=skip_context,
         callback_metadata={
             "channel": channel,
             "thread_ts": thread_ts,

--- a/vibeteam/gateway/routes/slack.py
+++ b/vibeteam/gateway/routes/slack.py
@@ -880,6 +880,17 @@ async def _submit_agent_async(
     template = classify_task_template(role, user_message, is_thread_reply=is_thread_reply)
     skip_context = template == "health_check"
 
+    # Set max_iterations based on task type to prevent scope creep.
+    # Health checks need very few tool calls; investigations need more.
+    max_iterations_map = {
+        "health_check": 15,
+        "conversational": 10,
+        "notification": 10,
+        "deployment": 25,
+        "investigation": 30,
+    }
+    max_iterations = max_iterations_map.get(template, 30)
+
     # Build callback URL
     callback_url = f"{config.GATEWAY_URL}/callback/agent"
     progress_url = f"{config.GATEWAY_URL}/callback/agent/progress"
@@ -893,6 +904,7 @@ async def _submit_agent_async(
         callback_url=callback_url,
         progress_url=progress_url,
         skip_context_injection=skip_context,
+        max_iterations=max_iterations,
         callback_metadata={
             "channel": channel,
             "thread_ts": thread_ts,

--- a/vibeteam/gateway/server.py
+++ b/vibeteam/gateway/server.py
@@ -285,6 +285,7 @@ async def call_agent_service_async(
     callback_url: str = "",
     callback_metadata: dict[str, Any] | None = None,
     progress_url: str | None = None,
+    skip_context_injection: bool = False,
 ) -> dict[str, Any]:
     """
     Submit a task to the agent service asynchronously.
@@ -302,6 +303,9 @@ async def call_agent_service_async(
         callback_url: URL where agent should POST results
         callback_metadata: Opaque data passed through to callback
         progress_url: URL where agent should POST progress updates (optional)
+        skip_context_injection: If True, skip pre-fetched kubectl/Sentry context
+            injection. Used for focused tasks like health checks where the task
+            prompt already contains all necessary instructions.
 
     Returns:
         {"job_id": "...", "status": "accepted"} or {"error": "..."}
@@ -329,7 +333,7 @@ async def call_agent_service_async(
     # For openhands, add parameters
     if fw == "openhands":
         payload["use_tools"] = True
-        payload["skip_context_injection"] = False
+        payload["skip_context_injection"] = skip_context_injection
 
     # Pass progress_url so agent service can send intermediate updates
     if progress_url:

--- a/vibeteam/gateway/server.py
+++ b/vibeteam/gateway/server.py
@@ -286,6 +286,7 @@ async def call_agent_service_async(
     callback_metadata: dict[str, Any] | None = None,
     progress_url: str | None = None,
     skip_context_injection: bool = False,
+    max_iterations: int = 30,
 ) -> dict[str, Any]:
     """
     Submit a task to the agent service asynchronously.
@@ -306,6 +307,7 @@ async def call_agent_service_async(
         skip_context_injection: If True, skip pre-fetched kubectl/Sentry context
             injection. Used for focused tasks like health checks where the task
             prompt already contains all necessary instructions.
+        max_iterations: Maximum agent iterations before forced stop (default: 30)
 
     Returns:
         {"job_id": "...", "status": "accepted"} or {"error": "..."}
@@ -334,6 +336,7 @@ async def call_agent_service_async(
     if fw == "openhands":
         payload["use_tools"] = True
         payload["skip_context_injection"] = skip_context_injection
+        payload["max_iterations"] = max_iterations
 
     # Pass progress_url so agent service can send intermediate updates
     if progress_url:


### PR DESCRIPTION
## Summary

Fixes the issue where the ReleaseEngineer agent ran 26 steps over 16+ minutes on a simple health check request, timed out, and never produced a final summary.

**Root causes identified and fixed:**
1. No `health_check` task template — request was misclassified as `investigation`, giving the agent an overly broad, SupportEngineer-focused prompt
2. `asyncio.wait_for` + `asyncio.to_thread` does NOT kill the underlying thread when timeout fires — the agent keeps running indefinitely with no way to stop it

## Changes

### Health Check Task Template (commit e12ebbc)
- Add `health_check` classification in `classify_task_template()` — detects health keywords + release_engineer role + no error indicators
- Add focused `health_check` task template in `_build_task_prompt()` with namespace map and curl commands
- Add "Health Check Mode" to ReleaseEngineer system prompt (both AGENTS.md and fallback context)
- Skip context injection for health_check tasks to prevent rabbit-holing
- Add 12 unit tests for health_check classification
- Add `release_health_check` eval scenario with 3 metrics

### Max Iterations Enforcement (commit e08f5fa)
- Add `max_iterations` field to `AsyncRunRequest` (default: 30, was SDK default 500)
- Pass `max_iterations` through gateway → agent service → `LocalConversation(max_iteration_per_run=N)`
- Set per-task-type iteration limits in gateway:
  - `health_check`: 15
  - `conversational`: 10
  - `notification`: 10
  - `deployment`: 25
  - `investigation`: 30
- All 5 agents now respect `max_iterations` from kwargs
- Update tests to reflect new iteration enforcement strategy

## Eval Results

| Run | Steps | ResponseEfficiency | TaskCompletion | CorrectNamespace |
|-----|-------|--------------------|----------------|------------------|
| Before fix | 26+ | N/A (timeout) | 0.00 | N/A |
| After fix | ~7 | 0.90 ✅ | 1.00 ✅ | 1.00 ✅ |

## Test Results

All 694 tests pass, 0 failures.