### PR TITLE
Use GitHub App tokens per agent run

### DIFF
--- a/agent_service/autogen/server.py
+++ b/agent_service/autogen/server.py
@@ -4,10 +4,12 @@ AutoGen Agent Microservice.
 FastAPI server exposing AutoGen team functionality via REST API.
 """
 
+import contextlib
 import logging
 import os
 import time
 import uuid
+import threading
 from contextlib import asynccontextmanager
 from datetime import datetime, timezone
 from typing import Any
@@ -24,6 +26,57 @@ from .team import AutoGenTeam, create_team
 # Configure logging
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
+
+_GITHUB_TOKEN_LOCK = threading.Lock()
+
+
+def _resolve_role_for_token(role: str | None, task: str) -> str | None:
+    if role:
+        return role
+    try:
+        from agents.shared.role_resolver import parse_first_role_mention, route_by_keywords
+
+        parsed = parse_first_role_mention(task)
+        if parsed:
+            return parsed
+        return route_by_keywords(task)
+    except Exception:
+        return None
+
+
+@contextlib.contextmanager
+def _github_token_context(role: str | None):
+    """Temporarily set role-specific GitHub token for gh/SDK usage."""
+    if not role:
+        yield
+        return
+
+    token = None
+    try:
+        from vibeteam.utils.github_app import get_installation_token_for_role
+
+        token = get_installation_token_for_role(role)
+    except Exception:
+        token = None
+
+    with _GITHUB_TOKEN_LOCK:
+        old_env = {
+            "VIBETEAM_AGENT_ROLE": os.environ.get("VIBETEAM_AGENT_ROLE"),
+            "GITHUB_TOKEN": os.environ.get("GITHUB_TOKEN"),
+            "GH_TOKEN": os.environ.get("GH_TOKEN"),
+        }
+        os.environ["VIBETEAM_AGENT_ROLE"] = role
+        if token:
+            os.environ["GITHUB_TOKEN"] = token
+            os.environ["GH_TOKEN"] = token
+        try:
+            yield
+        finally:
+            for key, value in old_env.items():
+                if value is None:
+                    os.environ.pop(key, None)
+                else:
+                    os.environ[key] = value
 
 
 # Request/Response Models
@@ -146,20 +199,23 @@ async def run_task(request: RunRequest):
         # Generate context_id if not provided
         context_id = request.context_id or str(uuid.uuid4())[:8]
 
+        role_for_token = _resolve_role_for_token(request.role, request.task)
+
         # Run the task
-        if request.role:
-            result = await team.run_single_agent_async(
-                task=request.task,
-                role=request.role,
-                context_type=request.context_type,
-                context_id=context_id,
-            )
-        else:
-            result = await team.run_async(
-                task=request.task,
-                context_type=request.context_type,
-                context_id=context_id,
-            )
+        with _github_token_context(role_for_token):
+            if request.role:
+                result = await team.run_single_agent_async(
+                    task=request.task,
+                    role=request.role,
+                    context_type=request.context_type,
+                    context_id=context_id,
+                )
+            else:
+                result = await team.run_async(
+                    task=request.task,
+                    context_type=request.context_type,
+                    context_id=context_id,
+                )
 
         latency_ms = int((time.time() - start_time) * 1000)
 
@@ -221,24 +277,26 @@ async def run_task_stream(request: RunRequest):
         try:
             team = get_team()
             context_id = request.context_id or str(uuid.uuid4())[:8]
+            role_for_token = _resolve_role_for_token(request.role, request.task)
 
             # Send start event
             yield f"data: {{'event': 'start', 'context_id': '{context_id}'}}\n\n"
 
             # Run the task
-            if request.role:
-                result = await team.run_single_agent_async(
-                    task=request.task,
-                    role=request.role,
-                    context_type=request.context_type,
-                    context_id=context_id,
-                )
-            else:
-                result = await team.run_async(
-                    task=request.task,
-                    context_type=request.context_type,
-                    context_id=context_id,
-                )
+            with _github_token_context(role_for_token):
+                if request.role:
+                    result = await team.run_single_agent_async(
+                        task=request.task,
+                        role=request.role,
+                        context_type=request.context_type,
+                        context_id=context_id,
+                    )
+                else:
+                    result = await team.run_async(
+                        task=request.task,
+                        context_type=request.context_type,
+                        context_id=context_id,
+                    )
 
             # Send result
             import json

--- a/agent_service/crewai/server.py
+++ b/agent_service/crewai/server.py
@@ -4,10 +4,12 @@ CrewAI Agent Microservice.
 FastAPI server exposing CrewAI team functionality via REST API.
 """
 
+import contextlib
 import logging
 import os
 import time
 import uuid
+import threading
 from contextlib import asynccontextmanager
 from datetime import datetime, timezone
 from typing import Any
