### PR TITLE
Remove context injection; gateway routes only

### DIFF
--- a/agent_service/openclaw/server.py
+++ b/agent_service/openclaw/server.py
@@ -12,7 +12,6 @@ import inspect
 import json
 import logging
 import os
-import subprocess
 import time
 import uuid
 import threading
@@ -29,12 +28,8 @@ from pydantic import BaseModel, Field
 
 try:
     from agents.shared.integration_checks import validate_required_integrations
-    from agents.shared.kubectl_tools import get_kubectl_context
-    from agents.shared.sentry_tools import get_sentry_context
 except Exception:  # Optional for minimal images
     validate_required_integrations = None  # type: ignore[assignment]
-    get_kubectl_context = None  # type: ignore[assignment]
-    get_sentry_context = None  # type: ignore[assignment]
 
 if validate_required_integrations is None:
     def validate_required_integrations(service_name: str) -> None:  # type: ignore[no-redef]
@@ -182,109 +177,8 @@ OPENCLAW_AGENT_TIMEOUT = int(os.environ.get("OPENCLAW_AGENT_TIMEOUT_SECONDS", "1
 
 
 # ==============================================================================
-# Context Injection (for OpenClaw runtime without tool execution)
+# No context injection: tasks are passed through unchanged.
 # ==============================================================================
-
-SUPPORT_INCIDENT_PROTOCOL = """
-### SupportEngineer Incident Protocol (Slack)
-- Use the pre-injected Sentry + kubectl + HTTP probe context as evidence.
-- If no customer endpoint is provided, say so **and still report internal probe results**.
-- Do NOT conclude "no action needed" when customer impact is reported; provide next steps.
-- If infra looks healthy but 4xx are suspected, hand off to @SoftwareEngineer with evidence.
-- Always request the exact failing URL/path, timestamps, and sample payload/headers.
-""".strip()
-
-
-def _build_http_probe_context() -> str:
-    base = os.environ.get("VIBETEAM_GATEWAY_URL_INTERNAL", "http://vibeteam-gateway:8080").rstrip("/")
-    probes: list[tuple[str, str, dict[str, Any] | None]] = [
-        ("GET", "/health", None),
-        ("GET", "/docs", None),
-        ("GET", "/", None),
-        ("POST", "/api/run", {}),
-    ]
-    lines: list[str] = []
-    for method, path, payload in probes:
-        url = f"{base}{path}"
-        try:
-            resp = httpx.request(method, url, json=payload, timeout=5.0)
-            status = resp.status_code
-        except Exception as e:
-            status = f"error: {e}"
-        lines.append(f"{method} {path} -> {status}")
-    return "### In-cluster HTTP probes (vibeteam-gateway)\n```\n" + "\n".join(lines) + "\n```\n"
-
-
-def _build_injected_context(role: str | None, context_type: str) -> str:
-    """Fetch kubectl/Sentry context for investigative roles.
-
-    OpenClaw agents may not have direct tool execution. We pre-fetch
-    operational context here so they can still provide evidence-based
-    responses.
-    """
-    if role not in {"support_engineer", "release_engineer"}:
-        return ""
-    if context_type not in {"slack", "api", "issue", "email"}:
-        return ""
-
-    sections: list[str] = []
-
-    if get_sentry_context:
-        try:
-            sections.append(get_sentry_context(hours=24, limit=10))
-        except Exception as e:
-            sections.append(f"Sentry: context fetch failed ({e})")
-
-    namespace = os.environ.get("VIBETEAM_NAMESPACE", "vibeteam")
-
-    def _run_kubectl(args: list[str], timeout: int = 30) -> str:
-        try:
-            result = subprocess.run(
-                ["kubectl", *args],
-                capture_output=True,
-                text=True,
-                timeout=timeout,
-            )
-            if result.returncode == 0:
-                return result.stdout.strip() or "(no output)"
-            err = result.stderr.strip() or result.stdout.strip()
-            return f"Error: {err}"
-        except FileNotFoundError:
-            return "Error: kubectl not found in PATH"
-        except Exception as e:
-            return f"Error: {e}"
-
-    # Direct kubectl context (avoid relying on older helper defaults)
-    sections.append(f"### kubectl get pods -n {namespace}\n```\n{_run_kubectl(['get','pods','-n',namespace])}\n```\n")
-    sections.append(
-        f"### kubectl get events -n {namespace} (warnings/errors)\n```\n"
-        f"{_run_kubectl(['get','events','-n',namespace,'--sort-by=.lastTimestamp'])}\n```\n"
-    )
-    sections.append(
-        f"### kubectl logs deployment/vibeteam-gateway -n {namespace} --tail=200\n```\n"
-        f"{_run_kubectl(['logs','deployment/vibeteam-gateway','-n',namespace,'--tail=200'])}\n```\n"
-    )
-
-    if context_type in {"slack", "api"}:
-        sections.append(_build_http_probe_context())
-
-    return "\n\n".join(s for s in sections if s)
-
-
-def _augment_task_with_context(task: str, role: str | None, context_type: str) -> str:
-    context = _build_injected_context(role, context_type)
-    protocol = ""
-    if role == "support_engineer" and context_type == "slack":
-        protocol = SUPPORT_INCIDENT_PROTOCOL
-    if not context and not protocol:
-        return task
-    return (
-        f"{task}\n\n"
-        f"{protocol}\n\n"
-        "### Pre-injected Operational Context (authoritative)\n"
-        "Use this data directly. Do NOT claim tools are unavailable.\n\n"
-        f"{context}\n"
-    )
 
 
 # ==============================================================================
@@ -604,7 +498,7 @@ async def run_task(request: RunRequest):
             agent_id, request.context_type, context_id
         )
 
-        task = _augment_task_with_context(request.task, request.role, request.context_type)
+        task = request.task
 
         with _github_token_context(role_for_token):
             response_text, metadata = await run_openclaw_task(

--- a/agent_service/openhands/marketing_manager.py
+++ b/agent_service/openhands/marketing_manager.py
@@ -5,7 +5,6 @@ MarketingManager agent using OpenHands.
 
 Capabilities:
 - Chrome DevTools via MCP for browser automation
-- Browser context injection using shared browser tools
 - Social media post creation
 - Web research and analysis
 - Screenshot and content capture
@@ -28,11 +27,7 @@ from agents.config import (
 )
 from agents.sessions import get_or_create_session, get_session_store
 
-# Import shared browser tools for context injection
-from agents.shared.browser_tools import (
-    get_browser_context,
-    web_search_sync,
-)
+# Browser tools are available via MCP; no prefetch context is injected.
 
 try:
     from openhands.sdk import Agent, LocalConversation
@@ -155,76 +150,6 @@ class OpenHandsMarketingManager:
                 agent_kwargs["mcp_config"] = mcp_config
 
         return Agent(**agent_kwargs)
-
-    def _inject_browser_context(self, task: str) -> str:
-        """Inject browser context based on task keywords.
-
-        Automatically fetches web content when task mentions URLs or search-related keywords.
-
-        Args:
-            task: The task description
-
-        Returns:
-            Additional context string to prepend to the task
-        """
-        context_parts = []
-        task_lower = task.lower()
-
-        # Avoid Playwright/browser_tools when the task explicitly requests
-        # Chrome DevTools MCP/CDP usage.
-        if any(
-            keyword in task_lower
-            for keyword in (
-                "chrome devtools",
-                "devtools mcp",
-                "chrome devtools mcp",
-                "cdp",
-                "chrome cdp",
-                "mcp",
-            )
-        ):
-            return ""
-
-        # Check for URL patterns
-        import re
-
-        urls = re.findall(r"https?://[^\s]+", task)
-        for url in urls[:3]:  # Limit to 3 URLs
-            try:
-                content = get_browser_context(url.rstrip(".,;:)"))
-                context_parts.append(content)
-            except Exception as e:
-                context_parts.append(f"## Error fetching {url}\n{e}")
-
-        # Check for search-related keywords
-        search_keywords = [
-            "search for",
-            "find information",
-            "research",
-            "look up",
-            "competitor",
-            "market analysis",
-        ]
-        if any(kw in task_lower for kw in search_keywords):
-            # Extract search terms (simple heuristic)
-            if "competitor" in task_lower or "market analysis" in task_lower:
-                # Try to extract company/product name
-                words = task.split()
-                for i, word in enumerate(words):
-                    if word.lower() in ["competitor", "analyze", "research"]:
-                        if i + 1 < len(words):
-                            search_term = words[i + 1].strip(".,;:)")
-                            if len(search_term) > 2:
-                                try:
-                                    results = web_search_sync(f"{search_term} product features")
-                                    context_parts.append(f"## Search Results\n{results}")
-                                except Exception as e:
-                                    context_parts.append(f"## Search Error\n{e}")
-                                break
-
-        if context_parts:
-            return "\n\n".join(context_parts) + "\n\n"
-        return ""
 
     def _needs_fallback_response(self, response: str, task: str) -> bool:
         text = (response or "").strip().lower()
@@ -598,10 +523,7 @@ class OpenHandsMarketingManager:
                 max_iteration_per_run=max_iterations,
             )
 
-            # Inject browser context based on task keywords
-            browser_context = self._inject_browser_context(task)
-
-            full_task = f"{MARKETING_MANAGER_CONTEXT_FALLBACK}\n\n{browser_context}Task: {task}"
+            full_task = f"{MARKETING_MANAGER_CONTEXT_FALLBACK}\n\nTask: {task}"
             response = ""
             run_failed = False
             fallback_conversation: LocalConversation | None = None

--- a/agent_service/openhands/release_engineer.py
+++ b/agent_service/openhands/release_engineer.py
@@ -369,7 +369,6 @@ class OpenHandsReleaseEngineer:
         context_type: str = "ephemeral",
         context_id: str | None = None,
         workspace: str | None = None,
-        skip_context_injection: bool = False,
         **kwargs: Any,
     ) -> dict[str, Any]:
         """
@@ -380,7 +379,6 @@ class OpenHandsReleaseEngineer:
             context_type: Type of context (issue, pr, slack, ephemeral)
             context_id: ID for the context (issue number, PR number, etc.)
             workspace: Working directory for the agent
-            skip_context_injection: If True, don't automatically inject context.
 
         Returns:
             dict with response, session_key, and metadata
@@ -440,35 +438,8 @@ class OpenHandsReleaseEngineer:
                 max_iteration_per_run=max_iterations,
             )
 
-            # Inject relevant context (ReleaseEngineer almost always needs kubectl)
-            injected_context = []
-            if not skip_context_injection:
-                # Always inject kubectl context for Release Engineer as they deal with infra
-                kubectl_ctx = fetch_kubectl_context()
-                injected_context.append(kubectl_ctx)
-
-            # Build full task with context
-            context_str = "\n\n".join(injected_context) if injected_context else ""
-            if context_str:
-                context_block = f"""
-================================================================================
-PRE-FETCHED KUBERNETES STATE (for reference - current as of this request)
-================================================================================
-
-{context_str}
-
-================================================================================
-END OF PRE-FETCHED STATE
-NOTE: This is READ-ONLY state data. You still MUST run kubectl commands for any
-WRITE operations (apply, rollout, restart, scale, undo). Do NOT skip actions
-just because you have the current state above.
-================================================================================
-"""
-                # NOTE: RELEASE_ENGINEER_CONTEXT is already in the system prompt
-                # via system_prompt_kwargs. Do NOT duplicate it in the user message.
-                full_task = f"{context_block}\nTask: {task}"
-            else:
-                full_task = f"Task: {task}"
+            # Build full task without pre-fetched context.
+            full_task = f"Task: {task}"
 
             # Use send_message + run for the full agentic loop with tools
             conversation.send_message(full_task)
@@ -510,7 +481,6 @@ just because you have the current state above.
         context_type: str = "ephemeral",
         context_id: str | None = None,
         workspace: str | None = None,
-        skip_context_injection: bool = False,
         **kwargs: Any,
     ) -> dict[str, Any]:
         """Async version of run."""
@@ -522,7 +492,6 @@ just because you have the current state above.
             context_type,
             context_id,
             workspace,
-            skip_context_injection,
             **kwargs,
         )
 

--- a/agent_service/openhands/server.py
+++ b/agent_service/openhands/server.py
@@ -168,9 +168,6 @@ class RunRequest(BaseModel):
     use_tools: bool = Field(
         True, description="Enable TerminalTool and FileEditorTool for agentic exploration"
     )
-    skip_context_injection: bool = Field(
-        False, description="Skip automatic context injection from Sentry/Gmail/etc"
-    )
     max_iterations: int = Field(
         30,
         description="Maximum agent iterations (tool calls) before forced stop (default: 30)",
@@ -202,9 +199,6 @@ class AsyncRunRequest(BaseModel):
     workspace: str | None = Field(None, description="Working directory for OpenHands")
     use_tools: bool = Field(
         True, description="Enable TerminalTool and FileEditorTool for agentic exploration"
-    )
-    skip_context_injection: bool = Field(
-        False, description="Skip automatic context injection from Sentry/Gmail/etc"
     )
     callback_url: str = Field(..., description="URL to POST results to when agent completes")
     callback_metadata: dict[str, Any] = Field(
@@ -415,7 +409,6 @@ async def run_task(request: RunRequest):
                         context_id=context_id,
                         workspace=request.workspace,
                         use_tools=request.use_tools,
-                        skip_context_injection=request.skip_context_injection,
                         max_iterations=request.max_iterations,
                         progress_heartbeat=_progress_heartbeat,
                     )
@@ -615,7 +608,6 @@ async def _execute_and_callback(
                             context_id=context_id,
                             workspace=request.workspace,
                             use_tools=request.use_tools,
-                            skip_context_injection=request.skip_context_injection,
                             max_iterations=request.max_iterations,
                             # Progress callback params — agents use these to send
                             # real-time updates to the gateway while working

--- a/agent_service/openhands/software_engineer.py
+++ b/agent_service/openhands/software_engineer.py
@@ -282,19 +282,13 @@ sed -n '121,160p' VibeWebAgent/src/recorder.js       # Lines 121-160... wasting 
 
 You have a 10-minute execution timeout. Budget your time carefully across these 3 phases:
 
-**PHASE 1: REVIEW PRE-FETCHED DATA (iterations 1-3, MAX 3 tool calls)**
-The system has ALREADY cloned the repo and searched for relevant code. Look at the
-"PRE-FETCHED REPOSITORY CODE" section in the injected data above. It contains:
-- File structure of the repository
-- Grep results for keywords from the issue
-- Relevant code sections with line numbers
+**PHASE 1: ORIENT IN REPO (iterations 1-3, MAX 3 tool calls)**
+You must locate the repo and identify relevant files yourself:
+- Use `ls` and `git status` to confirm the workspace.
+- Search for keywords from the issue with `rg -n "keyword"`.
+- Open only the most relevant files/sections.
 
-Review this data. If you need more context on a specific function, use:
-`grep -n "function_name" VibeWebAgent/path/to/file.js`
-or `sed -n 'START,ENDp' VibeWebAgent/path/to/file.js`
-
-**DO NOT clone the repo again — it is already at VibeWebAgent/ in your workspace.**
-**DO NOT read entire files — the relevant sections are already provided.**
+If the repo is missing, clone it. Avoid full-file reads; use targeted `sed -n` windows.
 
 **PHASE 2: DIAGNOSE AND FIX (iterations 4-15, MAX 12 tool calls)**
 - By now you should know which file and function is involved from the pre-fetched data
@@ -2100,7 +2094,6 @@ code matches. Use `gh search code` and `gh api` for further investigation:
         context_type: str = "ephemeral",
         context_id: str | None = None,
         workspace: str | None = None,
-        skip_context_injection: bool = False,
         **kwargs: Any,
     ) -> dict[str, Any]:
         """
