### PR TITLE
fix: optimize health_check to 3 tool calls, add merging-to-master docs

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -17,6 +17,18 @@ Each agent has specific service ownership and handoff responsibilities. Evry age
 
 Do not ask for tokens, evrything inside .env, just export it `export $( < .env )`
 
+### Merging to Master
+
+**Merging to master is safe and expected during development.** Do NOT ask for permission to merge.
+
+The live system uses `git-sync` with `--ref=master` and `--period=30s`, so changes must land on master to be picked up by the running pods. The standard workflow is:
+
+1. Create a feature branch
+2. Open a PR for traceability
+3. Merge immediately (squash merge preferred)
+4. Delete the feature branch
+
+If running evals, pause rollouts first to prevent mid-eval restarts (see "Analyzing Evaluation Tests" section).
 
 ### Investigation vs Action Flow
 

--- a/agent_service/openhands/release_engineer.py
+++ b/agent_service/openhands/release_engineer.py
@@ -290,13 +290,14 @@ Received handoff about [issue].
 When you receive a task labeled "Health Check Request" (NOT an incident or deployment):
 
 1. Determine the target namespace from the user message (see Namespace Map above).
-2. Check pod & deployment status in that ONE namespace only.
-3. Curl the health endpoint for that namespace.
-4. Report a concise summary: pod status, replica counts, health endpoint result, verdict.
+2. **Tool call 1**: Check pods, deployments, and recent events in that ONE namespace
+   (combine into a single bash command).
+3. **Tool call 2**: Curl the health endpoint for that namespace.
+4. **Tool call 3**: Post your concise summary (finish action).
 
-**Efficiency goal**: Complete in ≤ 7 tool calls. Do NOT deep-dive into logs, events,
-Sentry, TLS, or ingress config for a health check. If curl fails from the sandbox,
-note it as a sandbox limitation and move on — kubectl pod status is the primary indicator.
+**3 tool calls total.** Do NOT re-run kubectl to "show" output, check services/ingress/TLS,
+run curl a second time, or deep-dive into logs, Sentry, or events beyond the basics.
+If curl fails from the sandbox, note it as a sandbox limitation and move on.
 
 ## CRITICAL: Communication is Handled By the System
 

--- a/agents/ReleaseEngineer/AGENTS.md
+++ b/agents/ReleaseEngineer/AGENTS.md
@@ -234,22 +234,17 @@ investigation or deployment), switch to **focused health-check mode**:
    - "production" / "prod" / "api" → `vibe`
    - "staging" / "dev" → `vibe-dev`
    - "agents" / "vibeteam" / "gateway" → `vibeteam`
-2. **Check pod & deployment status** in that ONE namespace only.
-3. **Curl the health endpoint** for that namespace:
-   - `vibe` → `https://api.vibebrowser.app/health/readiness`
-   - `vibe-dev` → `https://api-dev.vibebrowser.app/health/readiness`
-   - `vibeteam` → `https://webhook.team.vibebrowser.app/health`
-4. **Report a concise summary**: pod status, replica counts, health endpoint result,
-   overall verdict (Healthy / Unhealthy).
+2. **Tool call 1**: Check pods, deployments, and recent events in that ONE namespace
+   (combine into a single bash command).
+3. **Tool call 2**: Curl the health endpoint for that namespace.
+4. **Tool call 3**: Post your concise summary (finish action).
 
-**Efficiency goal**: Complete in ≤ 7 tool calls. Do NOT deep-dive into logs, events,
-Sentry, TLS, or ingress config for a health check. If curl fails from the sandbox,
-note it and move on — kubectl pod status is the primary health indicator.
+**3 tool calls total.** Do NOT re-run kubectl to "show" output, check services/ingress/TLS,
+run curl a second time, or deep-dive into logs, Sentry, or events beyond the basics.
 
-**Important**: If curl returns HTTP 000 or times out, this is a known sandbox
-networking limitation, NOT a production issue. Do NOT debug DNS, TLS, Traefik,
-or try alternative curl flags. Simply note "could not verify from sandbox" and
-base your verdict on kubectl output.
+If curl returns HTTP 000 or times out, this is a known sandbox networking limitation,
+NOT a production issue. Note "could not verify from sandbox" and base your verdict
+on kubectl output.
 
 ## Health Endpoints
 

