### PR TITLE
Align GitHub bot mentions with Slack handles

### DIFF
--- a/agent_service/shared/role_resolver.py
+++ b/agent_service/shared/role_resolver.py
@@ -87,9 +87,14 @@ def _load_handle_map() -> dict[str, AgentRole]:
         handle = cfg.get("slack_handle")
         if not handle:
             continue
-        key = re.sub(r"\\W+", "", str(handle)).lower()
-        if key:
-            handle_map[key] = role  # type: ignore[assignment]
+        raw = str(handle)
+        normalized = re.sub(r"\\W+", "", raw).lower()
+        slug = re.sub(r"(?<!^)(?=[A-Z])", "-", raw).lower()
+        slug = re.sub(r"[_\s]+", "-", slug)
+        slug = re.sub(r"[^a-z0-9-]+", "-", slug).strip("-")
+        for key in {normalized, raw.lower(), slug}:
+            if key:
+                handle_map[key] = role  # type: ignore[assignment]
     return handle_map
 
 

--- a/docs/github.md
+++ b/docs/github.md
@@ -25,7 +25,7 @@ Supported role suffixes:
 
 1. Go to GitHub Settings → Developer settings → GitHub Apps → New GitHub App
 2. Basic info:
-   - Name: `VibeTeam SWE Bot` (or per role)
+   - Name: use the Slack handle from `agents/agents.yaml` (e.g., `SoftwareEngineer`)
    - Homepage URL: `https://github.com/VibeTechnologies/VibeTeam`
 3. Permissions (Repository):
    - Contents: Read & Write

--- a/docs/user.md
+++ b/docs/user.md
@@ -46,6 +46,9 @@ GitHub App name (slug), so pick a short name when you create the app:
 If you need a different login, create a new app with the desired name and reinstall it.
 Renaming an existing app is not a reliable way to change the login.
 
+**Recommendation:** Use the role names from `agents/agents.yaml` (the Slack handles) as
+the GitHub App names so mentions align across Slack and GitHub.
+
 ## Want It to Feel Like “Real People”?
 
 Two options:

--- a/tests/test_role_resolver.py
+++ b/tests/test_role_resolver.py
@@ -109,6 +109,7 @@ class TestParseRoleMentions:
             ("@vibeteam-release-bot", ["release_engineer"]),
             ("@vibeteam-product-bot-260301", ["product_manager"]),
             ("@vibeteam-marketing-bot-260301", ["marketing_manager"]),
+            ("@software-engineer[bot]", ["software_engineer"]),
         ],
     )
     def test_github_bot_mentions(self, text, expected):


### PR DESCRIPTION
## Summary
- align GitHub bot mention parsing with Slack handles from `agents/agents.yaml`
- document recommended GitHub App naming for simple bot handles
- add test coverage for `@software-engineer[bot]` mention

## Testing
- `pytest tests/test_role_resolver.py -v -p no:rerunfailures`
- ad-hoc E2E: GitHub issue handoff triggered by `@softwareengineer[bot] @supportengineer[bot]` on https://github.com/VibeTechnologies/vibeteam-eval-hello-world/issues/60
