### PR TITLE
Test GitHub App token attribution

### DIFF
--- a/tests/test_agent_github_app_tokens.py
+++ b/tests/test_agent_github_app_tokens.py
@@ -1,0 +1,191 @@
+import os
+
+import pytest
+
+
+class _DummyStore:
+    async def save(self, *_args, **_kwargs) -> None:
+        return None
+
+
+def _dummy_store() -> _DummyStore:
+    return _DummyStore()
+
+
+def _clear_github_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.delenv("GITHUB_TOKEN", raising=False)
+    monkeypatch.delenv("GH_TOKEN", raising=False)
+    monkeypatch.delenv("VIBETEAM_AGENT_ROLE", raising=False)
+
+
+@pytest.mark.asyncio
+async def test_openhands_role_token_context_inferred(monkeypatch: pytest.MonkeyPatch) -> None:
+    from agent_service.openhands import server as oh_server
+
+    _clear_github_env(monkeypatch)
+
+    captured: dict[str, str | None] = {}
+
+    class DummyAgent:
+        def run(self, **_kwargs):  # type: ignore[no-untyped-def]
+            captured["token"] = os.environ.get("GITHUB_TOKEN")
+            captured["role"] = os.environ.get("VIBETEAM_AGENT_ROLE")
+            return {"response": "ok", "agent": "software_engineer"}
+
+    class DummyTeam:
+        def parse_mention(self, _text: str) -> str | None:
+            return None
+
+        def route_by_keywords(self, _text: str) -> str:
+            return "software_engineer"
+
+        def _get_agent(self, _role: str) -> DummyAgent:
+            return DummyAgent()
+
+        async def run_async(self, **_kwargs):  # type: ignore[no-untyped-def]
+            captured["token"] = os.environ.get("GITHUB_TOKEN")
+            captured["role"] = os.environ.get("VIBETEAM_AGENT_ROLE")
+            return {"response": "ok", "agent": "software_engineer"}
+
+    monkeypatch.setattr(oh_server, "get_team", lambda: DummyTeam())
+    monkeypatch.setattr(oh_server, "get_postgres_store", _dummy_store)
+
+    called: dict[str, str | None] = {}
+
+    def fake_get_token(role: str) -> str:
+        called["role"] = role
+        return "ghs_role_token"
+
+    monkeypatch.setattr(
+        "vibeteam.utils.github_app.get_installation_token_for_role",
+        fake_get_token,
+    )
+
+    request = oh_server.RunRequest(task="fix bug in module", role=None, context_type="slack")
+    await oh_server.run_task(request)
+
+    assert called["role"] == "software_engineer"
+    assert captured["token"] == "ghs_role_token"
+    assert captured["role"] == "software_engineer"
+    assert os.environ.get("GITHUB_TOKEN") is None
+    assert os.environ.get("VIBETEAM_AGENT_ROLE") is None
+
+
+@pytest.mark.asyncio
+async def test_autogen_role_token_context_mentions(monkeypatch: pytest.MonkeyPatch) -> None:
+    from agent_service.autogen import server as ag_server
+
+    _clear_github_env(monkeypatch)
+
+    captured: dict[str, str | None] = {}
+
+    class DummyTeam:
+        async def run_async(self, **_kwargs):  # type: ignore[no-untyped-def]
+            captured["token"] = os.environ.get("GITHUB_TOKEN")
+            captured["role"] = os.environ.get("VIBETEAM_AGENT_ROLE")
+            return {"response": "ok", "agent": "software_engineer"}
+
+        async def run_single_agent_async(self, **_kwargs):  # type: ignore[no-untyped-def]
+            captured["token"] = os.environ.get("GITHUB_TOKEN")
+            captured["role"] = os.environ.get("VIBETEAM_AGENT_ROLE")
+            return {"response": "ok", "agent": "software_engineer"}
+
+    monkeypatch.setattr(ag_server, "get_team", lambda: DummyTeam())
+    monkeypatch.setattr(ag_server, "get_postgres_store", _dummy_store)
+
+    called: dict[str, str | None] = {}
+
+    def fake_get_token(role: str) -> str:
+        called["role"] = role
+        return "ghs_role_token"
+
+    monkeypatch.setattr(
+        "vibeteam.utils.github_app.get_installation_token_for_role",
+        fake_get_token,
+    )
+
+    request = ag_server.RunRequest(task="please @swe create a PR", role=None, context_type="slack")
+    await ag_server.run_task(request)
+
+    assert called["role"] == "software_engineer"
+    assert captured["token"] == "ghs_role_token"
+    assert captured["role"] == "software_engineer"
+    assert os.environ.get("GITHUB_TOKEN") is None
+    assert os.environ.get("VIBETEAM_AGENT_ROLE") is None
+
+
+@pytest.mark.asyncio
+async def test_crewai_role_token_context_mentions(monkeypatch: pytest.MonkeyPatch) -> None:
+    from agent_service.crewai import server as crew_server
+
+    _clear_github_env(monkeypatch)
+
+    captured: dict[str, str | None] = {}
+
+    class DummyTeam:
+        async def run_async(self, **_kwargs):  # type: ignore[no-untyped-def]
+            captured["token"] = os.environ.get("GITHUB_TOKEN")
+            captured["role"] = os.environ.get("VIBETEAM_AGENT_ROLE")
+            return {"response": "ok", "agent": "software_engineer"}
+
+    monkeypatch.setattr(crew_server, "get_team", lambda: DummyTeam())
+    monkeypatch.setattr(crew_server, "get_postgres_store", _dummy_store)
+
+    called: dict[str, str | None] = {}
+
+    def fake_get_token(role: str) -> str:
+        called["role"] = role
+        return "ghs_role_token"
+
+    monkeypatch.setattr(
+        "vibeteam.utils.github_app.get_installation_token_for_role",
+        fake_get_token,
+    )
+
+    request = crew_server.RunRequest(task="hey @swe update docs", role=None, context_type="slack")
+    await crew_server.run_task(request)
+
+    assert called["role"] == "software_engineer"
+    assert captured["token"] == "ghs_role_token"
+    assert captured["role"] == "software_engineer"
+    assert os.environ.get("GITHUB_TOKEN") is None
+    assert os.environ.get("VIBETEAM_AGENT_ROLE") is None
+
+
+@pytest.mark.asyncio
+async def test_openclaw_role_token_context_mentions(monkeypatch: pytest.MonkeyPatch) -> None:
+    from agent_service.openclaw import server as oc_server
+
+    _clear_github_env(monkeypatch)
+
+    captured: dict[str, str | None] = {}
+
+    async def fake_run_openclaw_task(*_args, **_kwargs):  # type: ignore[no-untyped-def]
+        captured["token"] = os.environ.get("GITHUB_TOKEN")
+        captured["role"] = os.environ.get("VIBETEAM_AGENT_ROLE")
+        return "ok", {}
+
+    monkeypatch.setattr(oc_server, "run_openclaw_task", fake_run_openclaw_task)
+    monkeypatch.setattr(oc_server, "get_postgres_store", _dummy_store)
+    monkeypatch.setattr(oc_server, "get_agent_entry", lambda _role: None)
+    monkeypatch.setattr(oc_server, "resolve_openclaw_agent_id", lambda _role: None)
+
+    called: dict[str, str | None] = {}
+
+    def fake_get_token(role: str) -> str:
+        called["role"] = role
+        return "ghs_role_token"
+
+    monkeypatch.setattr(
+        "vibeteam.utils.github_app.get_installation_token_for_role",
+        fake_get_token,
+    )
+
+    request = oc_server.RunRequest(task="ping @swe", role=None, context_type="slack")
+    await oc_server.run_task(request)
+
+    assert called["role"] == "software_engineer"
+    assert captured["token"] == "ghs_role_token"
+    assert captured["role"] == "software_engineer"
+    assert os.environ.get("GITHUB_TOKEN") is None
+    assert os.environ.get("VIBETEAM_AGENT_ROLE") is None

