### PR TITLE
Sanitize support handoff mentions case-insensitively

### DIFF
--- a/agent_service/openhands/support_engineer.py
+++ b/agent_service/openhands/support_engineer.py
@@ -562,6 +562,7 @@ END OF INJECTED DATA - The above data has ALREADY been fetched for you
                     r"@(ProductManager|MarketingManager|SupportEngineer|ReleaseEngineer|SoftwareEngineer)\\b",
                     r"\\1",
                     response,
+                    flags=re.IGNORECASE,
                 )
 
             session.add_message("user", task)


### PR DESCRIPTION
## Summary
- Remove role @mentions in Gmail/Sentry triage responses case-insensitively to avoid eval handoff delays.

## Testing
- Pending: full eval rerun