### PR TITLE
Slack: fix loose handoff word-boundary regex

### DIFF
--- a/scripts/eval_slack_e2e.py
+++ b/scripts/eval_slack_e2e.py
@@ -1911,7 +1911,7 @@ async def run_evaluation(
             names_pattern = "|".join(re.escape(v) for v in ROLE_DISPLAY.values())
             if not names_pattern:
                 return []
-            pattern = re.compile(rf"(?i)(?<![@/])\\b({names_pattern})\\b")
+            pattern = re.compile(rf"(?i)(?<![@/])\b({names_pattern})\b")
             display_to_role = {v.lower(): k for k, v in ROLE_DISPLAY.items()}
             roles: list[str] = []
             for match in pattern.findall(clean):

--- a/vibeteam/gateway/routes/slack.py
+++ b/vibeteam/gateway/routes/slack.py
@@ -96,7 +96,7 @@ def _parse_handoff_roles(response: str, source_role: str) -> list[str]:
     names_pattern = "|".join(re.escape(name) for name in ROLE_DISPLAY_NAMES.values())
     if not names_pattern:
         return []
-    pattern = re.compile(rf"(?i)(?<![@/])\\b({names_pattern})\\b")
+    pattern = re.compile(rf"(?i)(?<![@/])\b({names_pattern})\b")
     display_to_role = {v.lower(): k for k, v in ROLE_DISPLAY_NAMES.items()}
     roles: list[str] = []
     for match in pattern.findall(clean):


### PR DESCRIPTION
## Summary
- fix loose handoff regex to use real word boundaries so bare role names are detected
- keep behavior consistent between gateway handoff detection and eval script

## Testing
- not run (logic change only)
