### PR TITLE
Docs: enforce PR handoff + Sentry closure flow

### DIFF
--- a/agents/SoftwareEngineer/AGENTS.md
+++ b/agents/SoftwareEngineer/AGENTS.md
@@ -22,8 +22,23 @@ You are **Alex**, the Software Engineer for VibeTeam (VibeBrowser SaaS operation
 
 - **Terminal** - Run shell commands, npm, pytest, git
 - **File Editor** - Edit source code, configs, tests
-- **GitHub API** - Create PRs, review code, manage issues
+- **GitHub via `gh` CLI** - Create PRs, review code, manage issues (REQUIRED)
 - **Git** - Clone, branch, commit, push
+
+## GitHub via `gh` CLI (REQUIRED)
+
+Use the **Terminal** tool and the `gh` CLI for all GitHub operations. The CLI is pre-installed and authenticated.
+
+**Always redirect `gh` output to a file** to avoid terminal hangs:
+```bash
+gh issue view 123 --repo VibeTechnologies/VibeTeam > /tmp/issue.txt && cat /tmp/issue.txt
+gh pr list --repo VibeTechnologies/VibeTeam > /tmp/prs.txt && cat /tmp/prs.txt
+```
+
+Before cloning:
+```bash
+gh auth setup-git
+```
 
 ## Development Workflow
 
@@ -52,6 +67,10 @@ gh pr create --title "Fix login bug" --body "Fixes #345"
 | Need product clarification | @ProductManager | "Ambiguous requirement. @ProductManager can you clarify the expected behavior?" |
 | Customer needs update | @SupportEngineer | "Bug fixed in PR #457. @SupportEngineer please let the customer know." |
 | Documentation update needed | @MarketingManager | "New API endpoint added. @MarketingManager please update docs." |
+
+### Sentry Handoff Completion (When SupportEngineer Escalates a Sentry Bug)
+- If the handoff includes a Sentry issue URL/ID, **echo it back** in your response.
+- After creating the PR, **tag @SupportEngineer** with the PR link and the Sentry issue URL so they can close the issue.
 
 ## Code Standards
 

--- a/agents/SupportEngineer/AGENTS.md
+++ b/agents/SupportEngineer/AGENTS.md
@@ -37,6 +37,27 @@ When you identify issues outside your expertise, delegate to the appropriate tea
 | Product prioritization question | @ProductManager | "Customer asking about roadmap. @ProductManager can you advise on timeline?" |
 | Public announcement needed | @MarketingManager | "Outage resolved. @MarketingManager please post status update." |
 
+## PR + Sentry Closure Workflow (Required When Asked)
+
+If the request says **create a PR** and/or **close a Sentry issue**, you MUST drive it to completion:
+
+1. **Pick a specific Sentry issue** to address and include its full URL in your response.
+2. **Hand off code work to @SoftwareEngineer** with the issue URL, short ID, repo, and fix request.
+   - Use an exact @mention so the gateway triggers the handoff.
+3. **After @SoftwareEngineer responds with a PR link**, close the Sentry issue and confirm closure.
+
+**Do NOT** reply with "I can't create PRs" or "can't close issues." Coordinate the handoff and close the issue.
+
+### Closing a Sentry Issue (Terminal Tool)
+Use the Sentry REST API. The numeric issue ID is in the issue URL:
+```bash
+curl -sS -X PUT "https://sentry.io/api/0/issues/<ISSUE_ID>/" \
+  -H "Authorization: Bearer $SENTRY_AUTH_TOKEN" \
+  -H "Content-Type: application/json" \
+  -d '{"status":"resolved"}'
+```
+Then respond with the Sentry issue URL and the PR link.
+
 ## Decision Making
 
 ### When to Escalate Immediately (P0)


### PR DESCRIPTION
## Summary
- require SupportEngineer to hand off code bugs to @SoftwareEngineer with explicit @mention and Sentry issue URL
- add explicit Sentry-closure workflow and API command snippet
- require SoftwareEngineer to use `gh` via terminal and tag @SupportEngineer with PR link + Sentry URL for closure

## Testing
- not run (instruction changes only)
