### PR TITLE
Tighten Sentry→PR handoffs and pass PR links

### DIFF
--- a/agent_service/openhands/software_engineer.py
+++ b/agent_service/openhands/software_engineer.py
@@ -2387,6 +2387,7 @@ END OF INJECTED DATA - The above data has ALREADY been fetched for you
             requires_tools = self._task_requires_tools(task, context_type)
             pr_required = self._task_requires_pr(task)
             used_single_pass = False
+            auto_pr_created = False
             if (prefetched_issue or prefetched_repo_only) and not requires_tools:
                 used_single_pass = True
                 print(
@@ -2420,9 +2421,10 @@ END OF INJECTED DATA - The above data has ALREADY been fetched for you
                             f"Sentry issue: {sentry_ref}\n"
                             "@SupportEngineer please close the Sentry issue now."
                         )
+                        auto_pr_created = True
 
             # If response is missing evidence, build a deterministic summary.
-            if prefetched_issue_number:
+            if prefetched_issue_number and not auto_pr_created:
                 import re as _re
 
                 response_lower = response.lower()
@@ -2450,7 +2452,7 @@ END OF INJECTED DATA - The above data has ALREADY been fetched for you
                     response = self._build_issue_triage_response(
                         prefetched_issue_number, github_ctx, repo_ctx
                     )
-            elif prefetched_repo_only:
+            elif prefetched_repo_only and not auto_pr_created:
                 import re as _re
 
                 response_lower = response.lower()

--- a/agent_service/openhands/support_engineer.py
+++ b/agent_service/openhands/support_engineer.py
@@ -154,6 +154,92 @@ def _summarize_sentry(context: str) -> str:
     return "Sentry status unavailable."
 
 
