### PR TITLE
Remove OpenClaw agent fallback and document system diagram

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -194,6 +194,31 @@ Before running VibeTeam agents or after infrastructure changes, verify system re
 - `k8s/`: Kubernetes base + overlays, secrets templates
 - `tests/`: unit and integration tests
 
+## System Diagram
+
+```
+Slack/GitHub/Sentry
+        |
+        v
+vibeteam-gateway (FastAPI)
+        |
+        |-- routes by role/framework (agents/agents.yaml)
+        |
+        +--> OpenHands svc (agent_service/openhands)
+        |        |
+        |        +--> Azure OpenAI + MCP tools (GitHub, Sentry, kubectl, etc.)
+        |
+        +--> OpenClaw svc (agent_service/openclaw)
+                 |
+                 +--> OpenClaw Gateway (Node, WS)
+                         |
+                         +--> LiteLLM (in-namespace)
+                         |
+                         +--> Azure OpenAI
+                         |
+                         +--> OpenClaw browser/CDP tooling
+```
+
 ## Deployment
 
 ### Quick Deploy (Recommended)

--- a/README.md
+++ b/README.md
@@ -16,6 +16,31 @@ VibeTeam provides specialized agents that run as Kubernetes CronJobs:
 | **Software Engineer** | Every 4 hours | Analyze GitHub issues, suggest fixes |
 | **Release Engineer** | Daily 9 AM | Track merged PRs, release readiness |
 
+## System Diagram
+
+```
+Slack/GitHub/Sentry
+        |
+        v
+vibeteam-gateway (FastAPI)
+        |
+        |-- routes by role/framework (agents/agents.yaml)
+        |
+        +--> OpenHands svc (agent_service/openhands)
+        |        |
+        |        +--> Azure OpenAI + MCP tools (GitHub, Sentry, kubectl, etc.)
+        |
+        +--> OpenClaw svc (agent_service/openclaw)
+                 |
+                 +--> OpenClaw Gateway (Node, WS)
+                         |
+                         +--> LiteLLM (in-namespace)
+                         |
+                         +--> Azure OpenAI
+                         |
+                         +--> OpenClaw browser/CDP tooling
+```
+
 ## Installation
 
 ```bash

--- a/agent_service/openclaw/server.py
+++ b/agent_service/openclaw/server.py
@@ -492,8 +492,15 @@ async def run_task(request: RunRequest):
             request.openclaw_agent_id
             or resolve_openclaw_agent_id(request.role)
             or (entry.openclaw_agent_id if entry else None)
-            or "product-manager"
         )
+        if not agent_id:
+            raise HTTPException(
+                status_code=400,
+                detail=(
+                    "OpenClaw agent_id not configured. Set openclaw_agent_id in "
+                    "agents/agents.yaml for the role or pass openclaw_agent_id."
+                ),
+            )
         session_key = request.session_key or _build_session_key(
             agent_id, request.context_type, context_id
         )

--- a/tests/test_agent_github_app_tokens.py
+++ b/tests/test_agent_github_app_tokens.py
@@ -168,7 +168,7 @@ async def test_openclaw_role_token_context_mentions(monkeypatch: pytest.MonkeyPa
     monkeypatch.setattr(oc_server, "run_openclaw_task", fake_run_openclaw_task)
     monkeypatch.setattr(oc_server, "get_postgres_store", _dummy_store)
     monkeypatch.setattr(oc_server, "get_agent_entry", lambda _role: None)
-    monkeypatch.setattr(oc_server, "resolve_openclaw_agent_id", lambda _role: None)
+    monkeypatch.setattr(oc_server, "resolve_openclaw_agent_id", lambda _role: "product-manager")
 
     called: dict[str, str | None] = {}
 


### PR DESCRIPTION
## Summary
- remove implicit OpenClaw agent_id fallback and return 400 when not configured
- document the current system diagram in AGENTS.md and README.md
- adjust OpenClaw GitHub app token test to provide explicit agent id

## Testing
- python -m pytest -q
- python scripts/eval_slack_e2e.py --scenario support_400_errors --channel C0AATPSADB8 --timeout 600 (report: results/eval_reports/eval_support_400_errors_20260303_001921.md)
