### PR TITLE
Remove autogen/crewai resources and fix eval API version

### DIFF
--- a/k8s/base/frameworks/kustomization.yaml
+++ b/k8s/base/frameworks/kustomization.yaml
@@ -3,8 +3,6 @@ apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
 resources:
-  - autogen.yaml
-  - crewai.yaml
   - openhands.yaml
 
 labels:

--- a/k8s/base/kustomization.yaml
+++ b/k8s/base/kustomization.yaml
@@ -10,8 +10,6 @@ resources:
   # Gateway (routes webhooks to agent microservices)
   - vibeteam-gateway.yaml
   # Agent Microservices (FastAPI servers handling all agent roles)
-  - autogen-svc.yaml
-  - crewai-svc.yaml
   - openhands-svc.yaml
   - scheduler-svc.yaml
   # Gmail email processor (daemon polling for support emails)

--- a/k8s/overlays/dev/kustomization.yaml
+++ b/k8s/overlays/dev/kustomization.yaml
@@ -12,30 +12,5 @@ resources:
 patches:
   - path: openhands-svc-patch.yaml
   - path: gateway-patch.yaml
-  # JSON patches for other deployments
-  - target:
-      kind: Deployment
-      name: crewai-agents
-    patch: |
-      - op: replace
-        path: /spec/template/spec/containers/0/image
-        value: ghcr.io/vibetechnologies/vibeteam-crewai:dev
-      - op: add
-        path: /spec/template/spec/containers/0/env/-
-        value:
-          name: GITHUB_BRANCH
-          value: "master"
-  - target:
-      kind: Deployment
-      name: autogen-agents
-    patch: |
-      - op: replace
-        path: /spec/template/spec/containers/0/image
-        value: ghcr.io/vibetechnologies/vibeteam-autogen:dev
-      - op: add
-        path: /spec/template/spec/containers/0/env/-
-        value:
-          name: GITHUB_BRANCH
-          value: "master"
 
 # Note: Avoid commonLabels/commonAnnotations as they affect selectors which are immutable

--- a/scripts/eval_slack_e2e.py
+++ b/scripts/eval_slack_e2e.py
@@ -1173,6 +1173,10 @@ async def run_evaluation(
         # Get Azure credentials
         api_key = os.environ.get("AZURE_OPENAI_API_KEY", os.environ.get("AZURE_API_KEY"))
         api_base = os.environ.get("AZURE_OPENAI_ENDPOINT", os.environ.get("AZURE_API_BASE"))
+        api_version = os.environ.get(
+            "AZURE_EVAL_API_VERSION",
+            os.environ.get("AZURE_API_VERSION", "2024-08-01-preview"),
+        )
 
         # Warn if credentials appear to be from wrong environment
         if api_base and "vibebrowser" not in api_base.lower():
@@ -1193,6 +1197,7 @@ async def run_evaluation(
                         "BENCHMARK_JUDGE_MODEL",
                         os.environ.get("AZURE_OPENAI_DEPLOYMENT", "gpt-5.2"),
                     ),
+                    api_version=api_version,
                 )
 
                 transcript = build_transcript(conversation)


### PR DESCRIPTION
## Summary
- remove autogen/crewai deployments from base + dev kustomization
- allow eval script to pass a separate Azure API version for judge model

## Testing
- Not run (eval rerun next)
