### PR TITLE
Enable Azure Responses API for gpt-5.2-codex

### DIFF
--- a/agent_service/openhands/utils.py
+++ b/agent_service/openhands/utils.py
@@ -40,7 +40,7 @@ def _get_context_window_from_env() -> tuple[str | None, int | None]:
     api_key = os.getenv("AZURE_OPENAI_API_KEY") or os.getenv("AZURE_API_KEY")
     api_version = os.getenv("AZURE_API_VERSION")
 
-    model = resolve_azure_model(model, api_base=api_base)
+    model = resolve_azure_model(model, api_base=api_base, api_version=api_version)
 
     ctx_tokens = get_model_context_window(
         model,

--- a/agents/config.py
+++ b/agents/config.py
@@ -95,7 +95,11 @@ class LLMConfig:
         try:
             from agents.shared.llm import resolve_azure_model
 
-            self.model = resolve_azure_model(self.model, api_base=self.api_base)
+            self.model = resolve_azure_model(
+                self.model,
+                api_base=self.api_base,
+                api_version=os.getenv("AZURE_API_VERSION"),
+            )
         except Exception:
             # Keep configured model if resolution fails (avoid import-time issues).
             pass

--- a/agents/shared/llm.py
+++ b/agents/shared/llm.py
@@ -16,22 +16,56 @@ from typing import Any
 
 import requests
 
+logger = logging.getLogger(__name__)
+
+RESPONSES_ONLY_MODELS = {"gpt-5.2-codex"}
+RESPONSES_MIN_API_VERSION = (2025, 3, 1)
+
+
+def _parse_api_version(version: str | None) -> tuple[int, int, int] | None:
+    if not version:
+        return None
+    parts = version.split("-")
+    if len(parts) < 3:
+        return None
+    try:
+        return (int(parts[0]), int(parts[1]), int(parts[2]))
+    except ValueError:
+        return None
+
+
+def _azure_api_version_supports_responses(version: str | None) -> bool:
+    parsed = _parse_api_version(version)
+    if not parsed:
+        return False
+    return parsed >= RESPONSES_MIN_API_VERSION
+
+
+def _azure_allow_responses_models() -> bool:
+    flag = os.getenv("AZURE_ALLOW_RESPONSES_MODELS", "").lower() in {"1", "true", "yes"}
+    if not flag:
+        return False
+    return _azure_api_version_supports_responses(os.getenv("AZURE_API_VERSION"))
+
+
 try:
     from openhands.sdk import LLM
 
     OPENHANDS_LLM_AVAILABLE = True
 
     class AzureLLM(LLM):
-        """LLM subclass that forces completion API for Azure OpenAI.
+        """LLM subclass with Azure-specific Responses API handling.
 
-        Azure OpenAI doesn't support the Responses API endpoint, so we override
-        uses_responses_api() to always return False. Without this, the SDK
-        attempts to call the Responses API and gets a 404 from Azure.
+        Azure OpenAI supports the Responses API only for newer API versions.
+        We default to chat completions unless responses are explicitly enabled.
         """
 
         def uses_responses_api(self) -> bool:
-            """Azure OpenAI doesn't support the Responses API."""
-            return False
+            """Enable responses API only when explicitly allowed and required."""
+            if not _azure_allow_responses_models():
+                return False
+            model_name = _normalize_model_name(getattr(self, "model", None))
+            return model_name in RESPONSES_ONLY_MODELS
 
 except ImportError:
     OPENHANDS_LLM_AVAILABLE = False
@@ -39,16 +73,12 @@ except ImportError:
     AzureLLM = None  # type: ignore[assignment,misc]
 
 
-logger = logging.getLogger(__name__)
-
-RESPONSES_ONLY_MODELS = {"gpt-5.2-codex"}
-
-
 def resolve_azure_model(
     model: str | None,
     *,
     api_base: str | None = None,
     allow_responses_models: bool | None = None,
+    api_version: str | None = None,
 ) -> str | None:
     """Resolve Azure model names that are Responses-only.
 
@@ -70,11 +100,14 @@ def resolve_azure_model(
         return model
 
     if allow_responses_models is None:
-        allow_responses_models = (
-            os.getenv("AZURE_ALLOW_RESPONSES_MODELS", "").lower() in {"1", "true", "yes"}
-        )
+        allow_responses_models = _azure_allow_responses_models()
 
-    if normalized in RESPONSES_ONLY_MODELS and not allow_responses_models:
+    if allow_responses_models and _azure_api_version_supports_responses(
+        api_version or os.getenv("AZURE_API_VERSION")
+    ):
+        return model
+
+    if normalized in RESPONSES_ONLY_MODELS:
         logger.warning(
             "Azure does not support /responses; falling back from %s to gpt-5.2",
             model,

--- a/k8s/base/autogen-svc.yaml
+++ b/k8s/base/autogen-svc.yaml
@@ -51,7 +51,10 @@ spec:
                   name: vibeteam-secrets
                   key: AZURE_OPENAI_DEPLOYMENT
             - name: AZURE_API_VERSION
-              value: "2024-08-01-preview"
+              valueFrom:
+                secretKeyRef:
+                  name: vibeteam-secrets
+                  key: AZURE_API_VERSION
             - name: GITHUB_TOKEN
               valueFrom:
                 secretKeyRef:

--- a/k8s/base/crewai-svc.yaml
+++ b/k8s/base/crewai-svc.yaml
@@ -51,7 +51,10 @@ spec:
                   name: vibeteam-secrets
                   key: AZURE_OPENAI_DEPLOYMENT
             - name: AZURE_API_VERSION
-              value: "2024-08-01-preview"
+              valueFrom:
+                secretKeyRef:
+                  name: vibeteam-secrets
+                  key: AZURE_API_VERSION
             - name: GITHUB_TOKEN
               valueFrom:
                 secretKeyRef:

--- a/k8s/base/frameworks/autogen.yaml
+++ b/k8s/base/frameworks/autogen.yaml
@@ -41,7 +41,10 @@ spec:
                   name: vibeteam-secrets
                   key: AZURE_API_BASE
             - name: AZURE_API_VERSION
-              value: "2024-08-01-preview"
+              valueFrom:
+                secretKeyRef:
+                  name: vibeteam-secrets
+                  key: AZURE_API_VERSION
             - name: GITHUB_TOKEN
               valueFrom:
                 secretKeyRef:

--- a/k8s/base/frameworks/crewai.yaml
+++ b/k8s/base/frameworks/crewai.yaml
@@ -41,7 +41,10 @@ spec:
                   name: vibeteam-secrets
                   key: AZURE_API_BASE
             - name: AZURE_API_VERSION
-              value: "2024-08-01-preview"
+              valueFrom:
+                secretKeyRef:
+                  name: vibeteam-secrets
+                  key: AZURE_API_VERSION
             - name: GITHUB_TOKEN
               valueFrom:
                 secretKeyRef:

--- a/k8s/base/frameworks/openhands.yaml
+++ b/k8s/base/frameworks/openhands.yaml
@@ -42,7 +42,10 @@ spec:
                   name: vibeteam-secrets
                   key: AZURE_API_BASE
             - name: AZURE_API_VERSION
-              value: "2024-08-01-preview"
+              valueFrom:
+                secretKeyRef:
+                  name: vibeteam-secrets
+                  key: AZURE_API_VERSION
             - name: GITHUB_TOKEN
               valueFrom:
                 secretKeyRef:

--- a/k8s/base/openhands-svc.yaml
+++ b/k8s/base/openhands-svc.yaml
@@ -61,7 +61,10 @@ spec:
                   name: vibeteam-secrets
                   key: AZURE_OPENAI_DEPLOYMENT
             - name: AZURE_API_VERSION
-              value: "2024-08-01-preview"
+              valueFrom:
+                secretKeyRef:
+                  name: vibeteam-secrets
+                  key: AZURE_API_VERSION
             - name: GITHUB_TOKEN
               valueFrom:
                 secretKeyRef:


### PR DESCRIPTION
## Summary
- allow Azure responses API for responses-only models when api-version >= 2025-03-01-preview and `AZURE_ALLOW_RESPONSES_MODELS=true`
- avoid codex fallback when responses is supported
- source AZURE_API_VERSION from secret in k8s manifests

## Testing
- Not run (config change)
