### PR TITLE
Allow GitHub bot handle mentions for role routing

### DIFF
--- a/agent_service/shared/role_resolver.py
+++ b/agent_service/shared/role_resolver.py
@@ -112,6 +112,25 @@ ROLE_PATTERN = re.compile(
 )
 
 # ---------------------------------------------------------------------------
+# GitHub App bot handles (optional mention aliases)
+# ---------------------------------------------------------------------------
+
+_github_bot_pattern = re.compile(
+    r"@?(?P<login>vibeteam-[a-z0-9-]+-bot(?:-\d+)?)(?:\[bot\])?",
+    re.IGNORECASE,
+)
+
+_github_bot_role_hints: list[tuple[str, AgentRole]] = [
+    ("swe", "software_engineer"),
+    ("software", "software_engineer"),
+    ("support", "support_engineer"),
+    ("release", "release_engineer"),
+    ("product", "product_manager"),
+    ("pm", "product_manager"),
+    ("marketing", "marketing_manager"),
+]
+
+# ---------------------------------------------------------------------------
 # Public API
 # ---------------------------------------------------------------------------
 
@@ -121,17 +140,23 @@ def parse_role_mentions(text: str) -> list[AgentRole]:
     Extract all role mentions from text.
 
     Matches @RoleName or /RoleName patterns, including short forms,
-    persona names, and aliases.
+    persona names, aliases, and GitHub bot handles.
 
     Returns a deduplicated list in order of first appearance.
     """
-    matches = ROLE_PATTERN.findall(text)
     roles: list[AgentRole] = []
+    matches = ROLE_PATTERN.findall(text)
     for match in matches:
         key = match.lower()
         role = ROLE_MENTION_MAP.get(key)
         if role and role not in roles:
             roles.append(role)
+    for bot_match in _github_bot_pattern.finditer(text):
+        login = bot_match.group("login").lower()
+        for hint, role in _github_bot_role_hints:
+            if hint in login and role not in roles:
+                roles.append(role)
+                break
     return roles
 
 

--- a/docs/user.md
+++ b/docs/user.md
@@ -29,7 +29,11 @@ login, for example:
 - `@software-engineer[bot]`
 - `@vibeteam-support-bot-260301[bot]`
 
-If you omit `[bot]`, GitHub will not resolve the mention.
+If you omit `[bot]`, GitHub will not resolve the mention, but the VibeTeam router
+still accepts it (for example, `@vibeteam-support-bot-260301`).
+
+You can also trigger handoffs with `/RoleName` (e.g., `/SupportEngineer`), but
+GitHub bot mentions work without any `/` prefix.
 
 ## Can We Use Simpler Bot Names?
 

--- a/tests/test_role_resolver.py
+++ b/tests/test_role_resolver.py
@@ -100,6 +100,20 @@ class TestParseRoleMentions:
     def test_slash_prefix(self, text, expected):
         assert parse_role_mentions(text) == expected
 
+    @pytest.mark.parametrize(
+        "text,expected",
+        [
+            ("@vibeteam-support-bot-260301", ["support_engineer"]),
+            ("@vibeteam-support-bot-260301[bot]", ["support_engineer"]),
+            ("vibeteam-swe-bot-260301[bot]", ["software_engineer"]),
+            ("@vibeteam-release-bot", ["release_engineer"]),
+            ("@vibeteam-product-bot-260301", ["product_manager"]),
+            ("@vibeteam-marketing-bot-260301", ["marketing_manager"]),
+        ],
+    )
+    def test_github_bot_mentions(self, text, expected):
+        assert parse_role_mentions(text) == expected
+
     # --- Persona names (team.py) ---
 
     @pytest.mark.parametrize(


### PR DESCRIPTION
## Summary
- detect GitHub bot handle mentions (e.g., `@vibeteam-support-bot-260301`) as role handoffs
- document bot mentions in `docs/user.md`
- add unit coverage for bot handle parsing

## Testing
- `pytest tests/test_role_resolver.py -v -p no:rerunfailures`
- `scripts/eval_github_e2e.py --scenario github_issue_handoff --repo VibeTechnologies/vibeteam-eval-hello-world --timeout 600`
