### PR TITLE
Force SWE no context injection in Slack

### DIFF
--- a/agent_service/openhands/software_engineer.py
+++ b/agent_service/openhands/software_engineer.py
@@ -21,7 +21,7 @@ import threading
 import time
 from typing import Any
 
-from agents.config import SOFTWARE_ENGINEER_CONFIG, AgentConfig
+from agents.config import SOFTWARE_ENGINEER_CONFIG, AgentConfig, get_mcp_config_dict
 from agents.sessions import get_or_create_session, get_session_store
 from agents.shared.kubectl_tools import get_multi_namespace_context
 
@@ -500,27 +500,36 @@ class OpenHandsSoftwareEngineer:
             num_retries=3,  # Retry transient failures (overall timeout is the safety net)
         )
 
-    def _create_agent(self, llm: LLM) -> Agent:
-        """Create Agent with LLM and tools."""
+    def _create_agent(self, llm: LLM, *, use_tools: bool = True) -> Agent:
+        """Create Agent with LLM and tools (MCP when available)."""
         # Load agent context from AGENTS.md hierarchy
         # Falls back to hardcoded context if files not found
         agent_context = compose_agent_context(
             "software_engineer", fallback_context=SOFTWARE_ENGINEER_CONTEXT_FALLBACK
         )
 
+        agent_kwargs: dict[str, Any] = {
+            "llm": llm,
+            "condenser": build_condenser(llm),
+            # Use our custom template that renders agent_context into the system prompt.
+            # Without this, the default system_prompt.j2 ignores agent_context kwargs.
+            "system_prompt_filename": get_prompt_path(),
+            "system_prompt_kwargs": {
+                "agent_context": agent_context,
+            },
+        }
+
+        if use_tools:
+            mcp_config = get_mcp_config_dict(self.config.mcp_servers)
+            if mcp_config.get("mcpServers"):
+                agent_kwargs["mcp_config"] = mcp_config
+
         return Agent(
-            llm=llm,
             tools=[
                 Tool(name=TerminalTool.name),
                 Tool(name=FileEditorTool.name),
             ],
-            condenser=build_condenser(llm),
-            # Use our custom template that renders agent_context into the system prompt.
-            # Without this, the default system_prompt.j2 ignores agent_context kwargs.
-            system_prompt_filename=get_prompt_path(),
-            system_prompt_kwargs={
-                "agent_context": agent_context,
-            },
+            **agent_kwargs,
         )
 
     def _extract_repo_from_task(self, task: str, context_id: str | None = None) -> str:
@@ -2120,7 +2129,8 @@ code matches. Use `gh search code` and `gh api` for further investigation:
         )
 
         llm = self._create_llm()
-        agent = self._create_agent(llm)
+        use_tools = bool(kwargs.get("use_tools", True))
+        agent = self._create_agent(llm, use_tools=use_tools)
 
         # Use provided workspace or create temporary one
         temp_dir = None
@@ -2317,6 +2327,11 @@ code matches. Use `gh search code` and `gh api` for further investigation:
                         "address",
                     )
                 )
