### PR TITLE
fix(slack): infer repo from Sentry project keys

### DIFF
--- a/vibeteam/gateway/routes/slack.py
+++ b/vibeteam/gateway/routes/slack.py
@@ -171,6 +171,10 @@ def _extract_sentry_urls(text: str) -> list[str]:
 
 
 def _extract_repo_reference(text: str) -> str | None:
+    sentry_project_patterns = [
+        (r"\bvibebrowserextension\b", "VibeTechnologies/VibeBrowserExtension"),
+        (r"\bvibe[-_ ]?api[-_ ]?gateway\b", "VibeTechnologies/vibe-api-gateway"),
+    ]
     alias_patterns = [
         (r"vibe[-_ ]?browser[-_ ]?extension", "VibeTechnologies/VibeBrowserExtension"),
         (r"vibe[-_ ]?api[-_ ]?gateway", "VibeTechnologies/vibe-api-gateway"),
@@ -189,6 +193,9 @@ def _extract_repo_reference(text: str) -> str | None:
             return match.group(1).strip().rstrip(").,")
 
     lowered = text.lower()
+    for pattern, repo in sentry_project_patterns:
+        if re.search(pattern, lowered):
+            return repo
     if "repo" in lowered or "repository" in lowered:
         for pattern, repo in alias_patterns:
             if re.search(pattern, lowered):


### PR DESCRIPTION
## Summary\n- map Sentry project keys (e.g., VIBEBROWSEREXTENSION, VIBE-API-GATEWAY) to canonical repos\n- enables SoftwareEngineer to select correct repo even if handoff says 'browser extension codebase' without owner\n\n## Testing\n- not run (requires Slack/Gateway env)