### PR TITLE
Limit Slack eval to issue + PR handoffs

### DIFF
--- a/docs/requirements.md
+++ b/docs/requirements.md
@@ -167,8 +167,8 @@ The `software_engineer_github_app_hello_world` scenario targets
 `VibeTechnologies/vibeteam-eval-hello-world` and validates PR creation plus bot
 attribution, so the SoftwareEngineer GitHub App must be installed on that repo.
 Post-checks also require `GITHUB_TOKEN` (or `GH_TOKEN`) to verify PR metadata.
-The `github_issue_pr_handoff_slack` scenario validates issue, discussion, and PR
-handoff comments in the same eval repo.
+The `github_issue_pr_handoff_slack` scenario validates issue + PR handoff comments in
+the same eval repo. Discussion handoffs are validated via `eval_github_e2e.py`.
 
 Use `scripts/eval_github_e2e.py` to validate GitHub webhook routing and multi-agent
 handoffs over issues, discussions, and PR comments. This requires:

--- a/docs/tests.md
+++ b/docs/tests.md
@@ -75,7 +75,7 @@ uv run python scripts/eval_slack_e2e.py --scenario software_engineer_pr_attribut
 uv run python scripts/eval_slack_e2e.py --scenario software_engineer_github_app_hello_world --channel C0AATPSADB8 --timeout 600
 uv run python scripts/eval_slack_e2e.py --scenario github_issue_pr_handoff_slack --channel C0AATPSADB8 --timeout 600
 
-`github_issue_pr_handoff_slack` validates cross-agent handoff comments across issue, discussion, and PR threads in the eval repo.
+`github_issue_pr_handoff_slack` validates cross-agent handoff comments across issue and PR threads in the eval repo.
 
 # GitHub webhook evaluation (issues/discussions/PR comments)
 uv run python scripts/eval_github_e2e.py --scenario github_threads_all --repo VibeTechnologies/vibeteam-eval-hello-world --pr 1 --timeout 600

--- a/scripts/eval_slack_e2e.py
+++ b/scripts/eval_slack_e2e.py
@@ -456,36 +456,32 @@ SCENARIOS = {
         "threshold": 0.70,
     },
     "github_issue_pr_handoff_slack": {
-        "name": "GitHub Handoff - Issue + Discussion + PR Comments (Slack Trigger)",
+        "name": "GitHub Handoff - Issue + PR Comments (Slack Trigger)",
         "message": (
             "@VibeTeam @SoftwareEngineer please do GitHub coordination ONLY in "
             "VibeTechnologies/vibeteam-eval-hello-world (do NOT use VibeTeam or any other repo). "
             "Use these threads: "
             "Issue: https://github.com/VibeTechnologies/vibeteam-eval-hello-world/issues/3 "
-            "Discussion: https://github.com/VibeTechnologies/vibeteam-eval-hello-world/discussions/6 "
             "PR: https://github.com/VibeTechnologies/vibeteam-eval-hello-world/pull/1 "
             "1) Add an issue comment summarizing the plan. "
             "Include /SupportEngineer in the issue comment to request a follow-up. "
-            "2) Add a discussion comment summarizing the plan and include /SupportEngineer there too. "
-            "If you use the github tool, use action add_discussion_comment with discussion_number=6. "
-            "3) Add a PR comment summarizing the plan and include /SupportEngineer there too. "
-            "Reply in Slack confirming all three comments were posted."
+            "2) Add a PR comment summarizing the plan and include /SupportEngineer there too. "
+            "Reply in Slack confirming both comments were posted."
         ),
         "expected_agent": "software_engineer",
         "timeout": 600,
         "post_checks": {
             "github_issue_multi_bot_comments": True,
-            "github_discussion_multi_bot_comments": True,
             "github_pr_multi_bot_comments": True,
         },
         "evaluation_criteria": {
             "TaskCompletion": (
-                "Did the SoftwareEngineer create the GitHub issue, discussion, and PR comments and share URLs? "
-                "REQUIRED: issue URL, discussion URL, and PR URL present in the response, and comments exist in all three threads."
+                "Did the SoftwareEngineer create the GitHub issue + PR comments and share URLs? "
+                "REQUIRED: issue URL and PR URL present in the response, and comments exist in both threads."
             ),
             "HandoffCompletion": (
-                "Did SupportEngineer post follow-up comments in the issue, discussion, and PR threads? "
-                "REQUIRED: at least two bot authors appear in all three threads."
+                "Did SupportEngineer post follow-up comments in the issue and PR threads? "
+                "REQUIRED: at least two bot authors appear in both threads."
             ),
             "ResponseEfficiency": (
                 "Is the response concise and focused? "


### PR DESCRIPTION
## Summary
- Narrow Slack eval scenario to issue + PR comments
- Clarify docs to note discussions are covered by GitHub webhook evals

## Testing
- `uv run pytest tests/ -q`
