### PR TITLE
fix: map vibebrowserextension to VibeWebAgent

### DIFF
--- a/vibeteam/gateway/routes/slack.py
+++ b/vibeteam/gateway/routes/slack.py
@@ -175,11 +175,11 @@ def _extract_sentry_urls(text: str) -> list[str]:
 
 def _extract_repo_reference(text: str) -> str | None:
     sentry_project_patterns = [
-        (r"\bvibebrowserextension\b", "VibeTechnologies/VibeBrowserExtension"),
+        (r"\bvibebrowserextension\b", "VibeTechnologies/VibeWebAgent"),
         (r"\bvibe[-_ ]?api[-_ ]?gateway\b", "VibeTechnologies/vibe-api-gateway"),
     ]
     alias_patterns = [
-        (r"vibe[-_ ]?browser[-_ ]?extension", "VibeTechnologies/VibeBrowserExtension"),
+        (r"vibe[-_ ]?browser[-_ ]?extension", "VibeTechnologies/VibeWebAgent"),
         (r"vibe[-_ ]?api[-_ ]?gateway", "VibeTechnologies/vibe-api-gateway"),
         (r"vibe[-_ ]?web[-_ ]?agent", "VibeTechnologies/VibeWebAgent"),
         (r"vibeteam", "VibeTechnologies/VibeTeam"),


### PR DESCRIPTION
## Summary\n- map vibebrowserextension Sentry project to VibeWebAgent repo for handoffs\n\n## Testing\n- not run (eval to follow)