### PR TITLE
Slack: detect bare role handoffs + eval Sentry URL parsing

### DIFF
--- a/scripts/eval_slack_e2e.py
+++ b/scripts/eval_slack_e2e.py
@@ -1358,15 +1358,22 @@ def _extract_sentry_issue_ids(text: str) -> list[int]:
     issue_ids: list[int] = []
     seen: set[int] = set()
 
-    url_pattern = re.compile(
-        r"https?://sentry\.io/(?:organizations/[^/]+/)?issues/(?P<number>\d+)",
-        re.IGNORECASE,
-    )
-    for match in url_pattern.finditer(text):
-        issue_id = int(match.group("number"))
-        if issue_id not in seen:
-            seen.add(issue_id)
-            issue_ids.append(issue_id)
+    url_patterns = [
+        re.compile(
+            r"https?://sentry\.io/(?:organizations/[^/]+/)?issues/(?P<number>\d+)",
+            re.IGNORECASE,
+        ),
+        re.compile(
+            r"https?://[A-Za-z0-9-]+\.sentry\.io/issues/(?P<number>\d+)",
+            re.IGNORECASE,
+        ),
+    ]
+    for pattern in url_patterns:
+        for match in pattern.finditer(text):
+            issue_id = int(match.group("number"))
+            if issue_id not in seen:
+                seen.add(issue_id)
+                issue_ids.append(issue_id)
 
     if issue_ids:
         return issue_ids
@@ -1894,9 +1901,30 @@ async def run_evaluation(
                     return role
             return ""
 
+        def _parse_role_mentions_loose(text: str) -> list[str]:
+            """Parse role mentions, including bare role names in handoff phrasing."""
+            explicit = parse_role_mentions(text)
+            if explicit:
+                return explicit
+            # Remove leading agent prefix like "[SupportEngineer]"
+            clean = re.sub(r"_?\\[[A-Za-z]+\\]\\s*", "", text.strip())
+            names_pattern = "|".join(re.escape(v) for v in ROLE_DISPLAY.values())
+            if not names_pattern:
+                return []
+            pattern = re.compile(
+                rf"(?i)(?<![@/])\\b({names_pattern})\\b(?=\\s*(?:please|:|-|—))"
+            )
+            display_to_role = {v.lower(): k for k, v in ROLE_DISPLAY.items()}
+            roles: list[str] = []
+            for match in pattern.findall(clean):
+                role = display_to_role.get(match.lower())
+                if role and role not in roles:
+                    roles.append(role)
+            return roles
+
         def _has_non_self_handoff(text: str) -> bool:
             """True if text mentions a role other than the current agent."""
-            targets = parse_role_mentions(text)
+            targets = _parse_role_mentions_loose(text)
             if not targets:
                 return False
             source_role = _display_to_role(_extract_agent_prefix(text))

--- a/vibeteam/gateway/routes/slack.py
+++ b/vibeteam/gateway/routes/slack.py
@@ -80,6 +80,34 @@ _trigger_rate_limiter = TokenBucketRateLimiter(
 )
 
 
+def _parse_handoff_roles(response: str, source_role: str) -> list[str]:
+    """Parse handoff roles, allowing bare role names in handoff phrasing.
+
+    Falls back to detecting lines like "SoftwareEngineer please ..." when @mentions
+    are missing, while avoiding self-handoffs.
+    """
+    message_router = get_message_router()
+    explicit = message_router.parse_role_mentions(response)
+    if explicit:
+        return explicit
+
+    # Remove leading agent prefix like "[SupportEngineer]" if present.
+    clean = re.sub(r"_?\\[[A-Za-z]+\\]\\s*", "", response.strip())
+    names_pattern = "|".join(re.escape(name) for name in ROLE_DISPLAY_NAMES.values())
+    if not names_pattern:
+        return []
+    pattern = re.compile(
+        rf"(?i)(?<![@/])\\b({names_pattern})\\b(?=\\s*(?:please|:|-|—))"
+    )
+    display_to_role = {v.lower(): k for k, v in ROLE_DISPLAY_NAMES.items()}
+    roles: list[str] = []
+    for match in pattern.findall(clean):
+        role = display_to_role.get(match.lower())
+        if role and role != source_role and role not in roles:
+            roles.append(role)
+    return roles
+
+
 def split_long_message(text: str, max_chunk_size: int = 2900) -> list[str]:
     """
     Split a long message into chunks, trying to break at newlines or spaces.
@@ -1230,8 +1258,7 @@ async def _run_agent_and_respond(
                 await send_slack_message(channel, formatted_chunk, thread_ts)
 
             # Check for handoffs in the response and execute them synchronously
-            message_router = get_message_router()
-            handoff_roles = message_router.parse_role_mentions(response)
+            handoff_roles = _parse_handoff_roles(response, role)
             logger.info(f"Checking for handoffs in response from {role}: found {handoff_roles}")
             if handoff_roles and current_depth < max_handoff_depth:
                 logger.info(


### PR DESCRIPTION
## Summary
- allow handoff detection when agents write `SoftwareEngineer please ...` without @mention
- extend Sentry URL parsing in eval post-checks to support org subdomain URLs
- keep strict @mention parsing for routing, only loosen for handoff detection

## Testing
- not run (logic change only)
