### PR TITLE
Docs: align eval metrics/thresholds with scenarios

### DIFF
--- a/docs/agent_evaluation_workflow.md
+++ b/docs/agent_evaluation_workflow.md
@@ -13,6 +13,7 @@ This is a short overview of the evaluation loop. The canonical architecture and 
 
 - Role mentions are parsed via `agents/shared/role_resolver.py` and accept `@RoleName` or `/RoleName`.
 - The judge model is configured in `scripts/eval_slack_e2e.py` (default `gpt-5.2`).
+- Metrics and thresholds are scenario-specific and defined in `scripts/eval_slack_e2e.py` (`SCENARIOS`). Reports list the per-metric thresholds used for that run.
 - See [design.md](design.md) for system architecture.
 
 ## Run a Scenario

--- a/docs/design.md
+++ b/docs/design.md
@@ -474,11 +474,23 @@ python scripts/eval_slack_e2e.py --scenario support_400_errors
 
 ### Evaluation Metrics (DeepEval)
 
-| Metric | Threshold | Description |
-|--------|-----------|-------------|
-| TaskCompletion | 0.7 | Request fully addressed |
-| HandoffQuality | 0.7 | Context preservation |
-| ResponseTime | < 60s | Time to first response |
+Metrics and thresholds are scenario-specific and defined in `scripts/eval_slack_e2e.py` (`SCENARIOS` dict). The report lists each metric with its threshold; overall pass requires all metrics to meet their thresholds (typically `0.60`–`0.80`).
+
+Common metrics include:
+- InvestigationQuality
+- EvidenceBasedDecision
+- HandoffCompletion
+- ResponseEfficiency
+- NotificationOnly
+- SentryUsage
+- GmailUsage
+- IssueAnalysis
+- DeploymentExecution
+- CorrectNamespace
+- ChromeDevToolsUsage
+- HNFitAndGuidelines
+- CommunityFitAndRules
+- SoftPromoQuality
 
 
 # DeepEval test design

--- a/docs/eval-architecture.md
+++ b/docs/eval-architecture.md
@@ -237,4 +237,24 @@ cat results/eval_reports/eval_support_400_errors_*.md | head -100
 | 0.6 - 0.8 | Good | Root cause identified with evidence |
 | 0.8 - 1.0 | Excellent | Full investigation, resolution implemented |
 
-**Threshold: 0.60** (must achieve to pass)
+## Metrics and Thresholds
+
+Metrics and thresholds are **scenario-specific** and defined in `scripts/eval_slack_e2e.py` (`SCENARIOS`). Typical thresholds range `0.60`–`0.80`. A scenario passes only if **all** of its metrics meet their thresholds, and the report lists each metric with its threshold.
+
+Common metrics include:
+- InvestigationQuality
+- EvidenceBasedDecision
+- HandoffCompletion
+- ResponseEfficiency
+- NotificationOnly
+- SentryUsage
+- GmailUsage
+- IssueAnalysis
+- DeploymentExecution
+- CorrectNamespace
+- ChromeDevToolsUsage
+- HNFitAndGuidelines
+- CommunityFitAndRules
+- SoftPromoQuality
+
+If DeepEval is unavailable, reports are written with status `NO EVALUATION (DeepEval not available)` and no metric scores.


### PR DESCRIPTION
## Summary
- Document that metrics and thresholds are scenario-specific (SCENARIOS in eval script)
- Replace outdated fixed-metric table in design doc
- Note DeepEval unavailable case in eval-architecture

## Why
Eval docs were out of sync with `scripts/eval_slack_e2e.py` (scenario metrics and thresholds). This closes #188.

## Testing
- Not run (doc-only changes)

Closes #188.