### PR TITLE
Treat async timeout as idle when progress updates

### DIFF
--- a/agent_service/openhands/progress.py
+++ b/agent_service/openhands/progress.py
@@ -32,6 +32,7 @@ def create_progress_callback(
     job_id: str,
     callback_metadata: dict[str, Any],
     start_time: float | None = None,
+    on_progress: Callable[[], None] | None = None,
 ) -> Callable[[Any], None]:
     """Create a callback function that sends progress updates to the gateway.
 
@@ -90,6 +91,13 @@ def create_progress_callback(
             summary = summary[:197] + "..."
 
         elapsed = int(now - _start)
+
+        # Notify caller (e.g., update heartbeat for idle timeout logic)
+        if on_progress:
+            try:
+                on_progress()
+            except Exception:
+                pass
 
         # Send progress update (best-effort, non-blocking within this sync context)
         _send_progress_sync(

--- a/agent_service/openhands/release_engineer.py
+++ b/agent_service/openhands/release_engineer.py
@@ -419,6 +419,7 @@ class OpenHandsReleaseEngineer:
                     progress_url=progress_url,
                     job_id=kwargs.get("job_id", ""),
                     callback_metadata=kwargs.get("callback_metadata", {}),
+                    on_progress=kwargs.get("progress_heartbeat"),
                 )
                 callbacks.append(progress_cb)
 

--- a/agent_service/openhands/server.py
+++ b/agent_service/openhands/server.py
@@ -106,7 +106,10 @@ class AsyncRunRequest(BaseModel):
     )
     execution_timeout: int = Field(
         600,
-        description="Overall execution timeout in seconds (default: 600 = 10 min)",
+        description=(
+            "Execution timeout in seconds. If progress updates are enabled, this is treated "
+            "as an idle timeout (no progress within the window). Otherwise it is a hard cap."
+        ),
     )
     max_iterations: int = Field(
         30,
@@ -365,7 +368,7 @@ async def _execute_and_callback(
     timeout, it sends the result to request.callback_url.
 
     Features:
-    - Overall execution timeout (default 600s / 10 min) prevents infinite hangs
+    - Timeout is treated as idle timeout when progress updates are enabled
     - On timeout, extracts partial results from whatever events exist
     - Sends progress updates to request.progress_url if provided
     - Concurrency limited by semaphore to prevent resource exhaustion
@@ -382,6 +385,21 @@ async def _execute_and_callback(
         start_time = time.time()
         context_id = request.context_id or str(uuid.uuid4())[:8]
         execution_timeout = request.execution_timeout
+        last_progress: dict[str, float] = {"time": start_time}
+        progress_enabled = bool(request.progress_url)
+
+        def _progress_heartbeat() -> None:
+            last_progress["time"] = time.time()
+
+        async def _run_with_idle_timeout(run_fn):
+            task = asyncio.create_task(asyncio.to_thread(run_fn))
+            while True:
+                done, _ = await asyncio.wait({task}, timeout=1.0)
+                if done:
+                    return done.pop().result()
+                if time.time() - last_progress["time"] > execution_timeout:
+                    task.cancel()
+                    raise asyncio.TimeoutError()
 
         try:
             team = get_team()
@@ -396,9 +414,8 @@ async def _execute_and_callback(
                 # Wrap agent.run in asyncio.wait_for to enforce overall timeout.
                 # This prevents the agent from hanging forever if an LLM call gets stuck.
                 try:
-                    result = await asyncio.wait_for(
-                        asyncio.to_thread(
-                            agent.run,
+                    def _run_agent():
+                        return agent.run(
                             task=request.task,
                             context_type=request.context_type,
                             context_id=context_id,
@@ -411,14 +428,21 @@ async def _execute_and_callback(
                             progress_url=request.progress_url,
                             job_id=job_id,
                             callback_metadata=request.callback_metadata,
-                        ),
-                        timeout=execution_timeout,
-                    )
+                            progress_heartbeat=_progress_heartbeat if progress_enabled else None,
+                        )
+
+                    if progress_enabled:
+                        result = await _run_with_idle_timeout(_run_agent)
+                    else:
+                        result = await asyncio.wait_for(
+                            asyncio.to_thread(_run_agent),
+                            timeout=execution_timeout,
+                        )
                 except asyncio.TimeoutError:
                     elapsed = int(time.time() - start_time)
                     logger.error(
                         f"[job={job_id}] Agent execution timed out after {elapsed}s "
-                        f"(limit={execution_timeout}s)"
+                        f"(limit={execution_timeout}s, progress_enabled={progress_enabled})"
                     )
                     agent_role = role or "team"
 
@@ -436,6 +460,7 @@ async def _execute_and_callback(
                         metadata={
                             "latency_ms": elapsed * 1000,
                             "timeout_seconds": execution_timeout,
+                            "timeout_mode": "idle" if progress_enabled else "absolute",
                             "timed_out": True,
                         },
                         callback_metadata=request.callback_metadata,

--- a/agent_service/openhands/software_engineer.py
+++ b/agent_service/openhands/software_engineer.py
@@ -1243,6 +1243,7 @@ code matches. Use `gh search code` and `gh api` for further investigation:
                     progress_url=progress_url,
                     job_id=kwargs.get("job_id", ""),
                     callback_metadata=kwargs.get("callback_metadata", {}),
+                    on_progress=kwargs.get("progress_heartbeat"),
                 )
                 agent_callbacks.append(progress_cb)
 

--- a/agent_service/openhands/support_engineer.py
+++ b/agent_service/openhands/support_engineer.py
@@ -367,6 +367,7 @@ class OpenHandsSupportEngineer:
                     progress_url=progress_url,
                     job_id=kwargs.get("job_id", ""),
                     callback_metadata=kwargs.get("callback_metadata", {}),
+                    on_progress=kwargs.get("progress_heartbeat"),
                 )
                 callbacks.append(progress_cb)
 


### PR DESCRIPTION
Fixes #120

## Summary
- treat `execution_timeout` as **idle timeout** when progress updates are enabled
- add a progress heartbeat callback to reset idle timer
- keep hard timeout for requests without progress updates

## Testing
- Not run (manual Slack thread verification pending)
