### PR TITLE
Make context injection configurable per agent

### DIFF
--- a/agents.yaml
+++ b/agents.yaml
@@ -16,6 +16,7 @@ agents:
     framework: openhands
     slack_handle: SoftwareEngineer
     agent_dir: agents/SoftwareEngineer
+    skip_context_injection: true
   marketing_manager:
     framework: openhands
     slack_handle: MarketingManager

--- a/docs/design.md
+++ b/docs/design.md
@@ -60,6 +60,8 @@
 - The gateway resolves which framework to use per role using `agents.yaml`.
 - `agents.yaml` is the single source of truth for role → framework mapping, Slack handle,
   and agent directory references (AGENTS.md resolves from the directory).
+- Optional `skip_context_injection` can be set per agent to force end-to-end
+  investigations without gateway prefetch context.
 - Example:
 
 ```yaml
@@ -73,6 +75,11 @@ agents:
     framework: openhands
     slack_handle: SupportEngineer
     agent_dir: agents/SupportEngineer
+  software_engineer:
+    framework: openhands
+    slack_handle: SoftwareEngineer
+    agent_dir: agents/SoftwareEngineer
+    skip_context_injection: true
 ```
 
 ## OpenClaw Flow

--- a/docs/requirements.md
+++ b/docs/requirements.md
@@ -31,7 +31,16 @@ agents:
     framework: openhands
     slack_handle: SupportEngineer
     agent_dir: agents/SupportEngineer
+  software_engineer:
+    framework: openhands
+    slack_handle: SoftwareEngineer
+    agent_dir: agents/SoftwareEngineer
+    skip_context_injection: true
 ```
+
+Optional agent flags:
+- `skip_context_injection`: when true, the gateway skips pre-fetched context
+  injection (Sentry/kubectl/Gmail) so the agent must use tools directly.
 
 ## Browser Automation
 

--- a/vibeteam/agents_config.py
+++ b/vibeteam/agents_config.py
@@ -27,6 +27,7 @@ class AgentEntry:
     slack_handle: str | None = None
     agent_dir: str | None = None
     prompt_path: str | None = None
+    skip_context_injection: bool | None = None
 
 
 AGENTS_CONFIG_PATH = os.environ.get("AGENTS_CONFIG_PATH", "agents.yaml")
@@ -61,6 +62,12 @@ def get_agent_entry(role: str | None) -> AgentEntry | None:
         raw = {}
     slack_handle = raw.get("slack_handle")
     agent_dir = raw.get("agent_dir")
+    skip_context_injection_raw = raw.get("skip_context_injection")
+    skip_context_injection = (
+        skip_context_injection_raw
+        if isinstance(skip_context_injection_raw, bool)
+        else None
+    )
     display = slack_handle or role.replace("_", " ").title()
     return AgentEntry(
         role=role,  # type: ignore[arg-type]
@@ -70,6 +77,7 @@ def get_agent_entry(role: str | None) -> AgentEntry | None:
         slack_handle=slack_handle,
         agent_dir=agent_dir,
         prompt_path=raw.get("prompt_path"),
+        skip_context_injection=skip_context_injection,
     )
 
 
@@ -124,6 +132,13 @@ def get_agent_dir(role: str | None) -> str | None:
     return None
 
 
+def get_skip_context_injection(role: str | None) -> bool | None:
+    entry = get_agent_entry(role)
+    if not entry:
+        return None
+    return entry.skip_context_injection
+
+
 def list_agents() -> list[AgentEntry]:
     agents = _get_agents_map()
     entries: list[AgentEntry] = []
@@ -142,5 +157,6 @@ __all__ = [
     "get_slack_handle",
     "get_agent_dir",
     "get_prompt_path",
+    "get_skip_context_injection",
     "list_agents",
 ]

--- a/vibeteam/gateway/routes/slack.py
+++ b/vibeteam/gateway/routes/slack.py
@@ -25,7 +25,7 @@ from fastapi import APIRouter, Header, HTTPException, Request
 from vibeteam.gateway.server import call_agent_service, call_agent_service_async, config
 from agents.shared.role_resolver import ROLE_MENTION_MAP, get_display_name
 from vibeteam.router import Router
-from vibeteam.agents_config import get_slack_handle
+from vibeteam.agents_config import get_skip_context_injection, get_slack_handle
 from vibeteam.router.models import AgentRole, route_by_keywords
 
 logger = logging.getLogger(__name__)
@@ -1136,9 +1136,9 @@ async def _submit_agent_async(
     is_thread_reply = thread_ts is not None
     template = classify_task_template(role, user_message, is_thread_reply=is_thread_reply)
     skip_context = template == "health_check"
-    if role == "software_engineer":
-        # Force end-to-end investigation via tools (no injected Sentry/kubectl/code context).
-        skip_context = True
+    skip_context_override = get_skip_context_injection(role)
+    if skip_context_override is not None:
+        skip_context = skip_context_override
     max_iterations_map = {
         "health_check": 15,
         "conversational": 30,
@@ -1146,7 +1146,6 @@ async def _submit_agent_async(
         "deployment": 80,
         "investigation": 120,
     }
-    max_iterations = max_iterations_map.get(template, 120)
     max_iterations = max_iterations_map.get(template, 120)
 
     # Best-effort: show assistant "typing" status in the thread while the agent runs.
@@ -1317,9 +1316,9 @@ async def _run_agent_and_respond(
     is_thread_reply = thread_ts is not None
     template = classify_task_template(role, user_message, is_thread_reply=is_thread_reply)
     skip_context = template == "health_check"
-    if role == "software_engineer":
-        # Force end-to-end investigation via tools (no injected Sentry/kubectl/code context).
-        skip_context = True
+    skip_context_override = get_skip_context_injection(role)
+    if skip_context_override is not None:
+        skip_context = skip_context_override
     max_iterations_map = {
         "health_check": 15,
         "conversational": 30,


### PR DESCRIPTION
## Summary
- Move context-injection override into `agents.yaml` via `skip_context_injection`.
- Remove role-specific injection hack from Slack routing.
- Document the new optional flag in `docs/design.md` and `docs/requirements.md`.

## Testing
- `export $( < ~/.env.d/codex.env ) && export $( < .env ) && .venv/bin/python -m pytest -q`
- `uv run python scripts/eval_slack_e2e.py --scenario support_400_errors --channel C0AATPSADB8 --timeout 600`
  - **FAILED**: InvestigationQuality 0.60, ResponseEfficiency 0.60
  - Report: `results/eval_reports/eval_support_400_errors_20260302_073143.md`
