### PR TITLE
Docs: note Azure eval env file location

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -18,6 +18,12 @@ to run an evaluation test.
 
 Before running any test `export $( < .env )`
 
+Azure credentials for evals live in `~/.env.d/codex.env`. Export them before `.env`:
+```bash
+export $( < ~/.env.d/codex.env )
+export $( < .env )
+```
+
 for example
 ```shell
 export $( < .env ) && .venv/bin/python -m pytest tests/test_openhands_service_integration.py -v --run-integration -s


### PR DESCRIPTION
## Summary
- document `~/.env.d/codex.env` as the source of Azure eval credentials
- keep eval instructions aligned with current dev environment

## Testing
- Not run (docs-only change).