### PR TITLE
Document GitHub App discussion permissions

### DIFF
--- a/docs/design.md
+++ b/docs/design.md
@@ -127,6 +127,9 @@ Gateway supports GitHub webhooks for:
 - `pull_request_review_comment`
 - `discussion` and `discussion_comment`
 
+Discussion comments are posted via GraphQL and require GitHub App discussions
+permissions to avoid `Resource not accessible by integration` failures.
+
 ## LLM Configuration
 
 - Default model: Azure OpenAI `gpt-5.2`.

--- a/docs/requirements.md
+++ b/docs/requirements.md
@@ -181,6 +181,8 @@ handoffs over issues, discussions, and PR comments. This requires:
 - GitHub webhooks enabled for `issues`, `issue_comment`, `pull_request_review_comment`,
   `discussion`, and `discussion_comment` events.
 - Discussions enabled on `VibeTechnologies/vibeteam-eval-hello-world`.
+- Role GitHub Apps granted Discussions read/write permission (otherwise discussion
+  comments fail with `Resource not accessible by integration`).
 - `GITHUB_TOKEN` (or `GH_TOKEN`) with issue/discussion write permissions.
 
 ## Gmail Processor


### PR DESCRIPTION
## Summary
- document required discussions permissions for GitHub Apps in requirements/design

## Testing
- not run (docs-only)
