### PR TITLE
Slack: treat bare role names as handoffs

### DIFF
--- a/scripts/eval_slack_e2e.py
+++ b/scripts/eval_slack_e2e.py
@@ -1907,13 +1907,11 @@ async def run_evaluation(
             if explicit:
                 return explicit
             # Remove leading agent prefix like "[SupportEngineer]"
-            clean = re.sub(r"_?\\[[A-Za-z]+\\]\\s*", "", text.strip())
+            clean = re.sub(r"_?\[[A-Za-z]+\]\s*", "", text.strip())
             names_pattern = "|".join(re.escape(v) for v in ROLE_DISPLAY.values())
             if not names_pattern:
                 return []
-            pattern = re.compile(
-                rf"(?i)(?<![@/])\\b({names_pattern})\\b(?=\\s*(?:please|:|-|—))"
-            )
+            pattern = re.compile(rf"(?i)(?<![@/])\\b({names_pattern})\\b")
             display_to_role = {v.lower(): k for k, v in ROLE_DISPLAY.items()}
             roles: list[str] = []
             for match in pattern.findall(clean):

--- a/vibeteam/gateway/routes/slack.py
+++ b/vibeteam/gateway/routes/slack.py
@@ -92,13 +92,11 @@ def _parse_handoff_roles(response: str, source_role: str) -> list[str]:
         return explicit
 
     # Remove leading agent prefix like "[SupportEngineer]" if present.
-    clean = re.sub(r"_?\\[[A-Za-z]+\\]\\s*", "", response.strip())
+    clean = re.sub(r"_?\[[A-Za-z]+\]\s*", "", response.strip())
     names_pattern = "|".join(re.escape(name) for name in ROLE_DISPLAY_NAMES.values())
     if not names_pattern:
         return []
-    pattern = re.compile(
-        rf"(?i)(?<![@/])\\b({names_pattern})\\b(?=\\s*(?:please|:|-|—))"
-    )
+    pattern = re.compile(rf"(?i)(?<![@/])\\b({names_pattern})\\b")
     display_to_role = {v.lower(): k for k, v in ROLE_DISPLAY_NAMES.items()}
     roles: list[str] = []
     for match in pattern.findall(clean):


### PR DESCRIPTION
## Summary
- make handoff detection permissive for bare role names (no @) in Slack responses
- update eval handoff detection to match the same behavior

## Testing
- not run (logic change only)
