### PR TITLE
Make namespace configurable and eval idle-timeout

### DIFF
--- a/agent_service/openhands/support_engineer.py
+++ b/agent_service/openhands/support_engineer.py
@@ -27,7 +27,11 @@ from agents.shared.docs_tools import get_docs_context
 
 # Import shared tools for context injection
 from agents.shared.gmail_tools import get_email_context
-from agents.shared.kubectl_tools import get_deployment_logs, get_multi_namespace_context
+from agents.shared.kubectl_tools import (
+    DEFAULT_NAMESPACE,
+    get_deployment_logs,
+    get_multi_namespace_context,
+)
 from agents.shared.langfuse_tools import get_langfuse_context
 from agents.shared.sentry_tools import get_sentry_context
 
@@ -44,13 +48,14 @@ def fetch_kubectl_context() -> str:
 
 def fetch_gmail_processor_context(tail: int = 80) -> str:
     """Fetch recent gmail-processor logs and keep unread-count lines only."""
-    result = get_deployment_logs("gmail-processor", namespace="vibeteam", tail=tail)
+    result = get_deployment_logs("gmail-processor", namespace=DEFAULT_NAMESPACE, tail=tail)
     if not result.success:
         return f"## Gmail Processor Logs\n\nError fetching logs: {result.stderr or result.stdout}"
     lines = [line for line in result.stdout.splitlines() if "unread" in line.lower()]
     if not lines:
         return "## Gmail Processor Logs\n\nNo unread-count lines found in recent logs."
     return "## Gmail Processor Logs (unread counts)\n\n" + "\n".join(lines)
+
 
 def fetch_gmail_context(max_results: int = 5) -> str:
     """Fetch Gmail context using shared tools."""
@@ -185,9 +190,7 @@ def build_gmail_summary() -> str:
 def build_notification_message(task: str) -> str:
     """Build a concise notification message from a notify-only task."""
     pr_match = re.search(r"PR\\s*#?(\\d+)", task, re.IGNORECASE)
-    env_match = re.search(
-        r"to\\s+(staging|production|prod|dev|qa)\\b", task, re.IGNORECASE
-    )
+    env_match = re.search(r"to\\s+(staging|production|prod|dev|qa)\\b", task, re.IGNORECASE)
     pr_part = f"PR #{pr_match.group(1)}" if pr_match else ""
     env = env_match.group(1).lower() if env_match else ""
     if env == "prod":
@@ -749,7 +752,8 @@ END OF INJECTED DATA - The above data has ALREADY been fetched for you
                 ]
             )
             is_explicit_investigation = any(
-                kw in task_lower for kw in ["investigate", "check", "debug", "analyze", "why", "error", "fail"]
+                kw in task_lower
+                for kw in ["investigate", "check", "debug", "analyze", "why", "error", "fail"]
             )
             if is_notification and not is_explicit_investigation:
                 response = build_notification_message(task)

