### PR TITLE
Fix OpenHands JSON wrapper and eval judge fallback

### DIFF
--- a/agent_service/openhands/utils.py
+++ b/agent_service/openhands/utils.py
@@ -128,7 +128,10 @@ def configure_textcontent_json_serialization() -> None:
             return str(obj)
 
         def _safe_dumps(obj, **kwargs):
-            return _json.dumps(obj, default=_safe_default, **kwargs)
+            # Respect caller-provided default if present
+            if "default" not in kwargs:
+                kwargs["default"] = _safe_default
+            return _json.dumps(obj, **kwargs)
 
         # Patch the agent module's json.dumps used in debug logging
         agent_mod.json.dumps = _safe_dumps  # type: ignore[assignment]

--- a/scripts/eval_slack_e2e.py
+++ b/scripts/eval_slack_e2e.py
@@ -1378,7 +1378,10 @@ async def run_evaluation(
                     os.environ.get("AZURE_OPENAI_DEPLOYMENT", "gpt-5.2"),
                 )
                 resolved_model = resolve_azure_model(
-                    raw_model, api_base=api_base, api_version=api_version
+                    raw_model,
+                    api_base=api_base,
+                    api_version=api_version,
+                    allow_responses_models=False,
                 )
                 # Azure deployment names should NOT include "azure/" prefix
                 if resolved_model and resolved_model.startswith("azure/"):


### PR DESCRIPTION
## Summary\n- Avoid double default argument in patched json.dumps wrapper\n- Force eval judge model to chat-compatible deployment when using Azure\n\n## Testing\n- Not run (requires cluster + Slack eval run)