@@ -24,6 +26,57 @@ from .crew import CrewAITeam, create_team
 # Configure logging
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
+
+_GITHUB_TOKEN_LOCK = threading.Lock()
+
+
+def _resolve_role_for_token(role: str | None, task: str) -> str | None:
+    if role:
+        return role
+    try:
+        from agents.shared.role_resolver import parse_first_role_mention, route_by_keywords
+
+        parsed = parse_first_role_mention(task)
+        if parsed:
+            return parsed
+        return route_by_keywords(task)
+    except Exception:
+        return None
+
+
+@contextlib.contextmanager
+def _github_token_context(role: str | None):
+    """Temporarily set role-specific GitHub token for gh/SDK usage."""
+    if not role:
+        yield
+        return
+
+    token = None
+    try:
+        from vibeteam.utils.github_app import get_installation_token_for_role
+
+        token = get_installation_token_for_role(role)
+    except Exception:
+        token = None
+
+    with _GITHUB_TOKEN_LOCK:
+        old_env = {
+            "VIBETEAM_AGENT_ROLE": os.environ.get("VIBETEAM_AGENT_ROLE"),
+            "GITHUB_TOKEN": os.environ.get("GITHUB_TOKEN"),
+            "GH_TOKEN": os.environ.get("GH_TOKEN"),
+        }
+        os.environ["VIBETEAM_AGENT_ROLE"] = role
+        if token:
+            os.environ["GITHUB_TOKEN"] = token
+            os.environ["GH_TOKEN"] = token
+        try:
+            yield
+        finally:
+            for key, value in old_env.items():
+                if value is None:
+                    os.environ.pop(key, None)
+                else:
+                    os.environ[key] = value
 
 
 # Request/Response Models
@@ -145,21 +198,24 @@ async def run_task(request: RunRequest):
         # Generate context_id if not provided
         context_id = request.context_id or str(uuid.uuid4())[:8]
 
+        role_for_token = _resolve_role_for_token(request.role, request.task)
+
         # Run the task (CrewAI is sync, so run in thread)
-        if request.role and not request.multi_agent:
-            result = await team.run_async(
-                task=request.task,
-                context_type=request.context_type,
-                context_id=context_id,
-                multi_agent=False,
-            )
-        else:
-            result = await team.run_async(
-                task=request.task,
-                context_type=request.context_type,
-                context_id=context_id,
-                multi_agent=request.multi_agent,
-            )
+        with _github_token_context(role_for_token):
+            if request.role and not request.multi_agent:
+                result = await team.run_async(
+                    task=request.task,
+                    context_type=request.context_type,
+                    context_id=context_id,
+                    multi_agent=False,
+                )
+            else:
+                result = await team.run_async(
+                    task=request.task,
+                    context_type=request.context_type,
+                    context_id=context_id,
+                    multi_agent=request.multi_agent,
+                )
 
         latency_ms = int((time.time() - start_time) * 1000)
 
@@ -221,17 +277,19 @@ async def run_task_stream(request: RunRequest):
         try:
             team = get_team()
             context_id = request.context_id or str(uuid.uuid4())[:8]
+            role_for_token = _resolve_role_for_token(request.role, request.task)
 
             # Send start event
             yield f"data: {{'event': 'start', 'context_id': '{context_id}'}}\n\n"
 
             # Run the task
-            result = await team.run_async(
-                task=request.task,
-                context_type=request.context_type,
-                context_id=context_id,
-                multi_agent=request.multi_agent,
-            )
+            with _github_token_context(role_for_token):
+                result = await team.run_async(
+                    task=request.task,
+                    context_type=request.context_type,
+                    context_id=context_id,
+                    multi_agent=request.multi_agent,
+                )
 
             # Send result
             import json

--- a/agent_service/openclaw/server.py
+++ b/agent_service/openclaw/server.py
@@ -7,6 +7,7 @@ FastAPI server exposing OpenClaw gateway execution via WebSocket RPC.
 from __future__ import annotations
 
 import asyncio
+import contextlib
 import inspect
 import json
 import logging
@@ -14,6 +15,7 @@ import os
 import subprocess
 import time
 import uuid
+import threading
 from contextlib import asynccontextmanager
 from datetime import datetime, timezone
 from typing import Any
@@ -85,6 +87,57 @@ except Exception:  # Fallback for images missing vibeteam.agents_config
 
 logging.basicConfig(level=logging.INFO)
 logger = logging.getLogger(__name__)
+
+_GITHUB_TOKEN_LOCK = threading.Lock()
+
+
+def _resolve_role_for_token(role: str | None, task: str) -> str | None:
+    if role:
+        return role
+    try:
+        from agents.shared.role_resolver import parse_first_role_mention, route_by_keywords
+
+        parsed = parse_first_role_mention(task)
+        if parsed:
+            return parsed
+        return route_by_keywords(task)
+    except Exception:
+        return None
+
+
+@contextlib.contextmanager
+def _github_token_context(role: str | None):
+    """Temporarily set role-specific GitHub token for gh/SDK usage."""
+    if not role:
+        yield
+        return
+
+    token = None
+    try:
+        from vibeteam.utils.github_app import get_installation_token_for_role
+
+        token = get_installation_token_for_role(role)
+    except Exception:
+        token = None
+
+    with _GITHUB_TOKEN_LOCK:
+        old_env = {
+            "VIBETEAM_AGENT_ROLE": os.environ.get("VIBETEAM_AGENT_ROLE"),
+            "GITHUB_TOKEN": os.environ.get("GITHUB_TOKEN"),
+            "GH_TOKEN": os.environ.get("GH_TOKEN"),
+        }
+        os.environ["VIBETEAM_AGENT_ROLE"] = role
+        if token:
+            os.environ["GITHUB_TOKEN"] = token
+            os.environ["GH_TOKEN"] = token
+        try:
+            yield
+        finally:
+            for key, value in old_env.items():
+                if value is None:
+                    os.environ.pop(key, None)
+                else:
+                    os.environ[key] = value
 
 
 # ==============================================================================