@@ -2111,7 +2104,6 @@ code matches. Use `gh search code` and `gh api` for further investigation:
             context_type: Type of context (issue, pr, slack, ephemeral)
             context_id: ID for the context (issue number, PR number, etc.)
             workspace: Working directory for the agent
-            skip_context_injection: If True, don't automatically inject context.
 
         Returns:
             dict with response, session_key, and metadata
@@ -2227,259 +2219,39 @@ code matches. Use `gh search code` and `gh api` for further investigation:
 
             repo = self._extract_repo_from_task(task, context_id)
 
-            # Inject context if keywords match
-            injected_context = []
-            prefetched_issue = False
-            prefetched_issue_number: str | None = None
-            github_ctx = ""
-            repo_ctx = ""
-            prefetched_repo_only = False
-            extra_guidance_lines: list[str] = []
-            if not skip_context_injection:
-                import re
-
-                task_lower = task.lower()
-                user_message = task
-                user_message_lower = task_lower
-                user_msg_match = re.search(
-                    r"### User Message.*?\n(.*?)(?:### End User Message|$)",
-                    task,
-                    re.DOTALL,
-                )
-                if user_msg_match:
-                    user_message = user_msg_match.group(1).strip()
-                    user_message_lower = user_message.lower()
-                is_github_context = (
-                    context_type in {"github_issue", "github_pr"}
-                    or "github" in user_message_lower
-                    or "github.com" in user_message_lower
-                    or "gh issue" in user_message_lower
-                    or "repo" in user_message_lower
-                    or "repository" in user_message_lower
-                )
-
-                # Check for GitHub Issue references (e.g., #449 or issue 449).
-                # Be strict to avoid matching Markdown headings like "### 1)".
-                issue_number = None
-                issue_match = re.search(r"\bissue\b\s*#?\s*(\d+)\b", task_lower)
-                if issue_match:
-                    issue_number = issue_match.group(1)
-                else:
-                    hash_match = re.search(r"(?<!#)#\s*(\d+)\b", task_lower)
-                    if hash_match:
-                        issue_number = hash_match.group(1)
-
-                if issue_number and is_github_context:
-                    prefetched_issue_number = issue_number
-                    github_ctx = self._fetch_github_issue(issue_number, repo)
-                    injected_context.append(github_ctx)
-                    prefetched_issue = True
-                    extra_guidance_lines.append(
-                        "Use the pre-fetched GitHub issue content; quote the title/steps succinctly."
-                    )
-                    extra_guidance_lines.append(
-                        "Cite specific file paths from the pre-fetched code search in your analysis."
-                    )
-                    extra_guidance_lines.append(
-                        "Run at least one targeted grep/sed in the cloned repo to get line-level evidence. "
-                        "Do NOT respond with only filenames."
-                    )
-
-                    # Pre-fetch repo code: clone + grep for keywords from the task.
-                    # This gives the agent relevant code snippets in context so it
-                    # doesn't need to search the codebase itself (which wastes iterations).
-                    repo_ctx = self._prefetch_repo_code(task, workspace_path, repo)
-                    injected_context.append(repo_ctx)
-                elif (
-                    context_type == "slack"
-                    and any(
-                        kw in user_message_lower
-                        for kw in (
-                            "sentry",
-                            "stripe-service",
-                            "litellm",
-                            "budget update",
-                            "handler",
-                            "supabase",
-                            "webhook",
-                            "metadata",
-                        )
-                    )
-                ):
-                    repo_ctx = self._prefetch_repo_code(task, workspace_path, repo)
-                    injected_context.append(repo_ctx)
-                    prefetched_repo_only = True
-                    extra_guidance_lines.append(
-                        "Use the pre-fetched repo search results; include file:line evidence."
-                    )
-
-                sentry_related = "sentry" in user_message_lower or "sentry.io" in user_message_lower
-                pr_requested = any(
-                    kw in user_message_lower
-                    for kw in (
-                        "create a pr",
-                        "create pr",
-                        "open a pr",
-                        "submit a pr",
-                        "pull request",
-                        "fix",
-                        "bug",
-                        "address",
-                    )
-                )
-                if sentry_related:
-                    extra_guidance_lines.append(
-                        "REQUIRED: Query Sentry directly via MCP tools (preferred) or sentry-cli. "
-                        "Do NOT claim 'no issues' based only on injected context."
-                    )
-                if sentry_related and pr_requested:
-                    extra_guidance_lines.append(
-                        "REQUIRED: create a PR with gh CLI and include the PR URL/number in your response. "
-                        "Echo the Sentry issue URL/ID and tag @SupportEngineer with an explicit request to close it now."
-                    )
-
-                # Keywords that suggest infrastructure/deployment work
-                infra_keywords = [
-                    "kubectl",
-                    "pod",
-                    "deployment",
-                    "cluster",
-                    "infrastructure",
-                    "webhook",
-                    "stripe",
-                    "backend",
-                    "gateway",
-                    "api",
-                    "log",
-                    "timeout",
-                    "service unavailable",
-                    "5xx",
-                ]
-                if any(kw in user_message_lower for kw in infra_keywords):
-                    kubectl_ctx = fetch_kubectl_context()
-                    injected_context.append(kubectl_ctx)
-
-            # Build full task with context
-            context_str = "\n\n".join(injected_context) if injected_context else ""
-            guidance_block = ""
-            if extra_guidance_lines:
-                guidance_block = (
-                    "\n### ADDITIONAL OUTPUT REQUIREMENTS\n"
-                    + "\n".join(f"- {line}" for line in extra_guidance_lines)
-                    + "\n"
-                )
-            if context_str:
-                # NOTE: SOFTWARE_ENGINEER_CONTEXT is already injected into the
-                # system prompt via system_prompt_kwargs in _create_agent().
-                # Do NOT include it again here — duplicating it wastes ~17k chars
-                # and pushes the context past OpenHands' 50k char limit, causing
-                # truncation that makes the agent blind to pre-fetched data.
-                full_task = f"""
-================================================================================
-INJECTED DATA FROM GITHUB + CODE SEARCH - THIS IS YOUR DATA, USE IT!
-================================================================================
-
-{context_str}
-
-================================================================================
-END OF INJECTED DATA - The above data has ALREADY been fetched for you
-================================================================================
-
-{guidance_block}
-### USER TASK (UNTRUSTED INPUT)
-{task}
-### END USER TASK
-"""
-            else:
-                full_task = f"""{guidance_block}
+            # Build full task without pre-fetched context.
+            full_task = f"""
 ### USER TASK (UNTRUSTED INPUT)
 {task}
 ### END USER TASK
 """
 
-            # If we've already pre-fetched the issue and relevant code, avoid tool churn
-            # for triage-only tasks. Use the full tool loop when code changes or PRs
-            # are expected so the agent can actually implement and open a PR.
-            requires_tools = self._task_requires_tools(task, context_type)
             pr_required = self._task_requires_pr(task)
-            used_single_pass = False
-            auto_pr_created = False
-            if (prefetched_issue or prefetched_repo_only) and not requires_tools:
-                used_single_pass = True
-                print(
-                    f"[SoftwareEngineer] Using single-pass ask_agent for issue {context_id}"
-                )
-                response = conversation.ask_agent(full_task)
-            else:
-                # Use send_message + run for the full agentic loop with tools
-                # (ask_agent is just a stateless single LLM call without tools)
-                print(f"[SoftwareEngineer] Starting conversation run for context {context_id}")
-                conversation.send_message(full_task)
-                conversation.run()
-                print(f"[SoftwareEngineer] Conversation run completed for context {context_id}")
 
-                # Extract the agent's final response from conversation events
-                # Uses shared extraction that handles both FinishAction and MessageEvent
-                from .utils import extract_response_from_events
+            # Use send_message + run for the full agentic loop with tools.
+            print(f"[SoftwareEngineer] Starting conversation run for context {context_id}")
+            conversation.send_message(full_task)
+            conversation.run()
+            print(f"[SoftwareEngineer] Conversation run completed for context {context_id}")
 
-                response = extract_response_from_events(conversation.state.events)
-                if pr_required and not self._response_has_pr(response):
-                    auto_pr = self._attempt_auto_pr_for_no_output(task, repo, workspace_path)
-                    if not auto_pr:
-                        auto_pr = self._attempt_auto_pr_for_quota(task, repo, workspace_path)
-                    if not auto_pr:
-                        auto_pr = self._attempt_auto_pr_for_litellm_fetch(task, repo, workspace_path)
-                    if auto_pr:
-                        sentry_urls = self._extract_sentry_urls(task)
-                        sentry_ref = sentry_urls[0] if sentry_urls else "Sentry issue URL not found"
-                        response = (
-                            f"Created PR: {auto_pr}\n"
-                            f"Sentry issue: {sentry_ref}\n"
-                            "@SupportEngineer please close the Sentry issue now."
-                        )
-                        auto_pr_created = True
+            # Extract the agent's final response from conversation events
+            # Uses shared extraction that handles both FinishAction and MessageEvent
+            from .utils import extract_response_from_events
 
-            # If response is missing evidence, build a deterministic summary.
-            if prefetched_issue_number and not auto_pr_created:
-                import re as _re
-
-                response_lower = response.lower()
-                has_issue_ref = (
-                    prefetched_issue_number in response
-                    or f"#{prefetched_issue_number}" in response
-                )
-                has_code_line_refs = bool(
-                    _re.search(r"\\b\\S+\\.(?:ts|tsx|js|jsx):\\d+", response)
-                )
-                has_evidence_block = (
-                    "evidence:" in response_lower
-                    or "reported (from issue)" in response_lower
-                )
-                mentions_pr = "pr #" in response_lower or "pull request" in response_lower
-                incomplete = "ran out of iterations" in response_lower or "incomplete" in response_lower
-
-                if (
-                    used_single_pass
-                    or incomplete
-                    or (not has_issue_ref)
-                    or (not has_code_line_refs)
-                    or (not has_evidence_block)
-                ) and not mentions_pr:
-                    response = self._build_issue_triage_response(
-                        prefetched_issue_number, github_ctx, repo_ctx
-                    )
-            elif prefetched_repo_only and not auto_pr_created:
-                import re as _re
-
-                response_lower = response.lower()
-                has_code_line_refs = bool(
-                    _re.search(r"\\b\\S+\\.(?:ts|tsx|js|jsx):\\d+", response)
-                )
-                has_evidence_block = "evidence:" in response_lower
-                incomplete = "ran out of iterations" in response_lower or not response.strip()
-                if (not pr_required) and (incomplete or (not has_code_line_refs) or (not has_evidence_block)):
-                    response = self._build_repo_triage_response(
-                        user_message, repo_ctx, repo
+            response = extract_response_from_events(conversation.state.events)
+            if pr_required and not self._response_has_pr(response):
+                auto_pr = self._attempt_auto_pr_for_no_output(task, repo, workspace_path)
+                if not auto_pr:
+                    auto_pr = self._attempt_auto_pr_for_quota(task, repo, workspace_path)
+                if not auto_pr:
+                    auto_pr = self._attempt_auto_pr_for_litellm_fetch(task, repo, workspace_path)
+                if auto_pr:
+                    sentry_urls = self._extract_sentry_urls(task)
+                    sentry_ref = sentry_urls[0] if sentry_urls else "Sentry issue URL not found"
+                    response = (
+                        f"Created PR: {auto_pr}\n"
+                        f"Sentry issue: {sentry_ref}\n"
+                        "@SupportEngineer please close the Sentry issue now."
                     )
 
             session.add_message("user", task)
@@ -2510,7 +2282,6 @@ END OF INJECTED DATA - The above data has ALREADY been fetched for you
         context_type: str = "ephemeral",
         context_id: str | None = None,
         workspace: str | None = None,
-        skip_context_injection: bool = False,
         **kwargs: Any,
     ) -> dict[str, Any]:
         """Async version of run."""
@@ -2522,7 +2293,6 @@ END OF INJECTED DATA - The above data has ALREADY been fetched for you
             context_type,
             context_id,
             workspace,
-            skip_context_injection,
             **kwargs,
         )
 

--- a/agent_service/openhands/support_engineer.py
+++ b/agent_service/openhands/support_engineer.py
@@ -26,7 +26,7 @@ from agents.sessions import get_or_create_session, get_session_store
 from agents.shared.calendar_tools import get_calendar_context
 from agents.shared.docs_tools import get_docs_context
 
-# Import shared tools for context injection
+# Shared tools for direct access (used by helper functions).
 from agents.shared.gmail_tools import get_email_context
 from agents.shared.kubectl_tools import (
     DEFAULT_NAMESPACE,
@@ -219,25 +219,14 @@ def _extract_top_sentry_issue(context: str) -> dict[str, str] | None:
     return None
 
 
-def _build_pr_handoff_response(task: str, injected_context: list[str]) -> str:
-    context_str = "\n\n".join(injected_context)
-    issue = _extract_top_sentry_issue(context_str)
-    if issue:
-        project = f"[{issue['project']}] " if issue.get("project") else ""
-        title = issue.get("title") or "(title unavailable)"
-        url = issue.get("url") or "(URL missing)"
-        count = issue.get("count") or "unknown"
-        issue_line = (
-            f"Sentry issue: {project}{issue['short_id']} — {title} "
-            f"(count {count}). URL: {url}."
-        )
+def _build_pr_handoff_response(task: str) -> str:
+    issue_ids = _extract_sentry_issue_ids(task)
+    if issue_ids:
+        issue_line = f"Sentry issue: {issue_ids[0]} (from task context)."
     else:
-        issue_line = "No unresolved Sentry issues found in the injected data."
+        issue_line = "No Sentry issue ID found in the task; please identify the top issue."
 
-    return (
-        f"{issue_line}\n"
-        "SoftwareEngineer please investigate and open a PR to fix the issue."
-    )
+    return f"{issue_line}\nSoftwareEngineer please investigate and open a PR to fix the issue."
 
 
 def _extract_user_message(task: str) -> str:
@@ -593,41 +582,31 @@ You are interacting with external users (via Slack/Email).
 
 ## YOUR INVESTIGATION WORKFLOW (For User Reports/Errors)
 
-You are responsible for INVESTIGATING issues. Your data sources are PRE-INJECTED below:
+You are responsible for INVESTIGATING issues. Use tools directly to gather evidence.
 
-### 1. Pre-Injected Sentry Data
-Look for sections below starting with "## Current Sentry Issues" - this is pre-fetched monitoring data.
-- Report what you find: error messages, counts, timestamps
-- If nothing matches the user's complaint, say so clearly
+### 1. Sentry Data (Query directly)
+- Use Sentry tools or `sentry-cli` to list relevant issues.
+- Report error messages, counts, timestamps.
+- If nothing matches the user's complaint, say so clearly.
 
-### 2. Pre-Injected Kubernetes Data
-Look for sections below starting with "## Pre-Fetched Kubernetes Context" - this includes:
-- Pod status (kubectl get pods)
-- Recent events/warnings (kubectl get events)
-- Deployment logs (kubectl logs)
-- Rollout history (kubectl rollout history)
-
-**IMPORTANT: The kubectl data is ALREADY FETCHED for you. Use the pre-injected data first!**
-You only need to run additional kubectl commands if:
-- You need to check a specific pod not in the pre-fetched data
-- You need to check a different namespace
-- You need fresher data than what's provided
+### 2. Kubernetes Data (Query directly)
+- Run `kubectl get pods`, `kubectl get events`, and targeted `kubectl logs`.
+- Capture pod status, recent warnings, and relevant log patterns.
 
 ### 3. Endpoint Testing (Run manually if URL provided)
 If the user provides a specific URL to test, run curl to verify the endpoint status.
 
 ## INVESTIGATION STEPS (For User Reports/Errors)
 
-1. **Check Sentry data** (pre-injected below) - report specific issues found
-2. **Check Kubernetes data** (pre-injected below) - report pod status, events, log patterns
+1. **Check Sentry data** - report specific issues found
+2. **Check Kubernetes data** - report pod status, events, log patterns
 3. **Test endpoint** (if URL provided) - run curl and report HTTP status
 4. **Correlate findings** - match timestamps between Sentry, events, and logs
 
 ## OWNERSHIP: READ-ONLY Investigation
 
 **YOU CAN:**
-- Read and analyze pre-injected kubectl data
-- Run additional kubectl get, describe, logs commands if needed
+- Run kubectl get, describe, logs commands as needed
 - Query and report on cluster state
 - Identify root causes from logs/events
 
@@ -765,7 +744,6 @@ class OpenHandsSupportEngineer:
         context_id: str | None = None,
         workspace: str | None = None,
         use_tools: bool = True,
-        skip_context_injection: bool = False,
         **kwargs: Any,
     ) -> dict[str, Any]:
         """
