### PR TITLE
Add support Sentry/Gmail evals and tighten outputs

### DIFF
--- a/agent_service/openhands/support_engineer.py
+++ b/agent_service/openhands/support_engineer.py
@@ -383,6 +383,7 @@ class OpenHandsSupportEngineer:
 
             # Inject relevant context based on task keywords (unless skipped)
             injected_context = []
+            extra_guidance_lines: list[str] = []
 
             if not skip_context_injection:
                 task_lower = task.lower()
@@ -445,10 +446,18 @@ class OpenHandsSupportEngineer:
                     # This eliminates the need for agents to run kubectl manually
                     kubectl_ctx = fetch_kubectl_context()
                     injected_context.append(kubectl_ctx)
+                    extra_guidance_lines.append(
+                        "When reporting Sentry, list issue short IDs, titles, and counts. "
+                        "If none, state \"No unresolved issues found\" and answer whether anything needs action."
+                    )
 
                 # Gmail context for email-related tasks
                 if any(kw in task_lower for kw in ["email", "gmail", "inbox", "message", "mail"]):
                     injected_context.append(fetch_gmail_context())
+                    extra_guidance_lines.append(
+                        "When reporting Gmail, list each unread email with subject, sender, date, and ID. "
+                        "If none, say \"No unread emails in inbox.\" If action is needed, draft the reply text."
+                    )
 
                 # Calendar context for scheduling-related tasks
                 if any(kw in task_lower for kw in ["calendar", "meeting", "schedule", "event"]):
@@ -487,6 +496,14 @@ class OpenHandsSupportEngineer:
 
             # Build full task with context
             context_str = "\n\n".join(injected_context) if injected_context else ""
+            guidance_block = ""
+            if extra_guidance_lines:
+                guidance_block = (
+                    "\n### ADDITIONAL OUTPUT REQUIREMENTS\n"
+                    + "\n".join(f"- {line}" for line in extra_guidance_lines)
+                    + "\n"
+                )
+
             if context_str:
                 # Add very clear visual separators so agents know this is the injected data
                 context_block = f"""
@@ -505,14 +522,14 @@ END OF INJECTED DATA - The above data has ALREADY been fetched for you
                 # Do NOT include it again here — duplicating it wastes ~17k chars
                 # and pushes the context past OpenHands' 50k char limit, causing
                 # truncation that makes the agent blind to injected data.
-                full_task = f"""{context_block}
+                full_task = f"""{context_block}{guidance_block}
 
 ### USER TASK (UNTRUSTED INPUT)
 {task}
 ### END USER TASK
 """
             else:
-                full_task = f"""
+                full_task = f"""{guidance_block}
 ### USER TASK (UNTRUSTED INPUT)
 {task}
 ### END USER TASK

--- a/scripts/eval_slack_e2e.py
+++ b/scripts/eval_slack_e2e.py
@@ -201,6 +201,117 @@ SCENARIOS = {
         },
         "threshold": 0.80,
     },
