### PR TITLE
Use GraphQL for discussion comments

### DIFF
--- a/tests/test_webhook_integration.py
+++ b/tests/test_webhook_integration.py
@@ -1841,7 +1841,7 @@ class TestGitHubHelperFunctions:
                 "403 Forbidden",
                 request=httpx.Request(
                     "POST",
-                    "https://api.github.com/repos/owner/repo/discussions/1/comments",
+                    "https://api.github.com/graphql",
                 ),
                 response=httpx.Response(403),
             )

--- a/vibeteam/connectors/github.py
+++ b/vibeteam/connectors/github.py
@@ -244,6 +244,19 @@ class GitHubConnector:
         response.raise_for_status()
         return response.json()
 
+    def _graphql(self, query: str, variables: dict | None = None) -> dict:
+        """Make a GraphQL request to GitHub."""
+        response = requests.post(
+            f"{GITHUB_API_BASE}/graphql",
+            headers=self._headers(),
+            json={"query": query, "variables": variables or {}},
+        )
+        response.raise_for_status()
+        payload = response.json()
+        if payload.get("errors"):
+            raise RuntimeError(f"GitHub GraphQL error: {payload['errors']}")
+        return payload.get("data", {})
+
     # =====================
     # Issue Operations
     # =====================
@@ -307,10 +320,34 @@ class GitHubConnector:
 
     def add_discussion_comment(self, discussion_number: int, body: str) -> dict:
         """Add a comment to a discussion."""
-        endpoint = (
-            f"/repos/{self.owner}/{self.repo}/discussions/{discussion_number}/comments"
+        query = """
+        query($owner: String!, $repo: String!, $number: Int!) {
+          repository(owner: $owner, name: $repo) {
+            discussion(number: $number) { id }
+          }
+        }
+        """
+        data = self._graphql(
+            query,
+            {"owner": self.owner, "repo": self.repo, "number": discussion_number},
         )
-        return self._post(endpoint, {"body": body})
+        discussion = (data.get("repository") or {}).get("discussion") or {}
+        discussion_id = discussion.get("id")
+        if not discussion_id:
+            raise RuntimeError("Discussion not found or missing ID")
+
+        mutation = """
+        mutation($discussionId: ID!, $body: String!) {
+          addDiscussionComment(input: {discussionId: $discussionId, body: $body}) {
+            comment { id body createdAt }
+          }
+        }
+        """
+        data = self._graphql(mutation, {"discussionId": discussion_id, "body": body})
+        comment = (data.get("addDiscussionComment") or {}).get("comment") or {}
+        if not comment:
+            raise RuntimeError("Failed to create discussion comment")
+        return comment
 
     def search_issues(
         self,

--- a/vibeteam/gateway/routes/github.py
+++ b/vibeteam/gateway/routes/github.py
@@ -297,17 +297,64 @@ async def post_github_discussion_comment(
         return
 
     try:
+        owner, name = repo.split("/", 1)
+    except ValueError:
+        logger.error(f"Invalid repo format for discussion comment: {repo}")
+        return
+
+    discussion_query = """
+    query($owner: String!, $repo: String!, $number: Int!) {
+      repository(owner: $owner, name: $repo) {
+        discussion(number: $number) { id }
+      }
+    }
+    """
+    comment_mutation = """
+    mutation($discussionId: ID!, $body: String!) {
+      addDiscussionComment(input: {discussionId: $discussionId, body: $body}) {
+        comment { id }
+      }
+    }
+    """
+
+    try:
         async with httpx.AsyncClient() as client:
             response = await client.post(
-                f"https://api.github.com/repos/{repo}/discussions/{discussion_number}/comments",
+                "https://api.github.com/graphql",
                 headers={
                     "Authorization": f"Bearer {token}",
                     "Accept": "application/vnd.github+json",
-                    "X-GitHub-Api-Version": "2022-11-28",
                 },
-                json={"body": body},
+                json={
+                    "query": discussion_query,
+                    "variables": {"owner": owner, "repo": name, "number": discussion_number},
+                },
             )
             response.raise_for_status()
+            payload = response.json()
+            if payload.get("errors"):
+                raise RuntimeError(payload["errors"])
+            discussion = (payload.get("data") or {}).get("repository", {}).get("discussion")
+            discussion_id = discussion.get("id") if isinstance(discussion, dict) else None
+            if not discussion_id:
+                logger.error(f"Missing discussion ID for {repo}#{discussion_number}")
+                return
+
+            response = await client.post(
+                "https://api.github.com/graphql",
+                headers={
+                    "Authorization": f"Bearer {token}",
+                    "Accept": "application/vnd.github+json",
+                },
+                json={
+                    "query": comment_mutation,
+                    "variables": {"discussionId": discussion_id, "body": body},
+                },
+            )
+            response.raise_for_status()
+            payload = response.json()
+            if payload.get("errors"):
+                raise RuntimeError(payload["errors"])
             logger.info(f"Posted discussion comment to {repo}#{discussion_number}")
 
     except Exception as e:


### PR DESCRIPTION
## Summary
- post discussion comments via GraphQL in gateway and connector
- fetch discussion id via GraphQL before comment mutation
- update webhook tests for GraphQL endpoint

## Testing
- `export $( < .env ) && uv run pytest tests/ -q`
- Slack/GitHub evals: pending after merge