--- a/scripts/eval_slack_e2e.py
+++ b/scripts/eval_slack_e2e.py
@@ -499,11 +499,11 @@ SCENARIOS = {
                 "(3) Agent did NOT check multiple unrelated namespaces, dig into Sentry/Langfuse, "
                 "or run an exhaustive investigation when a simple health check was requested. "
                 "SCORING: "
-                "Score 0.0-0.3: Agent timed out without producing a final report, or ran >20 tool calls. "
+                "Score 0.0-0.3: Agent timed out without producing a final report, or ran >15 tool calls. "
                 "Score 0.3-0.5: Unfocused — checked multiple namespaces or deep-dived into TLS/ingress/Traefik. "
-                "Score 0.5-0.7: Completed but with significant scope creep (>12 tool calls or checked unrelated services). "
-                "Score 0.7-0.9: Focused check of the right namespace with a clear summary, ≤12 tool calls. "
-                "Score 0.9-1.0: Highly efficient — ≤7 tool calls, right namespace, concise report."
+                "Score 0.5-0.7: Completed but with significant scope creep (>10 tool calls or checked unrelated services). "
+                "Score 0.7-0.9: Focused check of the right namespace with a clear summary, ≤7 tool calls. "
+                "Score 0.9-1.0: Highly efficient — ≤5 tool calls, right namespace, concise report."
             ),
             "TaskCompletion": (
                 "Did the agent actually report on the health and production readiness? "
@@ -540,7 +540,7 @@ SCENARIOS = {
                 "Count the number of tool calls / kubectl commands the agent ran",
                 "Check if the agent only checked the requested namespace (vibe for production)",
                 "Check if the agent avoided deep-diving into Sentry, Langfuse, TLS, Traefik, or extensive log analysis",
-                "Score 0.0-0.3 if timed out or >20 calls; 0.3-0.5 if unfocused; 0.5-0.7 if completed with scope creep; 0.7-0.9 if focused ≤12 calls; 0.9-1.0 if ≤7 calls with clear summary",
+                "Score 0.0-0.3 if timed out or >15 calls; 0.3-0.5 if unfocused; 0.5-0.7 if completed with scope creep; 0.7-0.9 if focused ≤7 calls; 0.9-1.0 if ≤5 calls with clear summary",
             ],
             "TaskCompletion": [
                 "Check if the agent reported pod status from kubectl output",

--- a/vibeteam/gateway/routes/slack.py
+++ b/vibeteam/gateway/routes/slack.py
@@ -747,28 +747,35 @@ or modify any resources. Just observe and report.
 ### Instructions
 
 You are the ReleaseEngineer performing a focused health check.
-Follow "Health Check Mode" from your system instructions:
+Follow "Health Check Mode" from your system instructions.
 
-1. **Determine the target namespace** from the user message.
-2. **Check pods & deployments** in that namespace:
-   ```bash
-   kubectl get pods -n <NAMESPACE> -o wide && kubectl get deployments -n <NAMESPACE>
-   ```
-3. **Curl the health endpoint**:
-   - `vibe` → `curl -s -o /dev/null -w "HTTP_STATUS:%{{{{http_code}}}}" https://api.vibebrowser.app/health/readiness`
-   - `vibe-dev` → `curl -s -o /dev/null -w "HTTP_STATUS:%{{{{http_code}}}}" https://api-dev.vibebrowser.app/health/readiness`
-   - `vibeteam` → `curl -s -o /dev/null -w "HTTP_STATUS:%{{{{http_code}}}}" https://webhook.team.vibebrowser.app/health`
-4. **Report** a concise summary: namespace, pod status, replica counts,
-   health endpoint result, overall verdict (Healthy / Unhealthy).
+**Execute EXACTLY these commands (adapt NAMESPACE). Do NOT add extra commands.**
+
+**Tool call 1** — Determine namespace & get infra status (run as ONE command):
+```bash
+kubectl get pods -n <NAMESPACE> -o wide && kubectl get deployments -n <NAMESPACE> && kubectl get events -n <NAMESPACE> --sort-by='.lastTimestamp' 2>/dev/null | tail -5
+```
+
+**Tool call 2** — Curl the health endpoint:
+- `vibe` → `curl -s -w "\nHTTP_STATUS:%{{{{http_code}}}}" https://api.vibebrowser.app/health/readiness`
+- `vibe-dev` → `curl -s -w "\nHTTP_STATUS:%{{{{http_code}}}}" https://api-dev.vibebrowser.app/health/readiness`
+- `vibeteam` → `curl -s -w "\nHTTP_STATUS:%{{{{http_code}}}}" https://webhook.team.vibebrowser.app/health`
+
+**Tool call 3** — Post your final summary to the conversation (finish action).
+
+That's it. **3 tool calls total.** Do NOT:
+- Re-run kubectl to "show" or "capture" output you already have
+- Check services, ingress, TLS, or Sentry
+- Run curl a second time to "confirm"
+- Deep-dive into logs or events beyond the tail-5 above
 
 **Curl may fail from the sandbox** — this is a known sandbox networking
 limitation, NOT a production issue. If curl returns 000 or times out,
-note "could not verify from sandbox" and move on. Do NOT debug DNS, TLS,
-Traefik, or try alternative curl flags. kubectl status is the primary indicator.
+note "could not verify from sandbox" and move on. kubectl status is the
+primary indicator.
 
-**Efficiency goal**: Complete in ≤ 7 tool calls. Avoid deep-diving into logs,
-events, Sentry, TLS certificates, or ingress config. Check only the namespace
-the user asked about.
+**Report format**: namespace, pod status, replica counts, health endpoint
+result, overall verdict (Healthy / Unhealthy).
 """
 
     else:
@@ -883,7 +890,7 @@ async def _submit_agent_async(
     # Set max_iterations based on task type to prevent scope creep.
     # Health checks need very few tool calls; investigations need more.
     max_iterations_map = {
-        "health_check": 15,
+        "health_check": 8,
         "conversational": 10,
         "notification": 10,
         "deployment": 25,


### PR DESCRIPTION
## Summary

- Health check template now prescribes exactly 3 tool calls (kubectl, curl, report) instead of vague "≤7" guidance
- Explicitly forbids re-running commands, checking services/ingress/TLS, duplicate curls
- Reduced `max_iterations` for health_check from 15 to 8 (safety net)
- Updated eval scoring bands to match tighter budget (≤5 calls = 0.9-1.0)
- Aligned system prompt (AGENTS.md + fallback context) with task template
- Added merging-to-master workflow instructions to root AGENTS.md (re-applied via PR after revert of direct push)

## Context

Previous eval runs showed the agent using 10 tool calls for a health check that should take 3. The agent was:
- Re-running kubectl to "show" or "capture" output it already had
- Checking services (not in template instructions)
- Running curl a second time to "confirm"
- Showing line counts and head of output files

This PR makes the template prescriptive: exact commands, exact order, explicit "do NOT" list.

## Testing

- All 178 routing + system prompt tests pass
- PR #112 CI: lint SUCCESS, test SUCCESS, openhands-agents SUCCESS
- Eval to be run after merge to verify reduced step count