+    "support_sentry_triage": {
+        "name": "Support Engineer - Sentry Triage Check",
+        "message": "@VibeTeam @SupportEngineer. Check Sentry issues. Anything to address?",
+        "expected_agent": "support_engineer",
+        "timeout": 600,
+        "evaluation_criteria": {
+            "SentryUsage": (
+                "Did the SupportEngineer actually check Sentry and report findings? "
+                "REQUIRED: "
+                "(1) Explicit mention of Sentry check; "
+                "(2) Either list specific issues (IDs/messages/counts) OR clearly state no issues found. "
+                "CRITICAL: If the response says Sentry is not configured or errors out, score 0.3 or lower. "
+                "SCORING: "
+                "Score 0.0-0.3: No Sentry mention or generic response. "
+                "Score 0.3-0.6: Mentions Sentry but no concrete findings. "
+                "Score 0.6-0.8: Reports Sentry findings or confirms none. "
+                "Score 0.8-1.0: Clear, specific Sentry findings with context."
+            ),
+            "TaskCompletion": (
+                "Did the agent answer 'Anything to address?' based on findings? "
+                "REQUIRED: "
+                "(1) Clear yes/no or action recommendation; "
+                "(2) Tied to the Sentry findings. "
+                "SCORING: "
+                "Score 0.0-0.3: No answer to the question. "
+                "Score 0.3-0.6: Vague answer without tying to Sentry. "
+                "Score 0.6-0.8: Clear answer tied to findings. "
+                "Score 0.8-1.0: Clear answer plus next steps or monitoring guidance."
+            ),
+            "ResponseEfficiency": (
+                "Evaluate whether the response is concise and focused. "
+                "SCORING: "
+                "Score 0.0-0.3: Rambling or off-topic. "
+                "Score 0.3-0.5: Some redundancy. "
+                "Score 0.5-0.7: Reasonably concise. "
+                "Score 0.7-0.9: Focused and efficient. "
+                "Score 0.9-1.0: Minimal, precise, and complete."
+            ),
+        },
+        "evaluation_steps": {
+            "SentryUsage": [
+                "Check for explicit Sentry mention.",
+                "Check for issue IDs/messages/counts OR explicit 'no issues found'.",
+                "Score <= 0.3 if Sentry not mentioned or if it says Sentry is not configured.",
+            ],
+            "TaskCompletion": [
+                "Check that the response directly answers whether there's anything to address.",
+                "Verify the answer is tied to Sentry findings.",
+            ],
+            "ResponseEfficiency": [
+                "Check that the response is concise and directly answers the request.",
+            ],
+        },
+        "threshold": 0.70,
+    },
+    "support_gmail_inbox": {
+        "name": "Support Engineer - Gmail Inbox Triage",
+        "message": "@VibeTeam @SupportEngineer, check Gmail inbox, anything to address? If so, work on it.",
+        "expected_agent": "support_engineer",
+        "timeout": 600,
+        "evaluation_criteria": {
+            "GmailUsage": (
+                "Did the SupportEngineer actually check Gmail inbox and report findings? "
+                "REQUIRED: "
+                "(1) Explicit mention of Gmail/inbox check; "
+                "(2) Either list unread emails (subject/sender/date or IDs) OR clearly state no unread emails. "
+                "CRITICAL: If the response says Gmail is not configured or errors out, score 0.3 or lower. "
+                "SCORING: "
+                "Score 0.0-0.3: No Gmail mention or generic response. "
+                "Score 0.3-0.6: Mentions Gmail but no concrete findings. "
+                "Score 0.6-0.8: Reports unread emails or confirms none. "
+                "Score 0.8-1.0: Clear, specific inbox triage with actionable context."
+            ),
+            "TaskCompletion": (
+                "Did the agent answer 'anything to address' and work on it if needed? "
+                "REQUIRED: "
+                "(1) Clear yes/no on items to address; "
+                "(2) If items exist, draft replies or outline actions per email; "
+                "(3) If no items, state inbox is clear. "
+                "SCORING: "
+                "Score 0.0-0.3: No answer to the question. "
+                "Score 0.3-0.6: Vague answer without tying to inbox findings. "
+                "Score 0.6-0.8: Clear answer tied to inbox findings. "
+                "Score 0.8-1.0: Clear answer plus draft responses or next steps."
+            ),
+            "ResponseEfficiency": (
+                "Evaluate whether the response is concise and focused. "
+                "SCORING: "
+                "Score 0.0-0.3: Rambling or off-topic. "
+                "Score 0.3-0.5: Some redundancy. "
+                "Score 0.5-0.7: Reasonably concise. "
+                "Score 0.7-0.9: Focused and efficient. "
+                "Score 0.9-1.0: Minimal, precise, and complete."
+            ),
+        },
+        "evaluation_steps": {
+            "GmailUsage": [
+                "Check for explicit Gmail/inbox mention.",
+                "Check for unread email details OR explicit 'no unread emails'.",
+                "Score <= 0.3 if Gmail not mentioned or if it says Gmail is not configured.",
+            ],
+            "TaskCompletion": [
+                "Check that the response directly answers whether there's anything to address.",
+                "Verify it is tied to inbox findings and includes draft actions if needed.",
+            ],
+            "ResponseEfficiency": [
+                "Check that the response is concise and directly answers the request.",
+            ],
+        },
+        "threshold": 0.70,
+    },
     "chrome_cdp_smoke": {
         "name": "Marketing Manager - Chrome CDP MCP Smoke Test",
         "message": (


### PR DESCRIPTION
## Summary
- Add SupportEngineer evals for Sentry triage and Gmail inbox triage
- Strengthen response requirements for Sentry/Gmail tasks

## Testing
- Pending: full eval suite rerun