+def _task_mentions_pr(task_lower: str) -> bool:
+    return bool(re.search(r"\bpr\b", task_lower)) or "pull request" in task_lower
+
+
+def _extract_top_sentry_issue(context: str) -> dict[str, str] | None:
+    lines = [line.rstrip() for line in context.splitlines()]
+    for idx, line in enumerate(lines):
+        if line.startswith("### ["):
+            match = re.match(r"### \[(?P<project>[^\]]+)\] (?P<short_id>\S+)", line)
+            if not match:
+                continue
+            project = match.group("project")
+            short_id = match.group("short_id")
+            title = ""
+            url = ""
+            count = ""
+            for j in range(idx + 1, min(idx + 6, len(lines))):
+                if lines[j].startswith("**") and lines[j].endswith("**"):
+                    title = lines[j].strip("*")
+                    break
+            for j in range(idx + 1, min(idx + 12, len(lines))):
+                if lines[j].startswith("- URL:"):
+                    url = lines[j].split(":", 1)[1].strip()
+                    break
+            for j in range(idx + 1, min(idx + 10, len(lines))):
+                if "Count:" in lines[j]:
+                    count = lines[j].split("Count:", 1)[1].split("|", 1)[0].strip()
+                    break
+            return {
+                "project": project,
+                "short_id": short_id,
+                "title": title,
+                "url": url,
+                "count": count,
+            }
+
+    # Fallback to details block if present.
+    for idx, line in enumerate(lines):
+        if line.startswith("## Sentry Issue Details:"):
+            short_id = line.split(":", 1)[1].strip()
+            title = ""
+            url = ""
+            count = ""
+            for j in range(idx + 1, min(idx + 6, len(lines))):
+                if lines[j].startswith("**") and lines[j].endswith("**"):
+                    title = lines[j].strip("*")
+                    break
+            for j in range(idx + 1, min(idx + 12, len(lines))):
+                if lines[j].startswith("- URL:"):
+                    url = lines[j].split(":", 1)[1].strip()
+                    break
+            for j in range(idx + 1, min(idx + 12, len(lines))):
+                if lines[j].startswith("- Count:"):
+                    count = lines[j].split(":", 1)[1].strip()
+                    break
+            return {
+                "project": "",
+                "short_id": short_id,
+                "title": title,
+                "url": url,
+                "count": count,
+            }
+    return None
+
+
+def _build_pr_handoff_response(task: str, injected_context: list[str]) -> str:
+    context_str = "\n\n".join(injected_context)
+    issue = _extract_top_sentry_issue(context_str)
+    if issue:
+        project = f"[{issue['project']}] " if issue.get("project") else ""
+        title = issue.get("title") or "(title unavailable)"
+        url = issue.get("url") or "(URL missing)"
+        count = issue.get("count") or "unknown"
+        issue_line = (
+            f"Sentry issue: {project}{issue['short_id']} — {title} "
+            f"(count {count}). URL: {url}."
+        )
+    else:
+        issue_line = "No unresolved Sentry issues found in the injected data."
+
+    return (
+        f"{issue_line}\n"
+        "SoftwareEngineer please investigate and open a PR to fix the issue."
+    )
+
+
 def _extract_user_message(task: str) -> str:
     match = re.search(
         r"### User Message \\(UNTRUSTED CONTENT\\)\\n(.*?)\\n### End User Message",
@@ -1022,6 +1108,7 @@ END OF INJECTED DATA - The above data has ALREADY been fetched for you
             if "gmail" in task_lower or "inbox" in task_lower:
                 response = build_gmail_summary()
 
+            pr_requested = _task_mentions_pr(task_lower)
             is_notification = any(
                 kw in task_lower
                 for kw in [
@@ -1038,6 +1125,12 @@ END OF INJECTED DATA - The above data has ALREADY been fetched for you
             )
             if is_notification and not is_explicit_investigation:
                 response = build_notification_message(task)
+
+            if pr_requested and not re.search(
+                r"https?://github\.com/\S+/pull/\d+", task, re.IGNORECASE
+            ):
+                # Keep PR request responses short and focused on a single issue + handoff.
+                response = _build_pr_handoff_response(task, injected_context)
 
             # Auto-close Sentry issue when a PR link is present in the task.
             if re.search(r"https?://github\.com/\S+/pull/\d+", task, re.IGNORECASE):

--- a/vibeteam/gateway/routes/slack.py
+++ b/vibeteam/gateway/routes/slack.py
@@ -173,6 +173,18 @@ def _extract_sentry_urls(text: str) -> list[str]:
     return unique
 
 
+def _extract_pr_urls(text: str) -> list[str]:
+    pattern = re.compile(r"https?://github\.com/\S+/pull/\d+", re.IGNORECASE)
+    urls = pattern.findall(text or "")
+    seen: set[str] = set()
+    unique: list[str] = []
+    for url in urls:
+        if url not in seen:
+            seen.add(url)
+            unique.append(url)
+    return unique
+
+
 def _extract_repo_reference(text: str) -> str | None:
     sentry_project_patterns = [
         (r"\bvibebrowserextension\b", "VibeTechnologies/VibeWebAgent"),
@@ -1379,16 +1391,21 @@ async def _run_agent_and_respond(
                         response
                     )
                     sentry_urls = _extract_sentry_urls(response)
+                    pr_urls = _extract_pr_urls(response)
                     repo_block = f"Repository: {repo_ref}\n\n" if repo_ref else ""
                     sentry_block = ""
                     if sentry_urls:
                         sentry_block = f"Sentry issue(s): {' '.join(sentry_urls)}\n\n"
+                    pr_block = ""
+                    if pr_urls:
+                        pr_block = f"PR(s): {' '.join(pr_urls)}\n\n"
                     # Pass minimal context to avoid overwhelming the next agent.
                     handoff_message = (
                         f"[Handoff from {display_name}]\n\n"
                         f"Original request: {user_message}\n\n"
                         f"{repo_block}"
                         f"{sentry_block}"
+                        f"{pr_block}"
                         f"Handoff request: {handoff_snippet}"
                     )
                     await _run_agent_and_respond(
@@ -1549,15 +1566,20 @@ async def handle_agent_callback(request: Request) -> dict[str, Any]:
             handoff_snippet = _extract_handoff_snippet(response, handoff_search)
             repo_ref = _extract_repo_reference(handoff_snippet) or _extract_repo_reference(response)
             sentry_urls = _extract_sentry_urls(response)
+            pr_urls = _extract_pr_urls(response)
             repo_block = f"Repository: {repo_ref}\n\n" if repo_ref else ""
             sentry_block = ""
             if sentry_urls:
                 sentry_block = f"Sentry issue(s): {' '.join(sentry_urls)}\n\n"
+            pr_block = ""
+            if pr_urls:
+                pr_block = f"PR(s): {' '.join(pr_urls)}\n\n"
             handoff_message = (
                 f"[Handoff from {display_name}]\n\n"
                 f"Original request: {user_message}\n\n"
                 f"{repo_block}"
                 f"{sentry_block}"
+                f"{pr_block}"
                 f"Handoff request: {handoff_snippet}"
             )
             await _submit_agent_async(


### PR DESCRIPTION
## Summary\n- keep SupportEngineer PR requests concise and focused on top Sentry issue\n- pass PR URLs through Slack handoffs so SupportEngineer can auto-close\n- prevent SoftwareEngineer auto-PR responses from being overwritten\n\n## Testing\n- Not run (will re-run support_sentry_to_pr eval after merge)