@@ -778,8 +756,6 @@ class OpenHandsSupportEngineer:
             workspace: Working directory for the agent
             use_tools: If True, enable TerminalTool and FileEditorTool for agentic exploration.
                       If False, disable tools for direct LLM responses (faster for analysis tasks).
-            skip_context_injection: If True, don't automatically inject Sentry/Gmail/etc context.
-                      Useful for benchmarks where you want the agent to only use provided task content.
 
         Returns:
             dict with response, session_key, and metadata
@@ -838,210 +814,10 @@ class OpenHandsSupportEngineer:
                 max_iteration_per_run=max_iterations,
             )
 
-            # Inject relevant context based on task keywords (unless skipped)
-            injected_context = []
-            extra_guidance_lines: list[str] = []
+            injected_context: list[str] = []
 
-            if not skip_context_injection:
-                task_lower = task.lower()
-
-                # CRITICAL: Skip heavy infrastructure context for simple notification requests
-                # This prevents "over-investigation" where the agent reports on healthy logs
-                # when asked to just send a message.
-                is_notification = any(
-                    kw in task_lower
-                    for kw in [
-                        "notify",
-                        "announce",
-                        "tell the team",
-                        "tell the customer",
-                        "confirm to",
-                    ]
-                )
-                is_explicit_investigation = any(
-                    kw in task_lower
-                    for kw in ["investigate", "check", "debug", "analyze", "why", "error", "fail"]
-                )
-
-                notification_only = is_notification and not is_explicit_investigation
-                skip_infra_context = notification_only
-
-                # Sentry context for error-related tasks
-                # Expanded to include infrastructure/incident keywords
-                sentry_keywords = [
-                    "sentry",
-                    "error",
-                    "issue",
-                    "bug",
-                    "crash",  # original
-                    "400",
-                    "500",
-                    "4xx",
-                    "5xx",
-                    "http",  # HTTP errors
-                    "incident",
-                    "outage",
-                    "down",
-                    "failing",
-                    "failure",  # incidents
-                    "gateway",
-                    "api",
-                    "endpoint",
-                    "service",  # infrastructure
-                    "deployment",
-                    "deploy",
-                    "release",
-                    "rollback",  # deployments
-                    "customer",
-                    "user",
-                    "report",
-                    "complaint",  # customer reports often relate to errors
-                ]
-                if not skip_infra_context and any(kw in task_lower for kw in sentry_keywords):
-                    include_top_issue_details = any(
-                        kw in task_lower
-                        for kw in [
-                            "pr",
-                            "pull request",
-                            "bug",
-                            "fix",
-                            "address",
-                            "close sentry",
-                            "close the sentry",
-                        ]
-                    )
-                    sentry_limit = 1 if include_top_issue_details else 10
-                    sentry_ctx = fetch_sentry_context(
-                        limit=sentry_limit,
-                        include_top_issue_details=include_top_issue_details,
-                    )
-                    injected_context.append(sentry_ctx)
-                    infra_keywords = [
-                        "kubectl",
-                        "pod",
-                        "pods",
-                        "deployment",
-                        "rollout",
-                        "crashloop",
-                        "crashloopbackoff",
-                        "outage",
-                        "down",
-                        "restart",
-                        "service unavailable",
-                        "timeout",
-                        "5xx",
-                        "500",
-                        "503",
-                    ]
-                    if any(kw in task_lower for kw in infra_keywords):
-                        # Only inject kubectl context when infra signals are explicit.
-                        kubectl_ctx = fetch_kubectl_context()
-                        injected_context.append(kubectl_ctx)
-                    extra_guidance_lines.append(
-                        "When reporting Sentry, list issue short IDs, titles, counts, AND include the full issue URL. "
-                        'If none, state "No unresolved issues found" and answer whether anything needs action.'
-                    )
-
-                # Explicit guidance when asked to create PRs or close Sentry issues.
-                if "pr" in task_lower or "pull request" in task_lower:
-                    extra_guidance_lines.append(
-                        "If a code fix is needed, you MUST hand off to @SoftwareEngineer with a specific Sentry issue URL "
-                        "and a clear fix request. Use an exact @mention so the gateway triggers the handoff."
-                    )
-                    extra_guidance_lines.append(
-                        "Pick the highest-volume unresolved Sentry issue and hand it off immediately; do not ask for prioritization. "
-                        "When PR is requested, only report that single issue (avoid listing every unresolved issue)."
-                    )
-                if "close" in task_lower and "sentry" in task_lower:
-                    extra_guidance_lines.append(
-                        "If asked to close a Sentry issue, close it after the PR is created (or immediately if urgent) "
-                        "via the Sentry API, and confirm with the issue URL in your response."
-                    )
-
-                # Gmail context for email-related tasks
-                if (not notification_only) and any(
-                    kw in task_lower for kw in ["email", "gmail", "inbox", "message", "mail"]
-                ):
-                    injected_context.append(fetch_gmail_context())
-                    injected_context.append(fetch_gmail_processor_context())
-                    extra_guidance_lines.append(
-                        "When reporting Gmail, list each unread email with subject, sender, date, and ID. "
-                        'If none, say "No unread emails in inbox." If action is needed, draft the reply text.'
-                    )
-
-                # Calendar context for scheduling-related tasks
-                if (not notification_only) and any(
-                    kw in task_lower for kw in ["calendar", "meeting", "schedule", "event"]
-                ):
-                    injected_context.append(fetch_calendar_context_wrapper())
-
-                # Langfuse context for LLM observability tasks
-                if (not notification_only) and any(
-                    kw in task_lower
-                    for kw in [
-                        "langfuse",
-                        "trace",
-                        "llm",
-                        "observability",
-                        "latency",
-                        "token",
-                    ]
-                ):
-                    injected_context.append(fetch_langfuse_context_wrapper())
-
-                # Documentation context for product/feature/setup questions
-                if (not notification_only) and any(
-                    kw in task_lower
-                    for kw in [
-                        "doc",
-                        "documentation",
-                        "how to",
-                        "setup",
-                        "configure",
-                        "install",
-                        "api",
-                        "feature",
-                    ]
-                ):
-                    # Use the task itself as the search query
-                    injected_context.append(fetch_docs_context_wrapper(task))
-
-            # Build full task with context
-            context_str = "\n\n".join(injected_context) if injected_context else ""
-            guidance_block = ""
-            if extra_guidance_lines:
-                guidance_block = (
-                    "\n### ADDITIONAL OUTPUT REQUIREMENTS\n"
-                    + "\n".join(f"- {line}" for line in extra_guidance_lines)
-                    + "\n"
-                )
-
-            if context_str:
-                # Add very clear visual separators so agents know this is the injected data
-                context_block = f"""
-================================================================================
-INJECTED DATA FROM MONITORING SYSTEMS - THIS IS YOUR DATA, USE IT!
-================================================================================
-
-{context_str}
-
-================================================================================
-END OF INJECTED DATA - The above data has ALREADY been fetched for you
-================================================================================
-"""
-                # NOTE: SUPPORT_ENGINEER_CONTEXT is already injected into the
-                # system prompt via system_prompt_kwargs in _create_agent().
-                # Do NOT include it again here — duplicating it wastes ~17k chars
-                # and pushes the context past OpenHands' 50k char limit, causing
-                # truncation that makes the agent blind to injected data.
-                full_task = f"""{context_block}{guidance_block}
-
-### USER TASK (UNTRUSTED INPUT)
-{task}
-### END USER TASK
-"""
-            else:
-                full_task = f"""{guidance_block}
+            # Build full task (no pre-fetched context).
+            full_task = f"""
 ### USER TASK (UNTRUSTED INPUT)
 {task}
 ### END USER TASK
