### PR TITLE
Respect skip_handoff in stable-conversation check

### DIFF
--- a/scripts/eval_slack_e2e.py
+++ b/scripts/eval_slack_e2e.py
@@ -1666,7 +1666,7 @@ async def run_evaluation(
 
                     latest_bot_msg = bot_messages[-1]
                     has_handoff = bool(ROLE_PATTERN.search(latest_bot_msg.text))
-                    if not has_handoff:
+                    if not has_handoff or scenario.get("skip_handoff", False):
                         print(
                             f"    Conversation stable for {int(time_since_last)}s, "
                             "no pending handoffs."


### PR DESCRIPTION
## Summary
- Ensure `skip_handoff` scenarios do not wait for handoff responses in the stable-conversation check.

## Testing
- Pending: Gmail eval rerun