### PR TITLE
Allow Gmail token refresh on read-only paths

### DIFF
--- a/agents/shared/gmail_tools.py
+++ b/agents/shared/gmail_tools.py
@@ -144,7 +144,14 @@ class GmailClient:
             if self.creds and self.creds.expired and self.creds.refresh_token:
                 # Refresh expired token
                 self.creds.refresh(self.Request())
-                self._save_token()
+                try:
+                    self._save_token()
+                except OSError as e:
+                    logger.warning(
+                        "Failed to write Gmail token to %s: %s",
+                        self.token_path,
+                        e,
+                    )
             else:
                 if headless:
                     raise RuntimeError(

--- a/vibeteam/connectors/gmail.py
+++ b/vibeteam/connectors/gmail.py
@@ -136,8 +136,11 @@ class GmailConnector:
                 flow = InstalledAppFlow.from_client_secrets_file(str(self.credentials_path), SCOPES)
                 self.creds = flow.run_local_server(port=0)
 
-            # Save token for future use
-            self._save_token()
+            # Save token for future use (best-effort; may be read-only in some environments)
+            try:
+                self._save_token()
+            except OSError:
+                pass
 
         # Build Gmail service
         self.service = build("gmail", "v1", credentials=self.creds)


### PR DESCRIPTION
## Summary
- Treat Gmail token save as best-effort when refreshing credentials
- Avoid failures when token path is mounted read-only

## Why
Support gmail evals sometimes fail because token refresh tries to write to a read-only mount (`/secrets/gmail-token.json`). We can still use refreshed creds for the current run without persisting.

## Testing
- Not run (logic change only)
