### PR TITLE
Fix discussion comment handoff fetch via GraphQL

### DIFF
--- a/scripts/eval_github_e2e.py
+++ b/scripts/eval_github_e2e.py
@@ -184,14 +184,14 @@ def _fetch_issue_comments(owner: str, repo: str, number: int, token: str) -> lis
         return response.json()
 
 
-def _create_discussion(owner: str, repo: str, token: str) -> tuple[int, str, datetime]:
+def _create_discussion(owner: str, repo: str, token: str) -> tuple[int, str, str, datetime]:
     repo_id, category_id = _get_repo_and_category_id(owner, repo, token)
     title = f"Eval GitHub discussion handoff {uuid.uuid4().hex[:8]}"
     body = "Eval discussion to test agent handoff via GitHub discussion comments."
     mutation = """
     mutation($repoId: ID!, $catId: ID!, $title: String!, $body: String!) {
       createDiscussion(input: {repositoryId: $repoId, categoryId: $catId, title: $title, body: $body}) {
-        discussion { number url createdAt }
+        discussion { id number url createdAt }
       }
     }
     """
@@ -203,26 +203,70 @@ def _create_discussion(owner: str, repo: str, token: str) -> tuple[int, str, dat
     discussion = (data.get("createDiscussion") or {}).get("discussion") or {}
     if not discussion:
         raise RuntimeError("Failed to create discussion via GraphQL")
-    return int(discussion["number"]), discussion["url"], _parse_ts(discussion["createdAt"])
+    return (
+        int(discussion["number"]),
+        discussion["url"],
+        discussion["id"],
+        _parse_ts(discussion["createdAt"]),
+    )
 
 
 def _create_discussion_comment(
-    owner: str, repo: str, token: str, number: int, body: str
+    owner: str, repo: str, token: str, discussion_id: str, body: str
 ) -> datetime:
-    url = f"https://api.github.com/repos/{owner}/{repo}/discussions/{number}/comments"
-    with httpx.Client(timeout=20.0) as client:
-        response = client.post(url, headers=_headers(token), json={"body": body})
-        response.raise_for_status()
-        data = response.json()
-    return _parse_ts(data["created_at"])
+    mutation = """
+    mutation($discussionId: ID!, $body: String!) {
+      addDiscussionComment(input: {discussionId: $discussionId, body: $body}) {
+        comment { createdAt }
+      }
+    }
+    """
+    data = _graphql_request(
+        token,
+        mutation,
+        {"discussionId": discussion_id, "body": body},
+    )
+    comment = (data.get("addDiscussionComment") or {}).get("comment") or {}
+    created_at = comment.get("createdAt")
+    if not created_at:
+        raise RuntimeError("Failed to create discussion comment via GraphQL")
+    return _parse_ts(created_at)
 
 
 def _fetch_discussion_comments(owner: str, repo: str, number: int, token: str) -> list[dict]:
-    url = f"https://api.github.com/repos/{owner}/{repo}/discussions/{number}/comments"
-    with httpx.Client(timeout=20.0) as client:
-        response = client.get(url, headers=_headers(token), params={"per_page": 100})
-        response.raise_for_status()
-        return response.json()
+    query = """
+    query($owner: String!, $repo: String!, $number: Int!) {
+      repository(owner: $owner, name: $repo) {
+        discussion(number: $number) {
+          comments(first: 100) {
+            nodes {
+              createdAt
+              author {
+                login
+                __typename
+              }
+            }
+          }
+        }
+      }
+    }
+    """
+    data = _graphql_request(token, query, {"owner": owner, "repo": repo, "number": number})
+    discussion = (data.get("repository") or {}).get("discussion") or {}
+    comments = (discussion.get("comments") or {}).get("nodes") or []
+    normalized: list[dict] = []
+    for comment in comments:
+        author = comment.get("author") or {}
+        normalized.append(
+            {
+                "created_at": comment.get("createdAt", ""),
+                "user": {
+                    "login": author.get("login"),
+                    "type": author.get("__typename"),
+                },
+            }
+        )
+    return normalized
 
 
 def _create_pr_comment(owner: str, repo: str, token: str, pr_number: int, body: str) -> datetime:
@@ -270,10 +314,10 @@ def _run_issue_handoff_existing(
 
 def _run_discussion_handoff(owner: str, repo: str, token: str, timeout: int) -> dict:
     _ensure_discussions_enabled(owner, repo, token)
-    discussion_number, discussion_url, _ = _create_discussion(owner, repo, token)
+    discussion_number, discussion_url, discussion_id, _ = _create_discussion(owner, repo, token)
     trigger_body = "Triggering handoff via discussion comment.\n/SoftwareEngineer /SupportEngineer"
     trigger_ts = _create_discussion_comment(
-        owner, repo, token, discussion_number, trigger_body
+        owner, repo, token, discussion_id, trigger_body
     )
 
     def fetch() -> list[dict]:

--- a/vibeteam/gateway/routes/github.py
+++ b/vibeteam/gateway/routes/github.py
@@ -345,6 +345,55 @@ async def fetch_github_discussion(
         return None
 
 
+async def fetch_github_discussion_comment(
+    repo: str,
+    comment_node_id: str,
+    role: str | None = None,
+) -> dict[str, Any] | None:
+    """Fetch discussion comment details via GraphQL node ID."""
+    token = await get_installation_token(role)
+    if not token:
+        token = os.environ.get("GITHUB_TOKEN")
+
+    if not token:
+        logger.warning("No GitHub token available, skipping discussion comment fetch")
+        return None
+
+    query = """
+    query($id: ID!) {
+      node(id: $id) {
+        ... on DiscussionComment {
+          body
+          createdAt
+          discussion {
+            number
+            title
+            body
+          }
+        }
+      }
+    }
+    """
+
+    try:
+        async with httpx.AsyncClient() as client:
+            response = await client.post(
+                "https://api.github.com/graphql",
+                headers={
+                    "Authorization": f"Bearer {token}",
+                    "Accept": "application/vnd.github+json",
+                },
+                json={"query": query, "variables": {"id": comment_node_id}},
+            )
+            response.raise_for_status()
+            data = response.json()
+        node = (data.get("data") or {}).get("node") or {}
+        return node if isinstance(node, dict) else None
+    except Exception as e:
+        logger.error(f"Failed to fetch discussion comment details: {e}")
+        return None
+
+
 async def run_agent_for_github_discussion(
     repo: str,
     discussion_number: int,
@@ -619,6 +668,7 @@ async def handle_github_webhook(
     if x_github_event == "discussion_comment" and action == "created":
         comment = payload.get("comment", {})
         comment_body = comment.get("body", "")
+        comment_node_id = comment.get("node_id", "")
         comment_user = comment.get("user", {}).get("login", "")
         comment_user_type = comment.get("user", {}).get("type", "")
         discussion = payload.get("discussion", {})
@@ -629,6 +679,17 @@ async def handle_github_webhook(
         # Ignore bot's own comments
         if comment_user_type == "Bot" or config.BOT_USERNAME.replace("[bot]", "") in comment_user:
             return {"status": "ignored", "reason": "own_comment"}
+
+        if comment_node_id and not comment_body:
+            fetched_comment = await fetch_github_discussion_comment(
+                repo_full_name, comment_node_id, role="software_engineer"
+            )
+            if fetched_comment:
+                comment_body = fetched_comment.get("body", comment_body) or comment_body
+                fetched_discussion = fetched_comment.get("discussion") or {}
+                discussion_number = discussion_number or fetched_discussion.get("number")
+                discussion_body = discussion_body or fetched_discussion.get("body", "")
+                discussion_title = discussion_title or fetched_discussion.get("title", "")
 
         if discussion_number and (not discussion_body or not discussion_title):
             fetched = await fetch_github_discussion(


### PR DESCRIPTION
## Summary
- fetch missing discussion comment body via GraphQL node ID
- create discussion comments in eval script via GraphQL and fetch comments via GraphQL

## Testing
- `export $( < .env ) && uv run pytest tests/ -q`
- `export $( < .env ) && uv run python scripts/eval_slack_e2e.py --scenario github_issue_pr_handoff_slack --channel C0AATPSADB8 --timeout 600` (running)