--- a/agents/shared/kubectl_tools.py
+++ b/agents/shared/kubectl_tools.py
@@ -11,6 +11,7 @@ Requirements:
 """
 
 import logging
+import os
 import subprocess
 import time
 from concurrent.futures import ThreadPoolExecutor
@@ -19,10 +20,10 @@ from dataclasses import dataclass
 logger = logging.getLogger(__name__)
 
 # Default namespace for VibeTeam internal infrastructure
-DEFAULT_NAMESPACE = "vibeteam"
+DEFAULT_NAMESPACE = os.getenv("VIBETEAM_NAMESPACE", "vibeteam")
 
 # Production namespace for customer-facing services
-PRODUCTION_NAMESPACE = "vibe"
+PRODUCTION_NAMESPACE = os.getenv("VIBETEAM_PRODUCTION_NAMESPACE", "vibe")
 
 # Key deployments to monitor per namespace
 KEY_DEPLOYMENTS = [

--- a/k8s/base/openhands-svc.yaml
+++ b/k8s/base/openhands-svc.yaml
@@ -33,28 +33,6 @@ spec:
       serviceAccountName: vibeteam-agent
       imagePullSecrets:
         - name: ghcr-pull-secret
-      initContainers:
-        - name: copy-gmail-token
-          image: ghcr.io/vibetechnologies/vibeteam:latest
-          command: ["sh", "-c"]
-          args:
-            - |
-              cp /gmail-secrets/gmail-token.json /gmail-writable/gmail-token.json 2>/dev/null || true
-              cp /gmail-secrets/gmail-credentials.json /gmail-writable/gmail-credentials.json 2>/dev/null || true
-              echo "Gmail credentials copied to writable volume"
-          volumeMounts:
-            - name: gmail-secrets
-              mountPath: /gmail-secrets
-              readOnly: true
-            - name: gmail-writable
-              mountPath: /gmail-writable
-      volumes:
-        - name: gmail-secrets
-          secret:
-            secretName: gmail-oauth-secret
-            optional: false
-        - name: gmail-writable
-          emptyDir: {}
       containers:
         - name: openhands
           image: ghcr.io/vibetechnologies/vibeteam-openhands:latest
@@ -101,10 +79,10 @@ spec:
               value: "http://browserless:3000"
             - name: OPENHANDS_SYNC_IDLE_TIMEOUT_SECONDS
               value: "300"
-            - name: GMAIL_CREDENTIALS_PATH
-              value: "/gmail/gmail-credentials.json"
-            - name: GMAIL_TOKEN_PATH
-              value: "/gmail/gmail-token.json"
+            - name: VIBETEAM_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
           resources:
             requests:
               memory: "3Gi"
@@ -112,9 +90,6 @@ spec:
             limits:
               memory: "6Gi"
               cpu: "1000m"
-          volumeMounts:
-            - name: gmail-writable
-              mountPath: /gmail
           livenessProbe:
             httpGet:
               path: /health

--- a/k8s/base/vibeteam-gateway.yaml
+++ b/k8s/base/vibeteam-gateway.yaml
@@ -41,6 +41,10 @@ spec:
               value: "http://scheduler-svc:8080"
             - name: DEFAULT_FRAMEWORK
               value: "openhands"
+            - name: VIBETEAM_NAMESPACE
+              valueFrom:
+                fieldRef:
+                  fieldPath: metadata.namespace
             # GitHub configuration
             - name: GITHUB_WEBHOOK_SECRET
               valueFrom:

--- a/scripts/eval_slack_e2e.py
+++ b/scripts/eval_slack_e2e.py
@@ -51,8 +51,8 @@ load_dotenv()
 # Add parent directory to path
 sys.path.insert(0, os.path.dirname(os.path.dirname(os.path.abspath(__file__))))
 
-from agents.shared.role_resolver import ROLE_PATTERN
 from agents.shared.llm import resolve_azure_model
+from agents.shared.role_resolver import ROLE_PATTERN
 from vibeteam.connectors.slack import SlackConnector
 
 # Try to import DeepEval
@@ -1522,7 +1522,9 @@ async def run_evaluation(
             )
 
         # Step 2: Wait for bot response (with handoff chain support + auto-extend)
-        print(f"\n>>> Step 2: Waiting for agent response (timeout: {wait_timeout}s)")
+        print(
+            f"\n>>> Step 2: Waiting for agent response (idle timeout: {wait_timeout}s, no hard cap)"
+        )
         start_time = time.time()
         last_message_count = 1  # We posted 1 message
         # Stable time: how long to wait after the last change before concluding.
@@ -1531,10 +1533,9 @@ async def run_evaluation(
         # is detected, but require at least one substantive response before exiting.
         stable_time_no_handoff = 30
         stable_time_with_handoff = 300  # 5min wait for handoff agent
-        last_change_time = 0.0  # Tracks BOTH new messages AND content edits
+        last_change_time = start_time  # Tracks BOTH new messages AND content edits
         last_content_fingerprint = ""  # Hash of all message texts to detect chat.update edits
         pending_handoff = False
-        effective_timeout = wait_timeout
         has_substantive_response = False  # True once a real (non-placeholder) bot msg arrives
         # Track substantive responses per agent role for handoff completion.
         # When a handoff is detected, we need a substantive response from the
@@ -1561,7 +1562,7 @@ async def run_evaluation(
             m = re.match(r"_?\[([A-Za-z]+)\]", text.strip())
             return m.group(1) if m else ""
 
-        while time.time() - start_time < effective_timeout:
+        while True:
             await asyncio.sleep(poll_interval)
 
             replies = slack.get_thread_replies(channel=channel, thread_ts=thread_ts, limit=50)
@@ -1588,17 +1589,7 @@ async def run_evaluation(
                     latest_bot_msg = bot_messages[-1]
                     has_handoff = bool(ROLE_PATTERN.search(latest_bot_msg.text))
                     if has_handoff and not scenario.get("skip_handoff", False):
-                        # Auto-extend timeout on handoff detection
-                        remaining = (start_time + effective_timeout) - time.time()
-                        if handoff_timeout_extension > remaining:
-                            effective_timeout = time.time() - start_time + handoff_timeout_extension
-                            print(
-                                f"    Handoff detected! Extended timeout to "
-                                f"{int(effective_timeout)}s "
-                                f"(+{handoff_timeout_extension}s from now)"
-                            )
-                        else:
-                            print("    Handoff detected in response! Waiting for next agent...")
+                        print("    Handoff detected in response! Waiting for next agent...")
                         pending_handoff = True
                         # Track which agent initiated the handoff so we can
                         # distinguish its messages from the handoff target's
@@ -1675,8 +1666,19 @@ async def run_evaluation(
                     else:
                         print("    Still waiting for handoff response...")
 
+            idle_timeout = handoff_timeout_extension if pending_handoff else wait_timeout
+            idle_for = int(time.time() - last_change_time)
             elapsed = int(time.time() - start_time)
-            print(f"    Waiting... ({elapsed}s / {int(effective_timeout)}s)")
+            print(f"    Waiting... (idle {idle_for}s / {idle_timeout}s, total {elapsed}s)")
+
+            if idle_for >= idle_timeout:
+                if not has_substantive_response:
+                    print(
+                        "    No substantive response before idle timeout. Stopping evaluation wait."
+                    )
+                else:
+                    print("    Idle timeout reached after last response. Stopping wait.")
+                break
 
         latency_ms = int((time.time() - start_time) * 1000)
 

--- a/vibeteam/gateway/routes/slack.py
+++ b/vibeteam/gateway/routes/slack.py
@@ -576,6 +576,7 @@ def _build_task_prompt(
     is_thread_reply = thread_ts is not None
     template = classify_task_template(role, user_message, is_thread_reply=is_thread_reply)
     thread_display = thread_ts or "new thread"
+    internal_ns = os.getenv("VIBETEAM_NAMESPACE", "vibeteam")
 
     if template == "deployment":
         return f"""## Slack Deployment Request
