### PR TITLE
Fallback for Azure responses-only models

### DIFF
--- a/agent_service/openhands/utils.py
+++ b/agent_service/openhands/utils.py
@@ -6,7 +6,7 @@ import logging
 import os
 from typing import Any
 
-from agents.shared.llm import get_model_context_window
+from agents.shared.llm import get_model_context_window, resolve_azure_model
 
 logger = logging.getLogger(__name__)
 
@@ -39,6 +39,8 @@ def _get_context_window_from_env() -> tuple[str | None, int | None]:
     api_base = os.getenv("AZURE_OPENAI_ENDPOINT") or os.getenv("AZURE_API_BASE")
     api_key = os.getenv("AZURE_OPENAI_API_KEY") or os.getenv("AZURE_API_KEY")
     api_version = os.getenv("AZURE_API_VERSION")
+
+    model = resolve_azure_model(model, api_base=api_base)
 
     ctx_tokens = get_model_context_window(
         model,

--- a/agents/config.py
+++ b/agents/config.py
@@ -92,6 +92,13 @@ class LLMConfig:
         self.api_key = (
             self.api_key or os.getenv("AZURE_OPENAI_API_KEY") or os.getenv("AZURE_API_KEY")
         )
+        try:
+            from agents.shared.llm import resolve_azure_model
+
+            self.model = resolve_azure_model(self.model, api_base=self.api_base)
+        except Exception:
+            # Keep configured model if resolution fails (avoid import-time issues).
+            pass
 
 
 @dataclass

--- a/agents/shared/llm.py
+++ b/agents/shared/llm.py
@@ -41,6 +41,48 @@ except ImportError:
 
 logger = logging.getLogger(__name__)
 
+RESPONSES_ONLY_MODELS = {"gpt-5.2-codex"}
+
+
+def resolve_azure_model(
+    model: str | None,
+    *,
+    api_base: str | None = None,
+    allow_responses_models: bool | None = None,
+) -> str | None:
+    """Resolve Azure model names that are Responses-only.
+
+    Azure OpenAI does not currently support the /responses API. If a model is
+    marked as responses-only in LiteLLM (e.g., gpt-5.2-codex), we must fall back
+    to a chat-completions-compatible model to avoid 404s.
+    """
+    if not model:
+        return None
+
+    normalized = model.split("/", 1)[1] if model.startswith("azure/") else model
+    api_base = _normalize_api_base(
+        api_base
+        or os.getenv("AZURE_OPENAI_ENDPOINT")
+        or os.getenv("AZURE_API_BASE")
+    )
+
+    if not api_base or "openai.azure.com" not in api_base:
+        return model
+
+    if allow_responses_models is None:
+        allow_responses_models = (
+            os.getenv("AZURE_ALLOW_RESPONSES_MODELS", "").lower() in {"1", "true", "yes"}
+        )
+
+    if normalized in RESPONSES_ONLY_MODELS and not allow_responses_models:
+        logger.warning(
+            "Azure does not support /responses; falling back from %s to gpt-5.2",
+            model,
+        )
+        return "gpt-5.2"
+
+    return model
+
 
 def _normalize_model_name(model: str | None) -> str | None:
     if not model:
@@ -233,4 +275,5 @@ __all__ = [
     "LLM",
     "OPENHANDS_LLM_AVAILABLE",
     "get_model_context_window",
+    "resolve_azure_model",
 ]


### PR DESCRIPTION
## Summary
- add Azure model resolution helper to avoid responses-only models
- fall back from `gpt-5.2-codex` to `gpt-5.2` on Azure
- reuse fallback for context window lookup

## Testing
- Not run (relies on Azure API behavior)