@@ -539,6 +592,7 @@ async def run_task(request: RunRequest):
     start_time = time.time()
     try:
         context_id = request.context_id or str(uuid.uuid4())[:8]
+        role_for_token = _resolve_role_for_token(request.role, request.task)
         entry = get_agent_entry(request.role) if request.role else None
         agent_id = (
             request.openclaw_agent_id
@@ -552,11 +606,12 @@ async def run_task(request: RunRequest):
 
         task = _augment_task_with_context(request.task, request.role, request.context_type)
 
-        response_text, metadata = await run_openclaw_task(
-            task=task,
-            agent_id=agent_id,
-            session_key=session_key,
-        )
+        with _github_token_context(role_for_token):
+            response_text, metadata = await run_openclaw_task(
+                task=task,
+                agent_id=agent_id,
+                session_key=session_key,
+            )
 
         latency_ms = int((time.time() - start_time) * 1000)
 

--- a/agent_service/openhands/server.py
+++ b/agent_service/openhands/server.py
@@ -73,6 +73,18 @@ def _github_token_context(role: str | None):
                 else:
                     os.environ[key] = value
 
+
+def _resolve_token_role(team: OpenHandsTeam, request: RunRequest) -> str | None:
+    if request.role:
+        return request.role
+    try:
+        role = team.parse_mention(request.task)
+        if role:
+            return role
+        return team.route_by_keywords(request.task)
+    except Exception:
+        return None
+
 # Concurrency control: limit the number of simultaneous agent executions
 # to prevent resource exhaustion when multiple jobs arrive concurrently.
 # Default: 3 concurrent jobs (configurable via MAX_CONCURRENT_JOBS env var).
@@ -330,6 +342,7 @@ async def run_task(request: RunRequest):
 
         # Determine role - let team route if not specified
         role = request.role
+        role_for_token = _resolve_token_role(team, request)
 
         # Run the task
         # Use asyncio.to_thread to run blocking agent code without blocking the event loop
@@ -339,7 +352,7 @@ async def run_task(request: RunRequest):
             agent = team._get_agent(role)
 
             def _run_agent():
-                with _github_token_context(role):
+                with _github_token_context(role_for_token):
                     return agent.run(
                         task=request.task,
                         context_type=request.context_type,
@@ -356,12 +369,13 @@ async def run_task(request: RunRequest):
                 result = await _run_with_idle_timeout(_run_agent)
         else:
             # Let team route based on @mentions or keywords
-            result = await team.run_async(
-                task=request.task,
-                context_type=request.context_type,
-                context_id=context_id,
-                workspace=request.workspace,
-            )
+            with _github_token_context(role_for_token):
+                result = await team.run_async(
+                    task=request.task,
+                    context_type=request.context_type,
+                    context_id=context_id,
+                    workspace=request.workspace,
+                )
 
         latency_ms = int((time.time() - start_time) * 1000)
         response_text = coerce_text(result.get("response", ""))
@@ -783,6 +797,7 @@ async def run_task_stream(request: RunRequest):
         try:
             team = get_team()
             context_id = request.context_id or str(uuid.uuid4())[:8]
+            role_for_token = _resolve_token_role(team, request)
 
             # Send start event
             yield f"data: {{'event': 'start', 'context_id': '{context_id}'}}\n\n"
@@ -790,19 +805,21 @@ async def run_task_stream(request: RunRequest):
             # Run the task
             if request.role:
                 agent = team._get_agent(request.role)
-                result = agent.run(
-                    task=request.task,
-                    context_type=request.context_type,
-                    context_id=context_id,
-                    workspace=request.workspace,
-                )
+                with _github_token_context(role_for_token):
+                    result = agent.run(
+                        task=request.task,
+                        context_type=request.context_type,
+                        context_id=context_id,
+                        workspace=request.workspace,
+                    )
             else:
-                result = await team.run_async(
-                    task=request.task,
-                    context_type=request.context_type,
-                    context_id=context_id,
-                    workspace=request.workspace,
-                )
+                with _github_token_context(role_for_token):
+                    result = await team.run_async(
+                        task=request.task,
+                        context_type=request.context_type,
+                        context_id=context_id,
+                        workspace=request.workspace,
+                    )
 
             # Send result
             import json


### PR DESCRIPTION
Ensure each agent run sets role-specific GitHub App tokens (GITHUB_TOKEN/GH_TOKEN) and VIBETEAM_AGENT_ROLE across OpenHands, AutoGen, CrewAI, and OpenClaw so gh CLI and connector actions are attributed to the correct app.