### PR TITLE
Add sync idle timeout heartbeat and env

### DIFF
--- a/agent_service/openhands/progress.py
+++ b/agent_service/openhands/progress.py
@@ -113,6 +113,25 @@ def create_progress_callback(
     return _progress_callback
 
 
+def create_heartbeat_callback(
+    on_progress: Callable[[], None] | None = None,
+) -> Callable[[Any], None]:
+    """Create a lightweight callback that only updates the progress heartbeat.
+
+    This is used when we want idle-timeout detection without sending
+    progress updates to Slack.
+    """
+
+    def _heartbeat_callback(_event: Any) -> None:
+        if on_progress:
+            try:
+                on_progress()
+            except Exception:
+                pass
+
+    return _heartbeat_callback
+
+
 def _send_progress_sync(
     progress_url: str,
     job_id: str,

--- a/agent_service/openhands/release_engineer.py
+++ b/agent_service/openhands/release_engineer.py
@@ -422,6 +422,12 @@ class OpenHandsReleaseEngineer:
                     on_progress=kwargs.get("progress_heartbeat"),
                 )
                 callbacks.append(progress_cb)
+            elif kwargs.get("progress_heartbeat"):
+                from .progress import create_heartbeat_callback
+
+                callbacks.append(
+                    create_heartbeat_callback(on_progress=kwargs.get("progress_heartbeat"))
+                )
 
             # Create local conversation with required workspace
             # max_iterations caps the number of agent iterations (tool calls)

--- a/agent_service/openhands/server.py
+++ b/agent_service/openhands/server.py
@@ -251,6 +251,31 @@ async def run_task(request: RunRequest):
     )
     logger.info(f"Task content: {request.task[:100]}...")
     start_time = time.time()
+    idle_timeout_raw = os.getenv("OPENHANDS_SYNC_IDLE_TIMEOUT_SECONDS", "")
+    idle_timeout: int | None = None
+    if idle_timeout_raw:
+        try:
+            idle_timeout = int(idle_timeout_raw)
+        except ValueError:
+            idle_timeout = None
+    if idle_timeout is not None and idle_timeout <= 0:
+        idle_timeout = None
+    last_progress: dict[str, float] = {"time": start_time}
+
+    def _progress_heartbeat() -> None:
+        last_progress["time"] = time.time()
+
+    async def _run_with_idle_timeout(run_fn):
+        task = asyncio.create_task(asyncio.to_thread(run_fn))
+        while True:
+            done, _ = await asyncio.wait({task}, timeout=1.0)
+            if done:
+                return done.pop().result()
+            if idle_timeout is None:
+                continue
+            if time.time() - last_progress["time"] > idle_timeout:
+                task.cancel()
+                raise asyncio.TimeoutError()
 
     try:
         team = get_team()
@@ -267,15 +292,22 @@ async def run_task(request: RunRequest):
         if role:
             # Run with specific agent in a thread pool
             agent = team._get_agent(role)
-            result = await asyncio.to_thread(
-                agent.run,
-                task=request.task,
-                context_type=request.context_type,
-                context_id=context_id,
-                workspace=request.workspace,
-                use_tools=request.use_tools,
-                skip_context_injection=request.skip_context_injection,
-            )
+
+            def _run_agent():
+                return agent.run(
+                    task=request.task,
+                    context_type=request.context_type,
+                    context_id=context_id,
+                    workspace=request.workspace,
+                    use_tools=request.use_tools,
+                    skip_context_injection=request.skip_context_injection,
+                    progress_heartbeat=_progress_heartbeat,
+                )
+
+            if idle_timeout is None:
+                result = await asyncio.to_thread(_run_agent)
+            else:
+                result = await _run_with_idle_timeout(_run_agent)
         else:
             # Let team route based on @mentions or keywords
             result = await team.run_async(
@@ -332,6 +364,32 @@ async def run_task(request: RunRequest):
             },
         )
 
+    except asyncio.TimeoutError:
+        elapsed_ms = int((time.time() - start_time) * 1000)
+        agent_role = role or "team"
+        session_key = f"openhands:{agent_role}:{request.context_type}:{context_id}"
+        timeout_detail = ""
+        if idle_timeout is not None:
+            timeout_detail = f"No progress for {idle_timeout} seconds (idle timeout). "
+
+        return RunResponse(
+            response=(
+                "I was working on this task but had to stop due to inactivity. "
+                f"{timeout_detail}Please try again or break the task into smaller steps."
+            ),
+            session_id=context_id,
+            session_key=session_key,
+            framework="openhands",
+            agents_used=[agent_role],
+            metadata={
+                "latency_ms": elapsed_ms,
+                "message_count": 2,
+                "workspace": request.workspace,
+                "timed_out": True,
+                "timeout_seconds": idle_timeout,
+                "timeout_mode": "idle",
+            },
+        )
     except Exception as e:
         logger.exception("Task execution failed")
         raise HTTPException(status_code=500, detail=str(e)) from e

--- a/agent_service/openhands/software_engineer.py
+++ b/agent_service/openhands/software_engineer.py
@@ -1515,6 +1515,12 @@ code matches. Use `gh search code` and `gh api` for further investigation:
                     on_progress=kwargs.get("progress_heartbeat"),
                 )
                 agent_callbacks.append(progress_cb)
+            elif kwargs.get("progress_heartbeat"):
+                from .progress import create_heartbeat_callback
+
+                agent_callbacks.append(
+                    create_heartbeat_callback(on_progress=kwargs.get("progress_heartbeat"))
+                )
 
             # max_iterations caps the number of agent iterations (tool calls)
             # to prevent runaway execution. Default is 30.

--- a/agent_service/openhands/support_engineer.py
+++ b/agent_service/openhands/support_engineer.py
@@ -483,6 +483,12 @@ class OpenHandsSupportEngineer:
                     on_progress=kwargs.get("progress_heartbeat"),
                 )
                 callbacks.append(progress_cb)
+            elif kwargs.get("progress_heartbeat"):
+                from .progress import create_heartbeat_callback
+
+                callbacks.append(
+                    create_heartbeat_callback(on_progress=kwargs.get("progress_heartbeat"))
+                )
 
             # max_iterations caps the number of agent iterations (tool calls)
             # to prevent runaway execution. Default is 30.

--- a/k8s/base/openhands-svc.yaml
+++ b/k8s/base/openhands-svc.yaml
@@ -77,6 +77,8 @@ spec:
                   key: SENTRY_AUTH_TOKEN
             - name: CHROME_DEVTOOLS_BROWSER_URL
               value: "http://browserless:3000"
+            - name: OPENHANDS_SYNC_IDLE_TIMEOUT_SECONDS
+              value: "300"
           resources:
             requests:
               memory: "3Gi"


### PR DESCRIPTION
## Summary
- add sync `/run` idle-timeout support with progress heartbeat
- add heartbeat-only callbacks when no progress_url
- add `OPENHANDS_SYNC_IDLE_TIMEOUT_SECONDS` env to openhands-svc

## Testing
- `ruff check` (selected files)
- `ruff format` (selected files)