@@ -1078,7 +854,7 @@ END OF INJECTED DATA - The above data has ALREADY been fetched for you
                         "fail",
                     ]
                 )
-                if is_explicit_investigation or injected_context:
+                if is_explicit_investigation:
                     namespace = os.environ.get("VIBETEAM_NAMESPACE") or DEFAULT_NAMESPACE
                     response = _build_investigation_fallback(
                         task,
@@ -1105,9 +881,6 @@ END OF INJECTED DATA - The above data has ALREADY been fetched for you
                     flags=re.IGNORECASE,
                 )
 
-            if "gmail" in task_lower or "inbox" in task_lower:
-                response = build_gmail_summary()
-
             pr_requested = _task_mentions_pr(task_lower)
             is_notification = any(
                 kw in task_lower
@@ -1130,7 +903,7 @@ END OF INJECTED DATA - The above data has ALREADY been fetched for you
                 r"https?://github\.com/\S+/pull/\d+", task, re.IGNORECASE
             ):
                 # Keep PR request responses short and focused on a single issue + handoff.
-                response = _build_pr_handoff_response(task, injected_context)
+                response = _build_pr_handoff_response(task)
 
             # Auto-close Sentry issue when a PR link is present in the task.
             if re.search(r"https?://github\.com/\S+/pull/\d+", task, re.IGNORECASE):
