### PR TITLE
Coerce agent responses to plain text

### DIFF
--- a/agent_service/openhands/server.py
+++ b/agent_service/openhands/server.py
@@ -23,7 +23,11 @@ from agents.config import AgentConfig
 from agents.shared.db import close_db, get_postgres_store, init_db
 
 from .team import OpenHandsTeam, create_team
-from .utils import configure_text_truncation, configure_textcontent_json_serialization
+from .utils import (
+    coerce_text,
+    configure_text_truncation,
+    configure_textcontent_json_serialization,
+)
 
 # Configure logging
 logging.basicConfig(level=logging.INFO)
@@ -282,6 +286,7 @@ async def run_task(request: RunRequest):
             )
 
         latency_ms = int((time.time() - start_time) * 1000)
+        response_text = coerce_text(result.get("response", ""))
 
         # Build session key
         agent_role = result.get("agent", role or "team")
@@ -305,7 +310,7 @@ async def run_task(request: RunRequest):
                         },
                         {
                             "role": "assistant",
-                            "content": result.get("response", ""),
+                            "content": response_text,
                             "timestamp": datetime.now(timezone.utc).isoformat(),
                         },
                     ],
@@ -315,7 +320,7 @@ async def run_task(request: RunRequest):
             logger.warning(f"Failed to save session to PostgreSQL: {e}")
 
         return RunResponse(
-            response=result.get("response", ""),
+            response=response_text,
             session_id=result.get("session_id", context_id),
             session_key=session_key,
             framework="openhands",
@@ -563,6 +568,7 @@ async def _execute_and_callback(
 
             latency_ms = int((time.time() - start_time) * 1000)
             agent_role = result.get("agent", role or "team")
+            response_text = coerce_text(result.get("response", ""))
             session_key = f"openhands:{agent_role}:{request.context_type}:{context_id}"
 
             # Save to PostgreSQL
@@ -583,7 +589,7 @@ async def _execute_and_callback(
                             },
                             {
                                 "role": "assistant",
-                                "content": result.get("response", ""),
+                                "content": response_text,
                                 "timestamp": datetime.now(timezone.utc).isoformat(),
                             },
                         ],
@@ -596,7 +602,7 @@ async def _execute_and_callback(
             payload = CallbackPayload(
                 job_id=job_id,
                 status="completed",
-                response=result.get("response", ""),
+                response=response_text,
                 session_id=result.get("session_id", context_id),
                 session_key=session_key,
                 agents_used=[agent_role],
@@ -697,7 +703,8 @@ async def run_task_stream(request: RunRequest):
             # Send result
             import json
 
-            yield f"data: {json.dumps({'event': 'message', 'content': result.get('response', '')})}\n\n"
+            response_text = coerce_text(result.get("response", ""))
+            yield f"data: {json.dumps({'event': 'message', 'content': response_text})}\n\n"
             yield f"data: {json.dumps({'event': 'done', 'session_id': result.get('session_id', context_id)})}\n\n"
 
         except Exception as e:

--- a/agent_service/openhands/utils.py
+++ b/agent_service/openhands/utils.py
@@ -194,6 +194,33 @@ def configure_textcontent_json_serialization() -> None:
         logger.warning("Failed to patch OpenHands JSON serialization: %s", e)
 
 
+def coerce_text(value: Any) -> str:
+    """Coerce OpenHands TextContent (or sequences of it) into a plain string."""
+    if value is None:
+        return ""
+    if isinstance(value, str):
+        return value
+    try:
+        from openhands.sdk.llm import TextContent  # type: ignore
+
+        if isinstance(value, TextContent):
+            return value.text or ""
+    except Exception:
+        pass
+
+    if isinstance(value, (list, tuple)):
+        parts = [coerce_text(item) for item in value]
+        return "".join(part for part in parts if part)
+
+    if hasattr(value, "text"):
+        try:
+            return str(getattr(value, "text"))
+        except Exception:
+            pass
+
+    return str(value)
+
+
 def build_condenser(llm: Any) -> Any | None:
     """Create an OpenHands condenser to auto-compact long conversations.
 
@@ -305,9 +332,9 @@ def extract_response_from_events(events: list[Any]) -> str:
                     logger.info(
                         "Extracted response from %s.message (%d chars)",
                         action_name,
-                        len(message),
+                        len(coerce_text(message)),
                     )
-                    response = message
+                    response = coerce_text(message)
                     break
                 # Fallback to thought (check both action and event)
                 thought = getattr(action, "thought", "") or getattr(event, "thought", "")
@@ -315,9 +342,9 @@ def extract_response_from_events(events: list[Any]) -> str:
                     logger.info(
                         "Extracted response from %s.thought (%d chars)",
                         action_name,
-                        len(thought),
+                        len(coerce_text(thought)),
                     )
-                    response = thought
+                    response = coerce_text(thought)
                     break
 
         # Check for MessageEvent (direct response without finish tool)
@@ -327,7 +354,7 @@ def extract_response_from_events(events: list[Any]) -> str:
                 if hasattr(llm_msg, "content") and llm_msg.content:
                     for block in llm_msg.content:
                         if hasattr(block, "text") and block.text:
-                            response = block.text
+                            response = coerce_text(block.text)
                             break
             if response:
                 logger.info(
@@ -350,9 +377,9 @@ def extract_response_from_events(events: list[Any]) -> str:
                     if thought:
                         logger.info(
                             "Extracted response from ThinkAction.thought fallback (%d chars)",
-                            len(thought),
+                            len(coerce_text(thought)),
                         )
-                        response = thought
+                        response = coerce_text(thought)
                         break
 
     if not response:
@@ -372,9 +399,9 @@ def extract_response_from_events(events: list[Any]) -> str:
                     logger.info(
                         "Extracted response from last ActionEvent.thought fallback (%s, %d chars)",
                         action_name,
-                        len(thought),
+                        len(coerce_text(thought)),
                     )
-                    response = thought
+                    response = coerce_text(thought)
                     break
 
     if not response:


### PR DESCRIPTION
Avoid CallbackPayload validation errors when OpenHands returns TextContent lists.