+                if sentry_related:
+                    extra_guidance_lines.append(
+                        "REQUIRED: Query Sentry directly via MCP tools (preferred) or sentry-cli. "
+                        "Do NOT claim 'no issues' based only on injected context."
+                    )
                 if sentry_related and pr_requested:
                     extra_guidance_lines.append(
                         "REQUIRED: create a PR with gh CLI and include the PR URL/number in your response. "

--- a/agents/SoftwareEngineer/AGENTS.md
+++ b/agents/SoftwareEngineer/AGENTS.md
@@ -82,6 +82,7 @@ gh pr create --title "Fix login bug" --body "Fixes #345"
 
 ### Sentry Handoff Completion (When SupportEngineer Escalates a Sentry Bug)
 - If the handoff includes a Sentry issue URL/ID, **echo it back** in your response.
+- Do **not** rely on injected context for Sentry status. **Always** query Sentry via MCP if available, otherwise use `sentry-cli`.
 - After creating the PR, **tag @SupportEngineer** with the PR link and the Sentry issue URL so they can close the issue.
 
 ## Code Standards

--- a/agents/SoftwareEngineer/skills/sentry-response/SKILL.md
+++ b/agents/SoftwareEngineer/skills/sentry-response/SKILL.md
@@ -18,6 +18,7 @@ description: Handle Sentry issues end-to-end for SoftwareEngineer (investigate, 
 ## Tool Selection
 - Prefer **Sentry MCP tools** if they exist (e.g., `mcp__sentry__*`).
 - If MCP is not available, use **sentry-cli** to pull issue data.
+- Do **not** conclude “no issues” from injected data alone — always query Sentry directly.
 
 ### Sentry MCP (Preferred)
 - List unresolved issues.

--- a/agents/config.py
+++ b/agents/config.py
@@ -152,6 +152,7 @@ SOFTWARE_ENGINEER_CONFIG = AgentConfig(
     mcp_servers={
         "github": MCP_SERVERS["github"],
         "filesystem": MCP_SERVERS["filesystem"],
+        "sentry": MCP_SERVERS["sentry"],
         **_CHROME_SERVER,
     },
 )

--- a/vibeteam/gateway/routes/slack.py
+++ b/vibeteam/gateway/routes/slack.py
@@ -1132,7 +1132,7 @@ async def _submit_agent_async(
         thread_ts=thread_ts,
     )
 
-    # Mirror async path: pick template to decide context injection + iteration limits.
+    # Pick template to decide context injection + iteration limits.
     is_thread_reply = thread_ts is not None
     template = classify_task_template(role, user_message, is_thread_reply=is_thread_reply)
     skip_context = template == "health_check"
@@ -1144,25 +1144,6 @@ async def _submit_agent_async(
         "investigation": 120,
     }
     max_iterations = max_iterations_map.get(template, 120)
-
-    # Determine if we should skip heavy context injection.
-    # Health checks are self-contained — the template has all instructions.
-    # Pre-fetched context (logs, events from all namespaces) causes the agent
-    # to rabbit-hole into investigating every anomaly it sees.
-    is_thread_reply = thread_ts is not None
-    template = classify_task_template(role, user_message, is_thread_reply=is_thread_reply)
-    skip_context = template == "health_check"
-
-    # Set max_iterations based on task type to prevent scope creep.
-    # Use generous limits and rely on idle timeouts + iteration warnings to
-    # avoid doom loops while allowing longer investigations (e.g., Sentry -> PR).
-    max_iterations_map = {
-        "health_check": 15,
-        "conversational": 30,
-        "notification": 30,
-        "deployment": 80,
-        "investigation": 120,
-    }
     max_iterations = max_iterations_map.get(template, 120)
 
     # Best-effort: show assistant "typing" status in the thread while the agent runs.
@@ -1328,6 +1309,19 @@ async def _run_agent_and_respond(
         channel=channel,
         thread_ts=thread_ts,
     )
+
+    # Pick template to decide context injection + iteration limits (sync path).
+    is_thread_reply = thread_ts is not None
+    template = classify_task_template(role, user_message, is_thread_reply=is_thread_reply)
+    skip_context = template == "health_check"
+    max_iterations_map = {
+        "health_check": 15,
+        "conversational": 30,
+        "notification": 30,
+        "deployment": 80,
+        "investigation": 120,
+    }
+    max_iterations = max_iterations_map.get(template, 120)
 
     status_thread_ts = thread_ts or message_ts
     await set_thread_status(channel, status_thread_ts, config.SLACK_ASSISTANT_STATUS_TEXT)

--- a/vibeteam/gateway/routes/slack.py
+++ b/vibeteam/gateway/routes/slack.py
@@ -1136,6 +1136,9 @@ async def _submit_agent_async(
     is_thread_reply = thread_ts is not None
     template = classify_task_template(role, user_message, is_thread_reply=is_thread_reply)
     skip_context = template == "health_check"
+    if role == "software_engineer":
+        # Force end-to-end investigation via tools (no injected Sentry/kubectl/code context).
+        skip_context = True
     max_iterations_map = {
         "health_check": 15,
         "conversational": 30,
@@ -1314,6 +1317,9 @@ async def _run_agent_and_respond(
     is_thread_reply = thread_ts is not None
     template = classify_task_template(role, user_message, is_thread_reply=is_thread_reply)
     skip_context = template == "health_check"
+    if role == "software_engineer":
+        # Force end-to-end investigation via tools (no injected Sentry/kubectl/code context).
+        skip_context = True
     max_iterations_map = {
         "health_check": 15,
         "conversational": 30,


### PR DESCRIPTION
## Summary
- Force `software_engineer` Slack requests to skip injected context so investigations are end-to-end via tools.

## Testing
- `export $( < ~/.env.d/codex.env ) && export $( < .env ) && .venv/bin/python -m pytest -q`
- `uv run python scripts/eval_slack_e2e.py --scenario support_400_errors --channel C0AATPSADB8 --timeout 600`
  - Report: `results/eval_reports/eval_support_400_errors_20260302_060931.md`