@@ -595,14 +596,14 @@ A user has requested a deployment via Slack.
 ### CRITICAL SAFETY RULE: DO NOT DESTROY YOUR OWN INFRASTRUCTURE
 ### =================================================================
 ###
-### You (ReleaseEngineer) run INSIDE vibeteam-gateway and openhands-svc.
+### You (ReleaseEngineer) run INSIDE {internal_ns} (vibeteam-gateway, openhands-svc).
 ### If you restart or replace these pods, YOUR REQUEST DIES and the
 ### response NEVER reaches Slack. The eval/user sees a timeout.
 ###
 ### FORBIDDEN (kills your in-flight request):
 ###   kubectl apply -k (ANY path) — modifies pod specs, kills your pod
-###   kubectl rollout restart deployment/vibeteam-gateway -n vibeteam
-###   kubectl rollout restart deployment/openhands-svc -n vibeteam
+###   kubectl rollout restart deployment/vibeteam-gateway -n {internal_ns}
+###   kubectl rollout restart deployment/openhands-svc -n {internal_ns}
 ###   kubectl delete pod/deployment for gateway or openhands
 ###
 ### CRITICAL: YOU HAVE NO LOCAL REPOSITORY FILES
@@ -631,14 +632,14 @@ A user has requested a deployment via Slack.
 ### |-------------|-------------|------------------|
 ### | `vibe`      | Production  | VibeBrowser: user-portal, stripe-service, litellm |
 ### | `vibe-dev`  | Staging     | VibeBrowser (staging mirrors prod) |
-### | `vibeteam`  | Internal    | VibeTeam agents: vibeteam-gateway, openhands-svc |
+### | `{internal_ns}`  | Internal    | VibeTeam agents: vibeteam-gateway, openhands-svc |
 ###
 ### Repository → Image Map:
 ### | Repository                        | Image                                              | Namespaces    |
 ### |-----------------------------------|------------------------------------------------------|---------------|
 ### | VibeTechnologies/VibeWebAgent     | ghcr.io/vibetechnologies/vibe-user-portal:<SHA>      | vibe, vibe-dev |
 ### | VibeTechnologies/VibeWebAgent     | ghcr.io/vibetechnologies/vibe-stripe-service:<SHA>   | vibe, vibe-dev |
-### | VibeTechnologies/VibeTeam         | ghcr.io/vibetechnologies/vibeteam:<SHA>              | vibeteam       |
+### | VibeTechnologies/VibeTeam         | ghcr.io/vibetechnologies/vibeteam:<SHA>              | {internal_ns}       |
 ###
 ### "staging" / "dev" → namespace: vibe-dev
 ### "production" / "prod" → namespace: vibe