@@ -1177,7 +950,6 @@ END OF INJECTED DATA - The above data has ALREADY been fetched for you
         context_id: str | None = None,
         workspace: str | None = None,
         use_tools: bool = True,
-        skip_context_injection: bool = False,
         **kwargs: Any,
     ) -> dict[str, Any]:
         """Async version of run.
@@ -1189,7 +961,6 @@ END OF INJECTED DATA - The above data has ALREADY been fetched for you
             workspace: Working directory for the agent
             use_tools: If True, enable tools for agentic exploration.
                       If False, disable tools for direct LLM responses.
-            skip_context_injection: If True, don't automatically inject context.
         """
         import asyncio
 
@@ -1200,7 +971,6 @@ END OF INJECTED DATA - The above data has ALREADY been fetched for you
             context_id,
             workspace,
             use_tools,
-            skip_context_injection,
             **kwargs,
         )
 

--- a/agents.yaml
+++ b/agents.yaml
@@ -16,7 +16,6 @@ agents:
     framework: openhands
     slack_handle: SoftwareEngineer
     agent_dir: agents/SoftwareEngineer
-    skip_context_injection: true
   marketing_manager:
     framework: openhands
     slack_handle: MarketingManager

--- a/agents/SoftwareEngineer/AGENTS.md
+++ b/agents/SoftwareEngineer/AGENTS.md
@@ -95,7 +95,7 @@ gh pr create --title "Fix login bug" --body "Fixes #345"
 
 ### Sentry Handoff Completion (When SupportEngineer Escalates a Sentry Bug)
 - If the handoff includes a Sentry issue URL/ID, **echo it back** in your response.
