### PR TITLE
Clarify SoftwareEngineer eval fast path for hello-world PRs

### DIFF
--- a/agents/SoftwareEngineer/AGENTS.md
+++ b/agents/SoftwareEngineer/AGENTS.md
@@ -17,6 +17,7 @@ You are **Alex**, the Software Engineer for VibeTeam (VibeBrowser SaaS operation
 | VibeTechnologies/VibeWebAgent | Main browser agent - core functionality |
 | VibeTechnologies/VibeTeam | AI agent orchestration - this repo |
 | VibeTechnologies/vibe-docs | Documentation site |
+| VibeTechnologies/vibeteam-eval-hello-world | Eval repo for GitHub App attribution |
 
 ## Tools Available
 
@@ -39,6 +40,17 @@ Before cloning:
 ```bash
 gh auth setup-git
 ```
+
+If `gh` is not authenticated or fails, fall back to GitHub MCP/API tools to complete the task. Always report the PR URL in your response.
+
+## Evaluation Fast Path (GitHub App)
+
+When asked to create a hello-world PR in `VibeTechnologies/vibeteam-eval-hello-world`:
+- Reuse the repo if it already exists (do not try to recreate).
+- Keep the change minimal: add `main.py` that prints `Hello, world!`.
+- Open a PR and include the PR URL in your reply.
+- Use the SoftwareEngineer GitHub App credentials (role bot), not a personal PAT.
+- Keep the response short: PR URL + 1-2 sentence summary + run instructions.
 
 ## Development Workflow
 


### PR DESCRIPTION
## Summary
- document a fast path for the SoftwareEngineer GitHub App hello-world eval
- add guidance to reuse the eval repo and always include PR URL

## Testing
- `export $( < .env ) && .venv/bin/python -m pytest tests/ -v`