@@ -652,7 +653,7 @@ You are the ReleaseEngineer. You MUST execute the deployment, not just describe 
 From the user's message, determine the target namespace:
 - "staging" / "dev" → namespace: `vibe-dev`
 - "production" / "prod" → namespace: `vibe`
-- "agents" / "vibeteam" → namespace: `vibeteam`
+- "agents" / "vibeteam" → namespace: `{internal_ns}`
 If the request mentions a PR on VibeTechnologies/VibeWebAgent, default to `vibe-dev`.
 
 **STEP 2 — Get Image Tag from PR (MANDATORY):**
@@ -682,7 +683,7 @@ kubectl set image deployment/user-portal user-portal=ghcr.io/vibetechnologies/vi
 kubectl set image deployment/stripe-service stripe-service=ghcr.io/vibetechnologies/vibe-stripe-service:<SHA> -n <NAMESPACE>
 ```
 Do NOT run `kubectl apply -k` — it modifies pod specs and kills your own pod.
-Do NOT deploy to the `vibeteam` namespace unless the request is explicitly about VibeTeam agents.
+Do NOT deploy to the `{internal_ns}` namespace unless the request is explicitly about VibeTeam agents.
 
 Then monitor rollout (safe, read-only):
 ```bash
@@ -711,7 +712,7 @@ Summarize deployment outcome clearly.
 
 **REQUIRED OUTPUT:**
 Your response MUST include:
-1. Target namespace identified (vibe-dev, vibe, or vibeteam) and why
+1. Target namespace identified (vibe-dev, vibe, or {internal_ns}) and why
 2. PR merge commit SHA (from `gh pr view`)
 3. Pre-deployment state (pod status before)
 4. Current image tags (what's running now)
@@ -791,11 +792,11 @@ A user has requested a quick health & production-readiness check.
 |-------------|-------------|------------------|
 | `vibe`      | Production  | VibeBrowser: user-portal, stripe-service, litellm |
 | `vibe-dev`  | Staging     | VibeBrowser (staging mirrors prod) |
-| `vibeteam`  | Internal    | VibeTeam agents: vibeteam-gateway, openhands-svc |
+| `{internal_ns}`  | Internal    | VibeTeam agents: vibeteam-gateway, openhands-svc |
 
 "production" / "prod" / "api" → namespace: `vibe`
 "staging" / "dev" → namespace: `vibe-dev`
-"agents" / "vibeteam" / "gateway" → namespace: `vibeteam`
+"agents" / "vibeteam" / "gateway" → namespace: `{internal_ns}`
 If unclear, default to the production namespace `vibe`.
 
 ### Safety Rule
@@ -817,7 +818,7 @@ kubectl get pods -n <NAMESPACE> -o wide && kubectl get deployments -n <NAMESPACE
 **Tool call 2** — Curl the health endpoint:
 - `vibe` → `curl -s -w "\nHTTP_STATUS:%{{{{http_code}}}}" https://api.vibebrowser.app/health/readiness`
 - `vibe-dev` → `curl -s -w "\nHTTP_STATUS:%{{{{http_code}}}}" https://api-dev.vibebrowser.app/health/readiness`
-- `vibeteam` → `curl -s -w "\nHTTP_STATUS:%{{{{http_code}}}}" https://webhook.team.vibebrowser.app/health`
+- `{internal_ns}` → `curl -s -w "\nHTTP_STATUS:%{{{{http_code}}}}" https://webhook.team.vibebrowser.app/health`
 
 **Tool call 3** — Post your final summary to the conversation (finish action).
 
@@ -859,9 +860,9 @@ Sentry/monitoring data has been injected above. Use this as INITIAL context.
 **STEP 2 — RUN kubectl Commands (MANDATORY):**
 You MUST run kubectl commands to complete your investigation. Example:
 ```bash
-kubectl get pods -n vibeteam
-kubectl get events -n vibeteam --sort-by='.lastTimestamp' | tail -20
-kubectl logs deployment/vibeteam-gateway -n vibeteam --tail=100
+kubectl get pods -n {internal_ns}
+kubectl get events -n {internal_ns} --sort-by='.lastTimestamp' | tail -20
+kubectl logs deployment/vibeteam-gateway -n {internal_ns} --tail=100
 ```
 If you skip kubectl, your investigation is INCOMPLETE.
 


### PR DESCRIPTION
## Summary
- make kubectl context and Slack instructions use configurable namespace
- add `VIBETEAM_NAMESPACE` env to gateway and openhands-svc
- switch eval waiting to idle-timeout (no hard cap)

## Testing
- `ruff format` (selected files)
- `ruff check` (selected files)