### PR TITLE
fix: improve sentry context and pr handoff

### DIFF
--- a/agent_service/openhands/software_engineer.py
+++ b/agent_service/openhands/software_engineer.py
@@ -553,6 +553,12 @@ class OpenHandsSoftwareEngineer:
             return True
 
         task_lower = task.lower()
+        # Sentry handoffs should always use tools (code + PR creation).
+        if "sentry" in task_lower:
+            if "sentry.io" in task_lower or "sentry issue" in task_lower or "issue" in task_lower:
+                return True
+            if "repository:" in task_lower or "repo" in task_lower:
+                return True
         # If a GitHub issue is referenced, require tools so we can inspect code.
         try:
             import re
@@ -1884,6 +1890,26 @@ code matches. Use `gh search code` and `gh api` for further investigation:
                     prefetched_repo_only = True
                     extra_guidance_lines.append(
                         "Use the pre-fetched repo search results; include file:line evidence."
+                    )
+
+                sentry_related = "sentry" in user_message_lower or "sentry.io" in user_message_lower
+                pr_requested = any(
+                    kw in user_message_lower
+                    for kw in (
+                        "create a pr",
+                        "create pr",
+                        "open a pr",
+                        "submit a pr",
+                        "pull request",
+                        "fix",
+                        "bug",
+                        "address",
+                    )
+                )
+                if sentry_related and pr_requested:
+                    extra_guidance_lines.append(
+                        "REQUIRED: create a PR with gh CLI and include the PR URL/number in your response. "
+                        "Echo the Sentry issue URL/ID and tag @SupportEngineer with an explicit request to close it now."
                     )
 
                 # Keywords that suggest infrastructure/deployment work

--- a/agent_service/openhands/support_engineer.py
+++ b/agent_service/openhands/support_engineer.py
@@ -37,9 +37,15 @@ from agents.shared.langfuse_tools import get_langfuse_context
 from agents.shared.sentry_tools import get_sentry_context
 
 
-def fetch_sentry_context(hours: int = 24, limit: int = 10) -> str:
+def fetch_sentry_context(
+    hours: int = 24, limit: int = 10, include_top_issue_details: bool = False
+) -> str:
     """Fetch Sentry issues and format as context for the agent."""
-    return get_sentry_context(hours=hours, limit=limit)
+    return get_sentry_context(
+        hours=hours,
+        limit=limit,
+        include_top_issue_details=include_top_issue_details,
+    )
 
 
 def fetch_kubectl_context() -> str:
@@ -782,7 +788,21 @@ class OpenHandsSupportEngineer:
                     "complaint",  # customer reports often relate to errors
                 ]
                 if not skip_infra_context and any(kw in task_lower for kw in sentry_keywords):
-                    sentry_ctx = fetch_sentry_context()
+                    include_top_issue_details = any(
+                        kw in task_lower
+                        for kw in [
+                            "pr",
+                            "pull request",
+                            "bug",
+                            "fix",
+                            "address",
+                            "close sentry",
+                            "close the sentry",
+                        ]
+                    )
+                    sentry_ctx = fetch_sentry_context(
+                        include_top_issue_details=include_top_issue_details
+                    )
                     injected_context.append(sentry_ctx)
                     # Also inject kubectl context for infrastructure issues
                     # This eliminates the need for agents to run kubectl manually

--- a/agents/shared/sentry_tools.py
+++ b/agents/shared/sentry_tools.py
@@ -225,7 +225,42 @@ class SentryClient:
 # ============================================================================
 
 
