### PR TITLE
Make Gmail token writable in openhands-svc

### DIFF
--- a/k8s/base/openhands-svc.yaml
+++ b/k8s/base/openhands-svc.yaml
@@ -33,10 +33,28 @@ spec:
       serviceAccountName: vibeteam-agent
       imagePullSecrets:
         - name: ghcr-pull-secret
+      initContainers:
+        - name: copy-gmail-token
+          image: ghcr.io/vibetechnologies/vibeteam:latest
+          command: ["sh", "-c"]
+          args:
+            - |
+              cp /gmail-secrets/gmail-token.json /gmail-writable/gmail-token.json 2>/dev/null || true
+              cp /gmail-secrets/gmail-credentials.json /gmail-writable/gmail-credentials.json 2>/dev/null || true
+              echo "Gmail credentials copied to writable volume"
+          volumeMounts:
+            - name: gmail-secrets
+              mountPath: /gmail-secrets
+              readOnly: true
+            - name: gmail-writable
+              mountPath: /gmail-writable
       volumes:
         - name: gmail-secrets
           secret:
             secretName: gmail-oauth-secret
+            optional: false
+        - name: gmail-writable
+          emptyDir: {}
       containers:
         - name: openhands
           image: ghcr.io/vibetechnologies/vibeteam-openhands:latest
@@ -84,9 +102,9 @@ spec:
             - name: OPENHANDS_SYNC_IDLE_TIMEOUT_SECONDS
               value: "300"
             - name: GMAIL_CREDENTIALS_PATH
-              value: "/secrets/gmail-credentials.json"
+              value: "/gmail/gmail-credentials.json"
             - name: GMAIL_TOKEN_PATH
-              value: "/secrets/gmail-token.json"
+              value: "/gmail/gmail-token.json"
           resources:
             requests:
               memory: "3Gi"
@@ -95,9 +113,8 @@ spec:
               memory: "6Gi"
               cpu: "1000m"
           volumeMounts:
-            - name: gmail-secrets
-              mountPath: /secrets
-              readOnly: true
+            - name: gmail-writable
+              mountPath: /gmail
           livenessProbe:
             httpGet:
               path: /health


### PR DESCRIPTION
## Summary\n- copy Gmail token/credentials to writable volume via initContainer\n- point GMAIL_* env vars to writable /gmail path\n- mount gmail-writable emptyDir\n\n## Testing\n- not run (config-only change)