--- a/tests/test_github_app_auth.py
+++ b/tests/test_github_app_auth.py
@@ -29,6 +29,12 @@ from vibeteam.utils import github_app
 class TestGitHubAppAuth:
     """Test GitHub App authentication utilities."""
 
+    def test_normalize_private_key(self):
+        raw = "-----BEGIN_RSA_PRIVATE_KEY-----\\nabc\\n-----END_RSA_PRIVATE_KEY-----"
+        normalized = github_app._normalize_private_key(raw)
+        assert "BEGIN RSA PRIVATE KEY" in normalized
+        assert "END RSA PRIVATE KEY" in normalized
+
     def test_generate_jwt(self):
         """Test JWT generation for GitHub App."""
         # Use a valid test RSA private key

--- a/vibeteam/utils/github_app.py
+++ b/vibeteam/utils/github_app.py
@@ -20,6 +20,15 @@ import jwt
 import requests
 
 
+def _normalize_private_key(private_key: str) -> str:
+    if not private_key:
+        return private_key
+    return (
+        private_key.replace("BEGIN_RSA_PRIVATE_KEY", "BEGIN RSA PRIVATE KEY")
+        .replace("END_RSA_PRIVATE_KEY", "END RSA PRIVATE KEY")
+    )
+
+
 def generate_jwt(app_id: str, private_key: str) -> str:
     """Generate a JWT for GitHub App authentication.
 
@@ -36,7 +45,8 @@ def generate_jwt(app_id: str, private_key: str) -> str:
         "exp": now + 600,  # expires in 10 minutes (max allowed by GitHub)
         "iss": app_id,
     }
-    return jwt.encode(payload, private_key, algorithm="RS256")
+    normalized_key = _normalize_private_key(private_key)
+    return jwt.encode(payload, normalized_key, algorithm="RS256")
 
 
 def _normalize_role(role: str) -> str:


### PR DESCRIPTION
Add unit tests to verify role-scoped GitHub App tokens are set per agent run, and normalize private key headers for env export compatibility.