-def get_sentry_context(hours: int = 24, limit: int = 10) -> str:
+def _format_issue_details(details: dict) -> str:
+    result = f"## Sentry Issue Details: {details.get('shortId', details.get('id', 'unknown'))}\n\n"
+    result += f"**{details.get('title', 'Unknown')}**\n\n"
+    result += f"- Status: {details.get('status', 'unknown')}\n"
+    result += f"- Level: {details.get('level', 'unknown')}\n"
+    result += f"- Count: {details.get('count', 0)}\n"
+    result += f"- Users Affected: {details.get('userCount', 0)}\n"
+    result += f"- First Seen: {details.get('firstSeen', 'unknown')}\n"
+    result += f"- Last Seen: {details.get('lastSeen', 'unknown')}\n"
+    result += f"- URL: {details.get('permalink', 'N/A')}\n"
+
+    latest_event = details.get("latestEvent")
+    if latest_event:
+        entries = latest_event.get("entries", [])
+        for entry in entries:
+            if entry.get("type") == "exception":
+                result += "\n### Stacktrace\n```\n"
+                values = entry.get("data", {}).get("values", [])
+                for exc in values:
+                    result += f"{exc.get('type', 'Exception')}: {exc.get('value', '')}\n"
+                    stacktrace = exc.get("stacktrace", {})
+                    frames = stacktrace.get("frames", [])[-5:]
+                    for frame in reversed(frames):
+                        filename = frame.get("filename", "?")
+                        lineno = frame.get("lineNo", "?")
+                        function = frame.get("function", "?")
+                        result += f"  at {function} ({filename}:{lineno})\n"
+                result += "```\n"
+                break
+
+    return result
+
+
+def get_sentry_context(
+    hours: int = 24, limit: int = 10, include_top_issue_details: bool = False
+) -> str:
     """
     Fetch Sentry issues and format as context for agents.
 
@@ -257,6 +292,13 @@ def get_sentry_context(hours: int = 24, limit: int = 10) -> str:
             result += f"- Level: {issue.level} | Count: {issue.count} | Users: {issue.user_count}\n"
             result += f"- First seen: {issue.first_seen[:10]} | Last seen: {issue.last_seen[:10]}\n"
             result += f"- URL: {issue.permalink}\n\n"
+
+        if include_top_issue_details and issues:
+            try:
+                details = client.get_issue_details(issues[0].id)
+                result += "\n" + _format_issue_details(details)
+            except Exception as e:
+                result += f"\nSentry: Failed to fetch top issue details ({e})\n"
 
         return result
 
@@ -297,37 +339,7 @@ async def get_sentry_issue_details(issue_id: str) -> str:
         client = SentryClient(auth_token=auth_token, timeout=10.0)
         details = client.get_issue_details(issue_id)
 
-        result = f"## Sentry Issue Details: {details.get('shortId', issue_id)}\n\n"
-        result += f"**{details.get('title', 'Unknown')}**\n\n"
-        result += f"- Status: {details.get('status', 'unknown')}\n"
-        result += f"- Level: {details.get('level', 'unknown')}\n"
-        result += f"- Count: {details.get('count', 0)}\n"
-        result += f"- Users Affected: {details.get('userCount', 0)}\n"
-        result += f"- First Seen: {details.get('firstSeen', 'unknown')}\n"
-        result += f"- Last Seen: {details.get('lastSeen', 'unknown')}\n"
-        result += f"- URL: {details.get('permalink', 'N/A')}\n"
-
-        # Include stacktrace if available
-        latest_event = details.get("latestEvent")
-        if latest_event:
-            entries = latest_event.get("entries", [])
-            for entry in entries:
-                if entry.get("type") == "exception":
-                    result += "\n### Stacktrace\n```\n"
-                    values = entry.get("data", {}).get("values", [])
-                    for exc in values:
-                        result += f"{exc.get('type', 'Exception')}: {exc.get('value', '')}\n"
-                        stacktrace = exc.get("stacktrace", {})
-                        frames = stacktrace.get("frames", [])[-5:]  # Last 5 frames
-                        for frame in reversed(frames):
-                            filename = frame.get("filename", "?")
-                            lineno = frame.get("lineNo", "?")
-                            function = frame.get("function", "?")
-                            result += f"  at {function} ({filename}:{lineno})\n"
-                    result += "```\n"
-                    break
-
-        return result
+        return _format_issue_details(details)
 
     except requests.Timeout:
         return "Sentry: Request timed out."


### PR DESCRIPTION
## Summary\n- add top Sentry issue stacktrace/details to context when PRs are requested\n- enforce tool usage and PR requirement for Sentry handoffs\n- include explicit close request to SupportEngineer\n\n## Testing\n- not run (eval to follow)