### PR TITLE
Add eyes reaction for Slack gateway reads

### DIFF
--- a/tests/test_async_callback.py
+++ b/tests/test_async_callback.py
@@ -849,13 +849,16 @@ class TestSlackEventsPassMessageTs:
             patch(
                 "vibeteam.gateway.routes.slack.add_reaction",
                 new_callable=AsyncMock,
-            ),
+            ) as mock_add,
             patch(
                 "vibeteam.gateway.routes.slack.run_agent_for_slack",
                 new_callable=AsyncMock,
             ) as mock_run,
         ):
             asyncio.run(_process_slack_event(payload))
+
+            mock_add.assert_any_call("C_TEST", "1234567890.123456", "eyes")
+            mock_add.assert_any_call("C_TEST", "1234567890.123456", "thinking_face")
 
             # Verify message_ts was passed
             mock_run.assert_called_once()
@@ -871,13 +874,16 @@ class TestSlackEventsPassMessageTs:
             patch(
                 "vibeteam.gateway.routes.slack.add_reaction",
                 new_callable=AsyncMock,
-            ),
+            ) as mock_add,
             patch(
                 "vibeteam.gateway.routes.slack.run_agent_for_slack",
                 new_callable=AsyncMock,
             ) as mock_run,
         ):
             asyncio.run(_process_slack_event(payload))
+
+            mock_add.assert_any_call("C_TEST", "1234567890.123456", "eyes")
+            mock_add.assert_any_call("C_TEST", "1234567890.123456", "thinking_face")
 
             mock_run.assert_called_once()
             assert mock_run.call_args.kwargs.get("message_ts") == "1234567890.123456"
@@ -892,13 +898,16 @@ class TestSlackEventsPassMessageTs:
             patch(
                 "vibeteam.gateway.routes.slack.add_reaction",
                 new_callable=AsyncMock,
-            ),
+            ) as mock_add,
             patch(
                 "vibeteam.gateway.routes.slack.run_agent_for_slack",
                 new_callable=AsyncMock,
             ) as mock_run,
         ):
             asyncio.run(_process_slack_event(payload))
+
+            mock_add.assert_any_call("C_TEST", "1234567890.123456", "eyes")
+            mock_add.assert_any_call("C_TEST", "1234567890.123456", "thinking_face")
 
             mock_run.assert_called_once()
             assert mock_run.call_args.kwargs.get("message_ts") == "1234567890.123456"

--- a/vibeteam/gateway/routes/slack.py
+++ b/vibeteam/gateway/routes/slack.py
@@ -355,6 +355,13 @@ async def add_reaction(
         return False
 
 
+async def add_read_reaction(channel: str, message_ts: str | None) -> bool:
+    """Add the :eyes: reaction to indicate the gateway read the message."""
+    if not message_ts:
+        return False
+    return await add_reaction(channel, message_ts, "eyes")
+
+
 async def remove_reaction(
     channel: str,
     timestamp: str,
@@ -1444,6 +1451,7 @@ async def _process_slack_event(payload: dict[str, Any]) -> dict[str, Any]:
 
             # React with thinking face to show we're working on it
             if message_ts:
+                await add_read_reaction(channel, message_ts)
                 await add_reaction(channel, message_ts, "thinking_face")
 
             await run_agent_for_slack(
@@ -1462,6 +1470,7 @@ async def _process_slack_event(payload: dict[str, Any]) -> dict[str, Any]:
 
             # React with thinking face to show we're working on it
             if message_ts:
+                await add_read_reaction(channel, message_ts)
                 await add_reaction(channel, message_ts, "thinking_face")
 
             await run_agent_for_slack(text, channel, thread_ts, user_id, message_ts=message_ts)
@@ -1525,6 +1534,7 @@ async def _process_slack_event(payload: dict[str, Any]) -> dict[str, Any]:
                     )
 
                 if message_ts:
+                    await add_read_reaction(channel, message_ts)
                     await add_reaction(channel, message_ts, "thinking_face")
 
                 await run_agent_for_slack(text, channel, thread_ts, user_id, message_ts=message_ts)
@@ -1570,6 +1580,7 @@ async def _process_slack_event(payload: dict[str, Any]) -> dict[str, Any]:
 
             # React with thinking face to show we're processing the message
             if message_ts:
+                await add_read_reaction(channel, message_ts)
                 await add_reaction(channel, message_ts, "thinking_face")
 
             await run_agent_for_slack(text, channel, thread_ts, user_id, message_ts=message_ts)


### PR DESCRIPTION
## Summary
- add a helper to react with :eyes: when Slack messages are read by the gateway
- apply :eyes: alongside :thinking_face: for app mentions, DMs, subscribed thread replies, and bot handoff messages
- extend Slack event tests to assert :eyes: reactions

## Testing
- `export $( < .env ) && uv run python -m pytest tests/test_async_callback.py -k SlackEventsPassMessageTs -v`
