### PR TITLE
fix(k8s): enable responses models for agents

### DIFF
--- a/k8s/base/autogen-svc.yaml
+++ b/k8s/base/autogen-svc.yaml
@@ -55,6 +55,8 @@ spec:
                 secretKeyRef:
                   name: vibeteam-secrets
                   key: AZURE_API_VERSION
+            - name: AZURE_ALLOW_RESPONSES_MODELS
+              value: "true"
             - name: GITHUB_TOKEN
               valueFrom:
                 secretKeyRef:

--- a/k8s/base/crewai-svc.yaml
+++ b/k8s/base/crewai-svc.yaml
@@ -55,6 +55,8 @@ spec:
                 secretKeyRef:
                   name: vibeteam-secrets
                   key: AZURE_API_VERSION
+            - name: AZURE_ALLOW_RESPONSES_MODELS
+              value: "true"
             - name: GITHUB_TOKEN
               valueFrom:
                 secretKeyRef:

--- a/k8s/base/frameworks/autogen.yaml
+++ b/k8s/base/frameworks/autogen.yaml
@@ -45,6 +45,8 @@ spec:
                 secretKeyRef:
                   name: vibeteam-secrets
                   key: AZURE_API_VERSION
+            - name: AZURE_ALLOW_RESPONSES_MODELS
+              value: "true"
             - name: GITHUB_TOKEN
               valueFrom:
                 secretKeyRef:

--- a/k8s/base/frameworks/crewai.yaml
+++ b/k8s/base/frameworks/crewai.yaml
@@ -45,6 +45,8 @@ spec:
                 secretKeyRef:
                   name: vibeteam-secrets
                   key: AZURE_API_VERSION
+            - name: AZURE_ALLOW_RESPONSES_MODELS
+              value: "true"
             - name: GITHUB_TOKEN
               valueFrom:
                 secretKeyRef:

--- a/k8s/base/frameworks/openhands.yaml
+++ b/k8s/base/frameworks/openhands.yaml
@@ -46,6 +46,8 @@ spec:
                 secretKeyRef:
                   name: vibeteam-secrets
                   key: AZURE_API_VERSION
+            - name: AZURE_ALLOW_RESPONSES_MODELS
+              value: "true"
             - name: GITHUB_TOKEN
               valueFrom:
                 secretKeyRef:

--- a/k8s/base/openhands-svc.yaml
+++ b/k8s/base/openhands-svc.yaml
@@ -65,6 +65,8 @@ spec:
                 secretKeyRef:
                   name: vibeteam-secrets
                   key: AZURE_API_VERSION
+            - name: AZURE_ALLOW_RESPONSES_MODELS
+              value: "true"
             - name: GITHUB_TOKEN
               valueFrom:
                 secretKeyRef:


### PR DESCRIPTION
Sets AZURE_ALLOW_RESPONSES_MODELS=true for agent deployments so responses-only models (e.g., gpt-5.2-codex) can be used when API version supports it.\n\nTests:\n- kustomize build k8s/base\n- kustomize build k8s/base/frameworks