### PR TITLE
Fix marketing_manager fallback mapping

### DIFF
--- a/vibeteam/agents/manager.py
+++ b/vibeteam/agents/manager.py
@@ -36,6 +36,7 @@ class AgentSessionManager:
     def _create_vibeteam_agent(self, role: AgentRole):
         """Create a vibeteam agent."""
         from vibeteam.agents import (
+            MarketerAgent,
             ProductManagerAgent,
             ReleaseEngineerAgent,
             SoftwareEngineerAgent,
@@ -47,7 +48,7 @@ class AgentSessionManager:
             "release_engineer": ReleaseEngineerAgent,
             "support_engineer": SupportEngineerAgent,
             "product_manager": ProductManagerAgent,
-            "marketing_manager": ProductManagerAgent,
+            "marketing_manager": MarketerAgent,
         }
         agent_class = agents.get(role)
         if agent_class:


### PR DESCRIPTION
## Summary
- Map `marketing_manager` to `MarketerAgent` in vibeteam fallback agent creation

## Why
The fallback mapping incorrectly routed `marketing_manager` to `ProductManagerAgent`, bypassing the dedicated marketing agent. This fixes issue #186.

## Testing
- Not run (single-line mapping change)

Closes #186.