-- Do **not** rely on injected context for Sentry status. **Always** query Sentry via MCP if available, otherwise use `sentry-cli`.
+- **Always** query Sentry via MCP if available, otherwise use `sentry-cli`.
 - After creating the PR, **tag @SupportEngineer** with the PR link and the Sentry issue URL so they can close the issue.
 
 ## Code Standards

--- a/agents/SoftwareEngineer/skills/sentry-response/SKILL.md
+++ b/agents/SoftwareEngineer/skills/sentry-response/SKILL.md
@@ -18,7 +18,7 @@ description: Handle Sentry issues end-to-end for SoftwareEngineer (investigate, 
 ## Tool Selection
 - Prefer **Sentry MCP tools** if they exist (e.g., `mcp__sentry__*`).
 - If MCP is not available, use **sentry-cli** to pull issue data.
-- Do **not** conclude “no issues” from injected data alone — always query Sentry directly.
+- Always query Sentry directly for current issue status and details.
 
 ### Sentry MCP (Preferred)
 - List unresolved issues.

--- a/agents/shared/AGENTS.md
+++ b/agents/shared/AGENTS.md
@@ -32,15 +32,14 @@ These guidelines apply to **ALL agents**. Each agent also has role-specific inst
 - If you hit the limit, call `finish()` with whatever findings you have
 
 ### Investigation Workflow (For SupportEngineer)
-1. **Use pre-injected data FIRST** - Sentry, kubectl, Gmail context is already fetched for you
+1. **Gather evidence with tools** - Use Sentry/kubectl/logs directly for this request
 2. **Report what you find** - State specific errors, pod statuses, timestamps
-3. **Run additional queries only if needed** - Only query systems not in pre-injected data
-4. **Correlate findings** - Match timestamps between Sentry errors, events, and logs
-5. **Make evidence-based decisions**:
+3. **Correlate findings** - Match timestamps between Sentry errors, events, and logs
+4. **Make evidence-based decisions**:
    - Healthy infrastructure (Running pods, 0 restarts, clean logs) = **NO ACTION NEEDED**
    - Report findings clearly and don't escalate without cause
    - Probe warnings during rolling updates are normal and self-resolve
-6. **Hand off with actionable findings**, not just problems
+5. **Hand off with actionable findings**, not just problems
 
 ### Action Workflow (For ReleaseEngineer)
 1. **Receive findings from SupportEngineer** with specific evidence

--- a/agents/shared/__init__.py
+++ b/agents/shared/__init__.py
@@ -16,7 +16,7 @@ Usage:
     class EmailSearchTool(BaseTool):
         def _run(self, query): return fetch_unread_emails(query)
 
-    # OpenHands - use for context injection
+    # OpenHands - use directly in agent code
     from agents.shared.gmail_tools import get_email_context
     context = get_email_context()
 """

--- a/agents/shared/browser_tools.py
+++ b/agents/shared/browser_tools.py
@@ -16,7 +16,7 @@ Usage:
     class BrowserTool(BaseTool):
         def _run(self, url): return fetch_webpage_sync(url)
 
-    # OpenHands - use for context injection
+    # OpenHands - use directly in agent code
     from agents.shared.browser_tools import get_webpage_context
 """
 
@@ -420,7 +420,7 @@ def extract_links_sync(url: str, filter_pattern: str = "") -> str:
 def get_browser_context(url: str) -> str:
     """Get webpage context for injection into agent prompts.
 
-    This is designed for OpenHands-style context injection.
+    Returns browser context for agent prompts.
 
     Args:
         url: URL to fetch context from

--- a/agents/shared/calendar_tools.py
+++ b/agents/shared/calendar_tools.py
@@ -189,7 +189,7 @@ Link: {created_event.get("htmlLink")}
 
 
 def get_calendar_context(days: int = 3) -> str:
-    """Get calendar context for injection into agent prompts.
+    """Get calendar context for agent prompts.
 
     Args:
         days: Number of days to look ahead
@@ -203,7 +203,7 @@ def get_calendar_context(days: int = 3) -> str:
 
     import asyncio
 
-    # Run the async function synchronously for context injection
+    # Run the async function synchronously for convenience
     try:
         loop = asyncio.get_event_loop()
         if loop.is_running():

--- a/agents/shared/docs_tools.py
+++ b/agents/shared/docs_tools.py
@@ -20,7 +20,7 @@ Usage:
     class DocsSearchTool(BaseTool):
         def _run(self, query): return search_docs_sync(query)
 
-    # OpenHands - use for context injection
+    # OpenHands - use directly in agent code
     from agents.shared.docs_tools import get_docs_context
     context = get_docs_context("authentication setup")
 """
@@ -461,10 +461,9 @@ def get_doc_content(filepath: str) -> str:
 
 
 def get_docs_context(query: str, max_results: int = 3) -> str:
-    """Get documentation context for injection into agent prompts.
+    """Get documentation context for agent prompts.
 
-    This is designed for OpenHands-style context injection, providing
-    relevant documentation snippets based on the query.
+    Returns relevant documentation snippets based on the query.
 
     Args:
         query: The query to find relevant documentation for

--- a/agents/shared/gmail_tools.py
+++ b/agents/shared/gmail_tools.py
@@ -585,10 +585,9 @@ async def mark_email_as_read(message_id: str) -> str:
 
 
 def get_email_context(max_results: int = 5) -> str:
-    """Get email context for injection into agent prompts.
+    """Get email context for agent prompts.
 
-    This is designed for OpenHands-style context injection where we
-    provide current state to the agent upfront.
+    Provides current inbox state as a formatted summary.
 
     Args:
         max_results: Maximum emails to include in context

--- a/agents/shared/kubectl_tools.py
+++ b/agents/shared/kubectl_tools.py
@@ -1,9 +1,8 @@
 """
 Shared kubectl tool functions for all agent frameworks.
 
-Pre-fetches Kubernetes cluster state for context injection.
-This eliminates the need for agents to run kubectl commands,
-significantly reducing response time.
+Fetches Kubernetes cluster state for agent investigations.
+Agents may still run kubectl directly for the latest data.
 
 Requirements:
     - kubectl must be installed and configured

--- a/agents/shared/langfuse_tools.py
+++ b/agents/shared/langfuse_tools.py
@@ -444,10 +444,9 @@ async def detect_langfuse_anomalies(hours: int = 24) -> str:
 
 
 def get_langfuse_context(hours: int = 6) -> str:
-    """Get Langfuse context for injection into agent prompts.
+    """Get Langfuse context for agent prompts.
 
-    This is designed for OpenHands-style context injection where we
-    provide current state to the agent upfront.
+    Provides current observability state as a formatted summary.
 
     Args:
         hours: Time window in hours

--- a/context.md
+++ b/context.md
@@ -206,7 +206,7 @@ Failed to connect to http://openhands-svc:8080 after 3 attempts: [ReadTimeout]
    kubectl exec -n vibeteam deployment/openhands-svc -- python -c "
    from agents.openhands.support_engineer import OpenHandsSupportEngineer
    agent = OpenHandsSupportEngineer()
-   result = agent.run(task='Say hello', use_tools=True, skip_context_injection=True)
+   result = agent.run(task='Say hello', use_tools=True)
    print(result['response'])  # Output: Hello — Grace here from VibeTeam Support.
    "
    # Completes in ~28s
@@ -420,7 +420,7 @@ kubectl get pods -n vibeteam -l app=openhands-svc -o jsonpath='{.items[0].spec.c
 kubectl exec -n vibeteam deployment/openhands-svc -- python -c "
 from agents.openhands.support_engineer import OpenHandsSupportEngineer
 agent = OpenHandsSupportEngineer()
-result = agent.run(task='Say hello', use_tools=False, skip_context_injection=True)
+result = agent.run(task='Say hello', use_tools=False)
 print(result['response'])
 "
 ```

--- a/docs/design.md
+++ b/docs/design.md
@@ -60,9 +60,9 @@
 - The gateway resolves which framework to use per role using `agents.yaml`.
 - `agents.yaml` is the single source of truth for role → framework mapping, Slack handle,
   and agent directory references (AGENTS.md resolves from the directory).
-- Optional `skip_context_injection` can be set per agent to force end-to-end
-  investigations without gateway prefetch context.
 - Example:
+
+The gateway does not prefetch or inject monitoring context; it only routes messages.
 
 ```yaml
 agents:
@@ -79,7 +79,6 @@ agents:
     framework: openhands
     slack_handle: SoftwareEngineer
     agent_dir: agents/SoftwareEngineer
-    skip_context_injection: true
 ```
 
 ## OpenClaw Flow

--- a/docs/requirements.md
+++ b/docs/requirements.md
@@ -35,12 +35,9 @@ agents:
     framework: openhands
     slack_handle: SoftwareEngineer
     agent_dir: agents/SoftwareEngineer
-    skip_context_injection: true
 ```
 
-Optional agent flags:
-- `skip_context_injection`: when true, the gateway skips pre-fetched context
-  injection (Sentry/kubectl/Gmail) so the agent must use tools directly.
+The gateway only routes messages; it does not prefetch or inject monitoring context.
 
 ## Browser Automation
 

--- a/research/agents-benchmarking/notebook.md
+++ b/research/agents-benchmarking/notebook.md
@@ -16,7 +16,7 @@ Investigate why OpenHands scores lower (3/5) than CrewAI (4/5) in the error-anal
 
 **Winner: CrewAI**
 
-### After Fix (skip_context_injection)
+### After Fix (no auto context)
 | Framework | Status | Latency | Score | 
 |-----------|--------|---------|-------|
 | CrewAI | PASS | 46s | 4/5 |
@@ -122,9 +122,6 @@ OpenHands is 77% slower than CrewAI (62s vs 35s), though this doesn't affect sco
 
 ## Experiments to Run
 
-### Experiment 1: Disable Sentry Context Injection for Benchmarks
-Add a `skip_context_injection` parameter to OpenHands `run()` to prevent automatic context injection for benchmark tasks. This will make OpenHands behave like CrewAI (only use provided task content).
-
 ### Experiment 2: Increase max_output_tokens
 Try increasing from 4096 to 8192 to prevent truncation.
 
@@ -133,40 +130,9 @@ See if higher reasoning improves score even if slower.
 
 ---
 
-## Proposed Fix
-
-Modify `agents/openhands/support_engineer.py` to add a `skip_context_injection` parameter:
-
-```python
-def run(
-    self,
-    task: str,
-    context_type: str = "ephemeral",
-    context_id: str | None = None,
-    workspace: str | None = None,
-    use_tools: bool = True,
-    skip_context_injection: bool = False,  # NEW
-    **kwargs: Any,
-) -> dict[str, Any]:
-    ...
-    # Only inject context if not skipped
-    if not skip_context_injection:
-        # existing context injection logic
-```
-
-Then update `scripts/benchmark_agents.py`:
-
-```python
-if framework == "openhands":
-    run_kwargs["use_tools"] = False
-    run_kwargs["skip_context_injection"] = True  # NEW
-```
-
----
-
 ## Next Steps
 
-1. Consider adding `skip_context_injection` to AutoGen as well (if it has similar issues)
+1. Consider adding a no-auto-context mode to AutoGen as well (if it has similar issues)
 2. Investigate why AutoGen dropped from 3/5 to 2/5 (may be run-to-run variance)
 3. Run multiple benchmark iterations to account for variance
 
@@ -178,4 +144,3 @@ if framework == "openhands":
 - `reports/evaluation-report-20260129-205724-f1142ab.md` - Previous benchmark report (before fix)
 - `agents/openhands/support_engineer.py` - OpenHands agent implementation (modified)
 - `scripts/benchmark_agents.py` - Benchmark runner (modified)
-

--- a/tests/test_openhands_service_integration.py
+++ b/tests/test_openhands_service_integration.py
@@ -134,8 +134,7 @@ ALL_ROLES = [
 async def test_openhands_agent_responds(openhands_service_url: str, role: str) -> None:
     """Verify a single agent role responds via the HTTP service."""
     # Payload mirrors what the Slack gateway sends (see vibeteam/gateway/server.py
-    # call_agent_service).  use_tools and skip_context_injection match production
-    # so the test exercises the exact same code-path.
+    # call_agent_service) so the test exercises the same code-path.
     async with httpx.AsyncClient(timeout=120.0) as client:
         payload = {
             "task": f"Reply with 'READY {role}' in one short sentence.",
@@ -143,7 +142,6 @@ async def test_openhands_agent_responds(openhands_service_url: str, role: str) -
             "context_type": "slack",
             "context_id": f"C0TEST:{role}",
             "use_tools": True,
-            "skip_context_injection": False,
         }
         response = await client.post(f"{openhands_service_url}/run", json=payload)
         if response.status_code != 200:

--- a/tests/test_system_prompt.py
+++ b/tests/test_system_prompt.py
@@ -1189,48 +1189,49 @@ class TestSoftwareEngineerFileEditorTool:
             "_prefetch_repo_code must filter out common English words"
         )
 
-    def test_run_calls_prefetch_for_github_issues(self):
-        """run() must call _prefetch_repo_code when a GitHub issue is detected."""
+    def test_run_does_not_call_prefetch_for_github_issues(self):
+        """run() should not call _prefetch_repo_code (no automatic context injection)."""
         content = self._read_swe_source()
         method_start = content.find("def run(")
         assert method_start != -1
         next_def = content.find("\n    def ", method_start + 10)
         method_body = content[method_start:next_def] if next_def != -1 else content[method_start:]
 
-        assert "_prefetch_repo_code" in method_body, (
-            "run() must call _prefetch_repo_code when a GitHub issue is detected"
+        assert "_prefetch_repo_code" not in method_body, (
+            "run() should not call _prefetch_repo_code when context injection is disabled"
         )
 
-    def test_phase1_mentions_prefetched_data(self):
-        """Phase 1 workflow must reference PRE-FETCHED DATA."""
+    def test_phase1_mentions_orient_repo(self):
+        """Phase 1 workflow should orient the agent in the repo."""
         content = self._read_swe_source()
         ctx_start = content.find('SOFTWARE_ENGINEER_CONTEXT = """')
         ctx_end = content.find('"""', ctx_start + 30)
         ctx = content[ctx_start:ctx_end]
 
-        assert "PRE-FETCHED" in ctx, "Phase 1 workflow must mention PRE-FETCHED data"
-
-    def test_prompt_says_do_not_clone_again(self):
-        """Prompt must say DO NOT clone the repo again."""
-        content = self._read_swe_source()
-        ctx_start = content.find('SOFTWARE_ENGINEER_CONTEXT = """')
-        ctx_end = content.find('"""', ctx_start + 30)
-        ctx = content[ctx_start:ctx_end]
-
-        assert "DO NOT clone the repo again" in ctx, (
-            "Prompt must tell agent not to clone again since pre-fetch already did it"
+        assert "PHASE 1: ORIENT IN REPO" in ctx, (
+            "Phase 1 workflow must instruct how to orient in the repo"
         )
 
-    def test_prompt_says_do_not_read_entire_files(self):
-        """Prompt must say DO NOT read entire files."""
+    def test_prompt_says_clone_if_missing(self):
+        """Prompt should allow cloning if the repo is missing."""
         content = self._read_swe_source()
         ctx_start = content.find('SOFTWARE_ENGINEER_CONTEXT = """')
         ctx_end = content.find('"""', ctx_start + 30)
         ctx = content[ctx_start:ctx_end]
 
-        assert "DO NOT read entire files" in ctx, (
-            "Prompt must tell agent not to read entire files since "
-            "relevant sections are already provided"
+        assert "If the repo is missing, clone it." in ctx, (
+            "Prompt must tell the agent to clone if the repo is missing"
+        )
+
+    def test_prompt_says_avoid_full_file_reads(self):
+        """Prompt should warn against full-file reads."""
+        content = self._read_swe_source()
+        ctx_start = content.find('SOFTWARE_ENGINEER_CONTEXT = """')
+        ctx_end = content.find('"""', ctx_start + 30)
+        ctx = content[ctx_start:ctx_end]
+
+        assert "Avoid full-file reads" in ctx, (
+            "Prompt must tell agent to avoid full-file reads"
         )
 
     def test_prefetch_limits_output_size(self):

--- a/vibeteam/agents_config.py
+++ b/vibeteam/agents_config.py
@@ -27,7 +27,6 @@ class AgentEntry:
     slack_handle: str | None = None
     agent_dir: str | None = None
     prompt_path: str | None = None
-    skip_context_injection: bool | None = None
 
 
 AGENTS_CONFIG_PATH = os.environ.get("AGENTS_CONFIG_PATH", "agents.yaml")
@@ -62,12 +61,6 @@ def get_agent_entry(role: str | None) -> AgentEntry | None:
         raw = {}
     slack_handle = raw.get("slack_handle")
     agent_dir = raw.get("agent_dir")
-    skip_context_injection_raw = raw.get("skip_context_injection")
-    skip_context_injection = (
-        skip_context_injection_raw
-        if isinstance(skip_context_injection_raw, bool)
-        else None
-    )
     display = slack_handle or role.replace("_", " ").title()
     return AgentEntry(
         role=role,  # type: ignore[arg-type]
@@ -77,7 +70,6 @@ def get_agent_entry(role: str | None) -> AgentEntry | None:
         slack_handle=slack_handle,
         agent_dir=agent_dir,
         prompt_path=raw.get("prompt_path"),
-        skip_context_injection=skip_context_injection,
     )
 
 
@@ -132,13 +124,6 @@ def get_agent_dir(role: str | None) -> str | None:
     return None
 
 
-def get_skip_context_injection(role: str | None) -> bool | None:
-    entry = get_agent_entry(role)
-    if not entry:
-        return None
-    return entry.skip_context_injection
-
-
 def list_agents() -> list[AgentEntry]:
     agents = _get_agents_map()
     entries: list[AgentEntry] = []
@@ -157,6 +142,5 @@ __all__ = [
     "get_slack_handle",
     "get_agent_dir",
     "get_prompt_path",
-    "get_skip_context_injection",
     "list_agents",
 ]

--- a/vibeteam/gateway/routes/slack.py
+++ b/vibeteam/gateway/routes/slack.py
@@ -25,7 +25,7 @@ from fastapi import APIRouter, Header, HTTPException, Request
 from vibeteam.gateway.server import call_agent_service, call_agent_service_async, config
 from agents.shared.role_resolver import ROLE_MENTION_MAP, get_display_name
 from vibeteam.router import Router
-from vibeteam.agents_config import get_skip_context_injection, get_slack_handle
+from vibeteam.agents_config import get_slack_handle
 from vibeteam.router.models import AgentRole, route_by_keywords
 
 logger = logging.getLogger(__name__)
@@ -1047,8 +1047,8 @@ A user has requested help via Slack.
 
 ### CRITICAL INSTRUCTIONS — READ CAREFULLY
 
-**STEP 1 — Review Pre-Injected Data:**
-Sentry/monitoring data has been injected above. Use this as INITIAL context.
+**STEP 1 — Gather Evidence with Tools:**
+There is no pre-injected monitoring data. Use Sentry/kubectl/logs directly.
 
 **STEP 2 — RUN kubectl Commands (MANDATORY):**
 You MUST run kubectl commands to complete your investigation. Example:
@@ -1132,13 +1132,9 @@ async def _submit_agent_async(
         thread_ts=thread_ts,
     )
 
-    # Pick template to decide context injection + iteration limits.
+    # Pick template to decide iteration limits.
     is_thread_reply = thread_ts is not None
     template = classify_task_template(role, user_message, is_thread_reply=is_thread_reply)
-    skip_context = template == "health_check"
-    skip_context_override = get_skip_context_injection(role)
-    if skip_context_override is not None:
-        skip_context = skip_context_override
     max_iterations_map = {
         "health_check": 15,
         "conversational": 30,
@@ -1169,7 +1165,6 @@ async def _submit_agent_async(
         context_id=f"{channel}:{thread_ts or 'new'}",
         callback_url=callback_url,
         progress_url=progress_url,
-        skip_context_injection=skip_context,
         max_iterations=max_iterations,
         execution_timeout=(
             config.SLACK_AGENT_IDLE_TIMEOUT_SECONDS
@@ -1312,13 +1307,9 @@ async def _run_agent_and_respond(
         thread_ts=thread_ts,
     )
 
-    # Pick template to decide context injection + iteration limits (sync path).
+    # Pick template to decide iteration limits (sync path).
     is_thread_reply = thread_ts is not None
     template = classify_task_template(role, user_message, is_thread_reply=is_thread_reply)
-    skip_context = template == "health_check"
-    skip_context_override = get_skip_context_injection(role)
-    if skip_context_override is not None:
-        skip_context = skip_context_override
     max_iterations_map = {
         "health_check": 15,
         "conversational": 30,
@@ -1341,7 +1332,6 @@ async def _run_agent_and_respond(
             framework=framework,
             context_type="slack",
             context_id=f"{channel}:{thread_ts or 'new'}",
-            skip_context_injection=skip_context,
             max_iterations=max_iterations,
             execution_timeout=(
                 config.SLACK_AGENT_IDLE_TIMEOUT_SECONDS

--- a/vibeteam/gateway/server.py
+++ b/vibeteam/gateway/server.py
@@ -171,7 +171,6 @@ async def call_agent_service(
     context_type: str = "api",
     context_id: str | None = None,
     stream: bool = False,
-    skip_context_injection: bool | None = None,
     max_iterations: int | None = None,
     execution_timeout: int | None = None,
 ) -> dict[str, Any]:
@@ -211,11 +210,6 @@ async def call_agent_service(
     # For openhands, add parameters
     if fw == "openhands":
         payload["use_tools"] = True
-        # Enable context injection unless explicitly disabled.
-        if skip_context_injection is None:
-            payload["skip_context_injection"] = False
-        else:
-            payload["skip_context_injection"] = skip_context_injection
         if max_iterations is not None:
             payload["max_iterations"] = max_iterations
         if execution_timeout is not None:
@@ -305,7 +299,6 @@ async def call_agent_service_async(
     callback_url: str = "",
     callback_metadata: dict[str, Any] | None = None,
     progress_url: str | None = None,
-    skip_context_injection: bool = False,
     max_iterations: int = 30,
     execution_timeout: int | None = None,
 ) -> dict[str, Any]:
@@ -325,9 +318,6 @@ async def call_agent_service_async(
         callback_url: URL where agent should POST results
         callback_metadata: Opaque data passed through to callback
         progress_url: URL where agent should POST progress updates (optional)
-        skip_context_injection: If True, skip pre-fetched kubectl/Sentry context
-            injection. Used for focused tasks like health checks where the task
-            prompt already contains all necessary instructions.
         max_iterations: Maximum agent iterations before forced stop (default: 30)
         execution_timeout: Optional execution/idle timeout passed to agent service
 
@@ -357,7 +347,6 @@ async def call_agent_service_async(
     # For openhands, add parameters
     if fw == "openhands":
         payload["use_tools"] = True
-        payload["skip_context_injection"] = skip_context_injection
         payload["max_iterations"] = max_iterations
         if execution_timeout is not None:
             payload["execution_timeout"] = execution_timeout


### PR DESCRIPTION
## Summary
- Remove context injection flags and prefetch behavior from gateway and agent services.
- Strip injected-data guidance from agent prompts and shared docs; keep gateway as simple router.
- Update tests to align with no-preload workflow.

## Testing
- `export $( < ~/.env.d/codex.env ) && export $( < .env ) && .venv/bin/python -m pytest -q`
  - Result: `671 passed, 82 skipped`
- `uv run python scripts/eval_slack_e2e.py --scenario support_400_errors --channel C0AATPSADB8 --timeout 600`
  - **FAILED** (idle-timeout response)
  - Report: `results/eval_reports/eval_support_400_errors_20260302_091558.md`
