### PR TITLE
Stabilize OpenClaw routing/CDP path and document AKS namespace policy

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -6,6 +6,7 @@ You are working on AI agentic team. Agent are implemented on OpenHands that runs
 - Use Kubernetes context `aks-1` only.
 - Use namespaces `vibeteam-dev` (dev) and `vibeteam-prod` (prod).
 - Do not deploy to any separate production cluster.
+- One Slack app cannot fan out events to both namespaces simultaneously; use separate Slack apps/endpoints per environment or route through a dedicated ingress proxy.
 
 ## Testing Expectations
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -3,10 +3,11 @@ You are working on AI agentic team. Agent are implemented on OpenHands that runs
 ## Kubernetes Targeting Policy
 
 - Authoritative deploy/test guide: `docs/k8s.md`
-- Use Kubernetes context `aks-1` only.
-- Use namespaces `vibeteam-dev` (dev) and `vibeteam-prod` (prod).
-- Do not deploy to any separate production cluster.
-- One Slack app cannot fan out events to both namespaces simultaneously; use separate Slack apps/endpoints per environment or route through a dedicated ingress proxy.
+- Use AKS kubeconfig `~/.kube/aks-1` (context `openclaw-aks`) only.
+- Use the production namespace `vibeteam` for live Slack-driven traffic.
+- `vibeteam-openclaw-1` is for isolated OpenClaw validation when needed.
+- Do not deploy to any separate cluster.
+- One Slack app cannot fan out events to multiple namespaces simultaneously; use separate Slack apps/endpoints per environment or route through a dedicated ingress proxy.
 
 ## Testing Expectations
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -5,7 +5,7 @@ You are working on AI agentic team. Agent are implemented on OpenHands that runs
 - Authoritative deploy/test guide: `docs/k8s.md`
 - Use AKS kubeconfig `~/.kube/aks-1` (context `openclaw-aks`) only.
 - Use the production namespace `vibeteam` for live Slack-driven traffic.
-- `vibeteam-openclaw-1` is for isolated OpenClaw validation when needed.
+- Use `vibeteam` as the only active namespace for deploys and Slack-triggered evals.
 - Do not deploy to any separate cluster.
 - One Slack app cannot fan out events to multiple namespaces simultaneously; use separate Slack apps/endpoints per environment or route through a dedicated ingress proxy.
 
@@ -88,7 +88,7 @@ uv run python scripts/eval_slack_e2e.py --scenario software_engineer_pr_attribut
 uv run python scripts/eval_slack_e2e.py --list-scenarios
 ```
 
-**Note:** Slack evals run against the dev environment. Unless explicitly requested, it is acceptable to skip evals/E2E tests and report: “No. I did not run evals or E2E tests.” This should not be treated as an issue.
+**Note:** Slack evals run against the `vibeteam` deployment on `aks-1`. Unless explicitly requested, it is acceptable to skip evals/E2E tests and report: “No. I did not run evals or E2E tests.” This should not be treated as an issue.
 
 ## GitHub App Attribution
 

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,5 +1,12 @@
 You are working on AI agentic team. Agent are implemented on OpenHands that runs as a service that host all the agents sessions. Gateways is used for integration with Slack. DeepEval is used to evaluate agent sessions. Use
 
+## Kubernetes Targeting Policy
+
+- Authoritative deploy/test guide: `docs/k8s.md`
+- Use Kubernetes context `aks-1` only.
+- Use namespaces `vibeteam-dev` (dev) and `vibeteam-prod` (prod).
+- Do not deploy to any separate production cluster.
+
 ## Testing Expectations
 
 Run unit tests and at least one Slack eval when changes affect agent behavior, routing, tools, or evaluation criteria.
@@ -183,6 +190,7 @@ Before running VibeTeam agents or after infrastructure changes, verify system re
 
 - **[docs/requirements.md](docs/requirements.md)** - System requirements, agent roles, and responsibilities
 - **[docs/design.md](docs/design.md)** - Architecture, routing logic, and design decisions
+- **[docs/k8s.md](docs/k8s.md)** - Authoritative cluster, namespace, deploy, and test workflow
 
 ## Codebase Map
 

--- a/agent_service/autogen/marketing_manager.py
+++ b/agent_service/autogen/marketing_manager.py
@@ -14,6 +14,7 @@ from typing import Any
 
 from agent_service.config import MARKETING_MANAGER_CONFIG, AgentConfig
 from agent_service.sessions import get_or_create_session, get_session_store
+from agent_service.shared.agents_md_loader import load_shared_instructions
 
 # Import shared browser tools
 from agent_service.shared.browser_tools import (
@@ -23,7 +24,6 @@ from agent_service.shared.browser_tools import (
     take_screenshot,
     web_search,
 )
-from agent_service.shared.agents_md_loader import load_shared_instructions
 from agent_service.shared.slack_tools import (
     send_message,
 )

--- a/agent_service/autogen/release_engineer.py
+++ b/agent_service/autogen/release_engineer.py
@@ -16,8 +16,8 @@ from typing import Any
 
 from agent_service.config import RELEASE_ENGINEER_CONFIG, AgentConfig
 from agent_service.sessions import get_or_create_session, get_session_store
-from agent_service.shared.docs_tools import search_infra_docs
 from agent_service.shared.agents_md_loader import load_shared_instructions
+from agent_service.shared.docs_tools import search_infra_docs
 from agent_service.shared.slack_tools import (
     read_slack_channel,
     read_slack_thread,

--- a/agent_service/autogen/server.py
+++ b/agent_service/autogen/server.py
@@ -7,9 +7,9 @@ FastAPI server exposing AutoGen team functionality via REST API.
 import contextlib
 import logging
 import os
+import threading
 import time
 import uuid
-import threading
 from contextlib import asynccontextmanager
 from datetime import datetime, timezone
 from typing import Any

--- a/agent_service/crewai/server.py
+++ b/agent_service/crewai/server.py
@@ -7,9 +7,9 @@ FastAPI server exposing CrewAI team functionality via REST API.
 import contextlib
 import logging
 import os
+import threading
 import time
 import uuid
-import threading
 from contextlib import asynccontextmanager
 from datetime import datetime, timezone
 from typing import Any

--- a/agent_service/openclaw/server.py
+++ b/agent_service/openclaw/server.py
@@ -12,9 +12,9 @@ import inspect
 import json
 import logging
 import os
+import threading
 import time
 import uuid
-import threading
 from contextlib import asynccontextmanager
 from datetime import datetime, timezone
 from typing import Any
@@ -32,6 +32,7 @@ except Exception:  # Optional for minimal images
     validate_required_integrations = None  # type: ignore[assignment]
 
 if validate_required_integrations is None:
+
     def validate_required_integrations(service_name: str) -> None:  # type: ignore[no-redef]
         missing: list[str] = []
         if not os.environ.get("SENTRY_AUTH_TOKEN"):
@@ -50,6 +51,7 @@ if validate_required_integrations is None:
                 f"[{service_name}] Required integrations not configured:\n- {details}\n"
                 "Service will not start until these are provided."
             )
+
 
 try:
     from agent_service.shared.db import close_db, get_postgres_store, init_db

--- a/agent_service/openhands/marketing_manager.py
+++ b/agent_service/openhands/marketing_manager.py
@@ -229,17 +229,17 @@ class OpenHandsMarketingManager:
             "Access note: Reddit is blocked via CDP in this environment (block page).\n\n"
             "Subreddits, page titles, rules, and threads (best-effort while blocked):\n"
             "1) r/productivity\n"
-            "- Page title: \"You've been blocked\"\n"
+            '- Page title: "You\'ve been blocked"\n'
             "- Rules note: Avoid direct self-promo; contribute value first; disclose affiliation if mentioned.\n"
-            "- Thread: \"How do you turn messy web research into actionable notes?\"\n"
+            '- Thread: "How do you turn messy web research into actionable notes?"\n'
             "2) r/webdev\n"
-            "- Page title: \"You've been blocked\"\n"
+            '- Page title: "You\'ve been blocked"\n'
             "- Rules note: No spam or self-promo; keep comments technical and on-topic.\n"
-            "- Thread: \"Tips for automating repetitive web UI workflows?\"\n"
+            '- Thread: "Tips for automating repetitive web UI workflows?"\n'
             "3) r/automation\n"
-            "- Page title: \"You've been blocked\"\n"
+            '- Page title: "You\'ve been blocked"\n'
             "- Rules note: Tools are okay if framed as a workflow; avoid salesy language.\n"
-            "- Thread: \"What’s your lightest-weight setup for browser task automation?\"\n\n"
+            '- Thread: "What’s your lightest-weight setup for browser task automation?"\n\n'
             "Drafts (value-first; only ONE mentions vibebrowser.app):\n"
             "Comment draft #1 (r/productivity thread):\n"
             "“A pattern that helped me is separating capture from reading. When you find a page, "

--- a/agent_service/openhands/server.py
+++ b/agent_service/openhands/server.py
@@ -10,9 +10,9 @@ import asyncio
 import contextlib
 import logging
 import os
+import threading
 import time
 import uuid
-import threading
 from contextlib import asynccontextmanager
 from datetime import datetime, timezone
 from typing import Any
@@ -22,8 +22,8 @@ from fastapi.responses import StreamingResponse
 from pydantic import BaseModel, Field
 
 from agent_service.config import AgentConfig
-from agent_service.shared.integration_checks import validate_required_integrations
 from agent_service.shared.db import close_db, get_postgres_store, init_db
+from agent_service.shared.integration_checks import validate_required_integrations
 
 from .team import OpenHandsTeam, create_team
 from .utils import (
@@ -79,9 +79,7 @@ def _disable_prompt_cache_retention() -> None:
     if flag is not None:
         enabled = flag.lower() in {"1", "true", "yes"}
     else:
-        enabled = bool(
-            os.environ.get("AZURE_OPENAI_ENDPOINT") or os.environ.get("AZURE_API_BASE")
-        )
+        enabled = bool(os.environ.get("AZURE_OPENAI_ENDPOINT") or os.environ.get("AZURE_API_BASE"))
     if not enabled:
         return
 
@@ -135,6 +133,7 @@ def _resolve_token_role(team: OpenHandsTeam, request: RunRequest) -> str | None:
         return team.route_by_keywords(request.task)
     except Exception:
         return None
+
 
 # Concurrency control: limit the number of simultaneous agent executions
 # to prevent resource exhaustion when multiple jobs arrive concurrently.

--- a/agent_service/openhands/software_engineer.py
+++ b/agent_service/openhands/software_engineer.py
@@ -562,12 +562,9 @@ class OpenHandsSoftwareEngineer:
         try:
             import re
 
-            if (
-                ("github" in task_lower)
-                and (
-                    re.search(r"\bissue\b\s*#?\s*\d+\b", task_lower)
-                    or re.search(r"(?<!#)#\s*\d+\b", task_lower)
-                )
+            if ("github" in task_lower) and (
+                re.search(r"\bissue\b\s*#?\s*\d+\b", task_lower)
+                or re.search(r"(?<!#)#\s*\d+\b", task_lower)
             ):
                 return True
         except Exception:
@@ -705,7 +702,7 @@ class OpenHandsSoftwareEngineer:
                 "      const errorMessage = 'AI_NoOutputGeneratedError: No output generated. Check the stream for errors.';\n"
                 "      console.error(`🤖 ${errorMessage}`);\n"
                 "      response = new AIMessage({\n"
-                "        content: \"I didn't get a response from the model. Please retry your request.\",\n"
+                '        content: "I didn\'t get a response from the model. Please retry your request.",\n'
                 "        additional_kwargs: { app_type: 'error', error: errorMessage }\n"
                 "      });\n"
                 "    }\n\n"
@@ -721,7 +718,9 @@ class OpenHandsSoftwareEngineer:
                 check=True,
                 timeout=30,
             )
-            subprocess.run(["git", "push", "-u", "origin", branch], cwd=repo_dir, check=True, timeout=120)
+            subprocess.run(
+                ["git", "push", "-u", "origin", branch], cwd=repo_dir, check=True, timeout=120
+            )
 
             sentry_urls = self._extract_sentry_urls(task)
             sentry_ref = sentry_urls[0] if sentry_urls else ""
@@ -762,9 +761,7 @@ class OpenHandsSoftwareEngineer:
         except Exception:
             return None
 
-    def _attempt_auto_pr_for_quota(
-        self, task: str, repo: str, workspace_path: str
-    ) -> str | None:
+    def _attempt_auto_pr_for_quota(self, task: str, repo: str, workspace_path: str) -> str | None:
         """Auto PR to treat quota-exceeded errors as retryable in VibeWebAgent."""
         task_lower = task.lower()
         title_lower = self._get_sentry_title_from_task(task).lower()
@@ -782,9 +779,9 @@ class OpenHandsSoftwareEngineer:
         target_rel = os.path.join("lib", "utils", "LLMWithRetry.js")
         target_path = os.path.join(repo_dir, target_rel)
 
+        import re
         import subprocess
         from pathlib import Path
-        import re
 
         try:
             subprocess.run(["gh", "auth", "setup-git"], capture_output=True, text=True, timeout=10)
@@ -843,7 +840,9 @@ class OpenHandsSoftwareEngineer:
                 check=True,
                 timeout=30,
             )
-            subprocess.run(["git", "push", "-u", "origin", branch], cwd=repo_dir, check=True, timeout=120)
+            subprocess.run(
+                ["git", "push", "-u", "origin", branch], cwd=repo_dir, check=True, timeout=120
+            )
 
             sentry_urls = self._extract_sentry_urls(task)
             sentry_ref = sentry_urls[0] if sentry_urls else ""
@@ -903,9 +902,9 @@ class OpenHandsSoftwareEngineer:
         target_rel = os.path.join("services", "subscription", "stripe-service", "server.js")
         target_path = os.path.join(repo_dir, target_rel)
 
+        import re
         import subprocess
         from pathlib import Path
-        import re
 
         try:
             subprocess.run(["gh", "auth", "setup-git"], capture_output=True, text=True, timeout=10)
@@ -948,7 +947,9 @@ class OpenHandsSoftwareEngineer:
             if marker not in content:
                 return None
             content = content.replace(marker, helper + marker)
-            content = content.replace("const userResponse = await fetch(", "const userResponse = await fetchWithRetry(")
+            content = content.replace(
+                "const userResponse = await fetch(", "const userResponse = await fetchWithRetry("
+            )
 
             Path(target_path).write_text(content)
 
@@ -961,7 +962,9 @@ class OpenHandsSoftwareEngineer:
                 check=True,
                 timeout=30,
             )
-            subprocess.run(["git", "push", "-u", "origin", branch], cwd=repo_dir, check=True, timeout=120)
+            subprocess.run(
+                ["git", "push", "-u", "origin", branch], cwd=repo_dir, check=True, timeout=120
+            )
 
             sentry_urls = self._extract_sentry_urls(task)
             sentry_ref = sentry_urls[0] if sentry_urls else ""
@@ -1111,9 +1114,7 @@ class OpenHandsSoftwareEngineer:
                     print(f"[SoftwareEngineer] Progress heartbeat unavailable: {exc}")
                 else:
                     agent_callbacks.append(
-                        create_heartbeat_callback(
-                            on_progress=kwargs.get("progress_heartbeat")
-                        )
+                        create_heartbeat_callback(on_progress=kwargs.get("progress_heartbeat"))
                     )
 
             # max_iterations caps the number of agent iterations (tool calls)

--- a/agent_service/openhands/support_engineer.py
+++ b/agent_service/openhands/support_engineer.py
@@ -915,10 +915,7 @@ class OpenHandsSupportEngineer:
                         client = SentryClient(timeout=10.0)
                         closed_id = issue_ids[0]
                         client.resolve_issue(closed_id)
-                        response = (
-                            f"Closed Sentry issue {closed_id}. "
-                            f"PR: {pr_url}."
-                        )
+                        response = f"Closed Sentry issue {closed_id}. PR: {pr_url}."
                     except Exception as exc:
                         response = f"Sentry: failed to close issue ({exc}). PR: {pr_url}."
 

--- a/agent_service/shared/browser_tools.py
+++ b/agent_service/shared/browser_tools.py
@@ -22,7 +22,8 @@ Usage:
 
 import asyncio
 import os
-from typing import Any
+from collections.abc import Awaitable
+from typing import Any, TypeVar
 from urllib.parse import quote_plus
 
 # Check for playwright availability
@@ -40,16 +41,28 @@ except ImportError:
 # Global browser instance for reuse
 _browser_instance: Browser | None = None
 _playwright_instance = None
+_browser_loop: asyncio.AbstractEventLoop | None = None
+_T = TypeVar("_T")
 
 
 async def _get_browser() -> Browser:
     """Get or create a browser instance."""
-    global _browser_instance, _playwright_instance
+    global _browser_instance, _playwright_instance, _browser_loop
 
     if not PLAYWRIGHT_AVAILABLE:
         raise ImportError(
             "Playwright not installed. Run: pip install playwright && playwright install chromium"
         )
+
+    current_loop = asyncio.get_running_loop()
+
+    # Sync wrappers use asyncio.run(), which creates a fresh event loop per call.
+    # If cached browser handles were created on a previous loop, drop those
+    # references to avoid cross-loop future errors.
+    if _browser_instance is not None and _browser_loop is not current_loop:
+        _browser_instance = None
+        _playwright_instance = None
+        _browser_loop = None
 
     if _browser_instance is None:
         _playwright_instance = await async_playwright().start()
@@ -57,21 +70,38 @@ async def _get_browser() -> Browser:
             headless=True,
             args=["--no-sandbox", "--disable-setuid-sandbox"],
         )
+        _browser_loop = current_loop
 
     return _browser_instance
 
 
 async def _cleanup_browser():
     """Clean up browser resources."""
-    global _browser_instance, _playwright_instance
+    global _browser_instance, _playwright_instance, _browser_loop
 
-    if _browser_instance:
-        await _browser_instance.close()
+    if not PLAYWRIGHT_AVAILABLE:
+        return
+
+    owning_loop = _browser_loop
+    current_loop = asyncio.get_running_loop()
+
+    try:
+        if _browser_instance and owning_loop is current_loop:
+            await _browser_instance.close()
+        if _playwright_instance and owning_loop is current_loop:
+            await _playwright_instance.stop()
+    finally:
         _browser_instance = None
-
-    if _playwright_instance:
-        await _playwright_instance.stop()
         _playwright_instance = None
+        _browser_loop = None
+
+
+async def _run_sync_with_browser_cleanup(coro: Awaitable[_T]) -> _T:
+    """Run a coroutine and ensure browser resources are cleaned up in that loop."""
+    try:
+        return await coro
+    finally:
+        await _cleanup_browser()
 
 
 async def fetch_webpage(url: str, timeout_ms: int = 30000) -> str:
@@ -201,7 +231,7 @@ async def _fetch_with_urllib(url: str) -> str:
 
 def fetch_webpage_sync(url: str, timeout_ms: int = 30000) -> str:
     """Synchronous version of fetch_webpage for CrewAI tools."""
-    return asyncio.run(fetch_webpage(url, timeout_ms))
+    return asyncio.run(_run_sync_with_browser_cleanup(fetch_webpage(url, timeout_ms)))
 
 
 async def web_search(query: str, num_results: int = 5) -> str:
@@ -279,7 +309,7 @@ For now, please use your knowledge to provide information about: {query}
 
 def web_search_sync(query: str, num_results: int = 5) -> str:
     """Synchronous version of web_search for CrewAI tools."""
-    return asyncio.run(web_search(query, num_results))
+    return asyncio.run(_run_sync_with_browser_cleanup(web_search(query, num_results)))
 
 
 async def take_screenshot(url: str, full_page: bool = False) -> dict[str, Any]:
@@ -343,7 +373,7 @@ async def take_screenshot(url: str, full_page: bool = False) -> dict[str, Any]:
 
 def take_screenshot_sync(url: str, full_page: bool = False) -> dict[str, Any]:
     """Synchronous version of take_screenshot."""
-    return asyncio.run(take_screenshot(url, full_page))
+    return asyncio.run(_run_sync_with_browser_cleanup(take_screenshot(url, full_page)))
 
 
 async def extract_links(url: str, filter_pattern: str = "") -> str:
@@ -414,7 +444,7 @@ async def extract_links(url: str, filter_pattern: str = "") -> str:
 
 def extract_links_sync(url: str, filter_pattern: str = "") -> str:
     """Synchronous version of extract_links."""
-    return asyncio.run(extract_links(url, filter_pattern))
+    return asyncio.run(_run_sync_with_browser_cleanup(extract_links(url, filter_pattern)))
 
 
 def get_browser_context(url: str) -> str:
@@ -466,4 +496,4 @@ Please provide your analysis.
 
 def analyze_competitor_page_sync(url: str) -> str:
     """Synchronous version of analyze_competitor_page."""
-    return asyncio.run(analyze_competitor_page(url))
+    return asyncio.run(_run_sync_with_browser_cleanup(analyze_competitor_page(url)))

--- a/agent_service/shared/kubectl_tools.py
+++ b/agent_service/shared/kubectl_tools.py
@@ -14,9 +14,9 @@ import os
 import subprocess
 import tempfile
 import time
-from pathlib import Path
 from concurrent.futures import ThreadPoolExecutor
 from dataclasses import dataclass
+from pathlib import Path
 
 logger = logging.getLogger(__name__)
 

--- a/agent_service/shared/langfuse_tools.py
+++ b/agent_service/shared/langfuse_tools.py
@@ -482,4 +482,3 @@ def get_langfuse_context(hours: int = 6) -> str:
 
     except Exception as e:
         return f"## LLM Observability Status\n\nError loading Langfuse data: {e}"
-

--- a/agent_service/shared/slack_tools.py
+++ b/agent_service/shared/slack_tools.py
@@ -649,7 +649,7 @@ def get_slack_handoff_instructions() -> str:
         "## TEAM COLLABORATION\n\n"
         "When you need help from another team member, @mention them naturally in your response:\n"
         f"{handles_text}\n\n"
-        f"Example: \"I've analyzed the request. @{example_handle} please implement the login validation fix.\"\n\n"
+        f'Example: "I\'ve analyzed the request. @{example_handle} please implement the login validation fix."\n\n'
         "The mentioned agent will automatically pick up the conversation.\n"
         "Always provide clear context when handing off so the receiving agent\n"
         "can understand and work on the task effectively.\n"

--- a/docs/OpenClawEval.md
+++ b/docs/OpenClawEval.md
@@ -4,18 +4,18 @@
 ```bash
 export $( < .env )
 unset AZURE_OPENAI_ENDPOINT AZURE_OPENAI_API_KEY
-export SLACK_BOT_TOKEN="$(KUBECONFIG=~/.kube/aks-1 kubectl get secret vibeteam-secrets -n vibeteam-openclaw-1 -o jsonpath='{.data.SLACK_BOT_TOKEN}' | base64 -d)"
-export SLACK_TRIGGER_SECRET="$(KUBECONFIG=~/.kube/aks-1 kubectl get secret vibeteam-secrets -n vibeteam-openclaw-1 -o jsonpath='{.data.SLACK_TRIGGER_SECRET}' | base64 -d)"
-export AZURE_API_KEY="$(KUBECONFIG=~/.kube/aks-1 kubectl get secret vibeteam-secrets -n vibeteam-openclaw-1 -o jsonpath='{.data.AZURE_API_KEY}' | base64 -d)"
-export AZURE_API_BASE="$(KUBECONFIG=~/.kube/aks-1 kubectl get secret vibeteam-secrets -n vibeteam-openclaw-1 -o jsonpath='{.data.AZURE_API_BASE}' | base64 -d)"
-export AZURE_API_VERSION="$(KUBECONFIG=~/.kube/aks-1 kubectl get secret vibeteam-secrets -n vibeteam-openclaw-1 -o jsonpath='{.data.AZURE_API_VERSION}' | base64 -d)"
+export SLACK_BOT_TOKEN="$(KUBECONFIG=~/.kube/aks-1 kubectl get secret vibeteam-secrets -n vibeteam -o jsonpath='{.data.SLACK_BOT_TOKEN}' | base64 -d)"
+export SLACK_TRIGGER_SECRET="$(KUBECONFIG=~/.kube/aks-1 kubectl get secret vibeteam-secrets -n vibeteam -o jsonpath='{.data.SLACK_TRIGGER_SECRET}' | base64 -d)"
+export AZURE_API_KEY="$(KUBECONFIG=~/.kube/aks-1 kubectl get secret vibeteam-secrets -n vibeteam -o jsonpath='{.data.AZURE_API_KEY}' | base64 -d)"
+export AZURE_API_BASE="$(KUBECONFIG=~/.kube/aks-1 kubectl get secret vibeteam-secrets -n vibeteam -o jsonpath='{.data.AZURE_API_BASE}' | base64 -d)"
+export AZURE_API_VERSION="$(KUBECONFIG=~/.kube/aks-1 kubectl get secret vibeteam-secrets -n vibeteam -o jsonpath='{.data.AZURE_API_VERSION}' | base64 -d)"
 export AZURE_EVAL_API_VERSION="$AZURE_API_VERSION"
 export SLACK_DEFAULT_CHANNEL="C0AATPSADB8"
 ```
 
 ## Port-forward gateway
 ```bash
-KUBECONFIG=~/.kube/aks-1 kubectl port-forward -n vibeteam-openclaw-1 svc/vibeteam-gateway 18080:8080
+KUBECONFIG=~/.kube/aks-1 kubectl port-forward -n vibeteam svc/vibeteam-gateway 18080:8080
 ```
 
 ## Run eval (OpenClaw)

--- a/docs/k8s.md
+++ b/docs/k8s.md
@@ -9,6 +9,22 @@ This document is the authoritative source for where VibeTeam is deployed and how
 - Prod namespace: `vibeteam-prod`
 - Do not deploy to any separate production cluster. Use `aks-1` only.
 
+## Slack Topology (Critical)
+
+Slack Event Subscriptions support a single Request URL per app. A single Slack app cannot deliver events to both `vibeteam-dev` and `vibeteam-prod` at the same time unless you add a routing proxy in front.
+
+Recommended setup:
+
+- Use one Slack app for prod, pointing to the prod gateway URL.
+- Use a separate Slack app for dev, pointing to the dev gateway URL.
+- Store each app's token/signing secret in the matching namespace secret.
+
+If you keep one Slack app:
+
+- Point it to prod only.
+- Use `/slack/trigger` for dev evals by targeting the dev gateway directly.
+- Do not expect both namespaces to receive live Slack events simultaneously.
+
 ## Preflight (Mandatory)
 
 Run these checks before any `kubectl apply`:

--- a/docs/k8s.md
+++ b/docs/k8s.md
@@ -7,24 +7,18 @@ This document is the authoritative source for where VibeTeam is deployed and how
 - Kubernetes cluster: AKS (`aks-1` kubeconfig)
 - Active context in `~/.kube/aks-1`: `openclaw-aks`
 - Production namespace: `vibeteam`
-- Secondary namespace for isolated OpenClaw eval/testing: `vibeteam-openclaw-1`
 - Do not deploy to any separate cluster. Use `aks-1` only.
+- Do not use additional namespaces for Slack-connected environments unless you also provision separate Slack app routing.
 
 ## Slack Topology (Critical)
 
-Slack Event Subscriptions support a single Request URL per app. A single Slack app cannot deliver events to both `vibeteam` and `vibeteam-openclaw-1` at the same time unless you add a routing proxy in front.
+Slack Event Subscriptions support a single Request URL per app. A single Slack app cannot deliver events to multiple namespaces at the same time unless you add a routing proxy in front.
 
 Recommended setup:
 
-- Keep the primary Slack app pointed at the production gateway in `vibeteam`.
-- If you need live Slack events in `vibeteam-openclaw-1`, use a separate Slack app or a request router.
-- Store each app's token/signing secret in the matching namespace secret.
-
-If you keep one Slack app:
-
-- Point it to production (`vibeteam`) only.
-- Use `/slack/trigger` for isolated evals by targeting the `vibeteam-openclaw-1` gateway directly.
-- Do not expect both namespaces to receive live Slack events simultaneously.
+- Keep the Slack app pointed at the gateway in `vibeteam`.
+- Use `/slack/trigger` for evals against the same gateway.
+- Store Slack and Azure tokens in `vibeteam/vibeteam-secrets`.
 
 ## Preflight (Mandatory)
 
@@ -35,7 +29,6 @@ kubectl config current-context
 kubectl config get-contexts
 KUBECONFIG=~/.kube/aks-1 kubectl config current-context
 KUBECONFIG=~/.kube/aks-1 kubectl get ns vibeteam
-KUBECONFIG=~/.kube/aks-1 kubectl get ns vibeteam-openclaw-1
 ```
 
 Use the AKS kubeconfig explicitly to avoid targeting the wrong cluster:
@@ -51,9 +44,9 @@ kubectl config use-context openclaw-aks
 
 ```bash
 KUBECONFIG=~/.kube/aks-1 kubectl apply -k k8s/overlays/dev
-KUBECONFIG=~/.kube/aks-1 kubectl rollout status deployment/vibeteam-gateway -n vibeteam-openclaw-1 --timeout=180s
-KUBECONFIG=~/.kube/aks-1 kubectl rollout status deployment/openhands-svc -n vibeteam-openclaw-1 --timeout=180s
-KUBECONFIG=~/.kube/aks-1 kubectl rollout status deployment/openclaw-svc -n vibeteam-openclaw-1 --timeout=180s
+KUBECONFIG=~/.kube/aks-1 kubectl rollout status deployment/vibeteam-gateway -n vibeteam --timeout=180s
+KUBECONFIG=~/.kube/aks-1 kubectl rollout status deployment/openhands-svc -n vibeteam --timeout=180s
+KUBECONFIG=~/.kube/aks-1 kubectl rollout status deployment/openclaw-svc -n vibeteam --timeout=180s
 ```
 
 ### Prod Deploy
@@ -124,6 +117,6 @@ KUBECONFIG=~/.kube/aks-1 kubectl logs deployment/openclaw-svc -n vibeteam --tail
 
 ## Notes
 
-- `k8s/overlays/dev/kustomization.yaml` targets `vibeteam-openclaw-1`.
+- `k8s/overlays/dev/kustomization.yaml` targets `vibeteam`.
 - `k8s/overlays/prod/kustomization.yaml` targets `vibeteam`.
-- If you see commands elsewhere using `-n vibeteam`, treat this document as authoritative and use the namespace that matches your target environment.
+- If you see commands elsewhere using other namespaces, treat this document as authoritative and use `vibeteam`.

--- a/docs/k8s.md
+++ b/docs/k8s.md
@@ -4,25 +4,26 @@ This document is the authoritative source for where VibeTeam is deployed and how
 
 ## Cluster And Namespace Policy
 
-- Kubernetes context/cluster: `aks-1`
-- Dev namespace: `vibeteam-dev`
-- Prod namespace: `vibeteam-prod`
-- Do not deploy to any separate production cluster. Use `aks-1` only.
+- Kubernetes cluster: AKS (`aks-1` kubeconfig)
+- Active context in `~/.kube/aks-1`: `openclaw-aks`
+- Production namespace: `vibeteam`
+- Secondary namespace for isolated OpenClaw eval/testing: `vibeteam-openclaw-1`
+- Do not deploy to any separate cluster. Use `aks-1` only.
 
 ## Slack Topology (Critical)
 
-Slack Event Subscriptions support a single Request URL per app. A single Slack app cannot deliver events to both `vibeteam-dev` and `vibeteam-prod` at the same time unless you add a routing proxy in front.
+Slack Event Subscriptions support a single Request URL per app. A single Slack app cannot deliver events to both `vibeteam` and `vibeteam-openclaw-1` at the same time unless you add a routing proxy in front.
 
 Recommended setup:
 
-- Use one Slack app for prod, pointing to the prod gateway URL.
-- Use a separate Slack app for dev, pointing to the dev gateway URL.
+- Keep the primary Slack app pointed at the production gateway in `vibeteam`.
+- If you need live Slack events in `vibeteam-openclaw-1`, use a separate Slack app or a request router.
 - Store each app's token/signing secret in the matching namespace secret.
 
 If you keep one Slack app:
 
-- Point it to prod only.
-- Use `/slack/trigger` for dev evals by targeting the dev gateway directly.
+- Point it to production (`vibeteam`) only.
+- Use `/slack/trigger` for isolated evals by targeting the `vibeteam-openclaw-1` gateway directly.
 - Do not expect both namespaces to receive live Slack events simultaneously.
 
 ## Preflight (Mandatory)
@@ -32,14 +33,16 @@ Run these checks before any `kubectl apply`:
 ```bash
 kubectl config current-context
 kubectl config get-contexts
-kubectl --context aks-1 get ns vibeteam-dev
-kubectl --context aks-1 get ns vibeteam-prod
+KUBECONFIG=~/.kube/aks-1 kubectl config current-context
+KUBECONFIG=~/.kube/aks-1 kubectl get ns vibeteam
+KUBECONFIG=~/.kube/aks-1 kubectl get ns vibeteam-openclaw-1
 ```
 
-If your active context is not `aks-1`, switch explicitly:
+Use the AKS kubeconfig explicitly to avoid targeting the wrong cluster:
 
 ```bash
-kubectl config use-context aks-1
+export KUBECONFIG=~/.kube/aks-1
+kubectl config use-context openclaw-aks
 ```
 
 ## Deploy
@@ -47,19 +50,19 @@ kubectl config use-context aks-1
 ### Dev Deploy
 
 ```bash
-kubectl --context aks-1 apply -k k8s/overlays/dev
-kubectl --context aks-1 rollout status deployment/vibeteam-gateway -n vibeteam-dev --timeout=180s
-kubectl --context aks-1 rollout status deployment/openhands-svc -n vibeteam-dev --timeout=180s
-kubectl --context aks-1 rollout status deployment/openclaw-svc -n vibeteam-dev --timeout=180s
+KUBECONFIG=~/.kube/aks-1 kubectl apply -k k8s/overlays/dev
+KUBECONFIG=~/.kube/aks-1 kubectl rollout status deployment/vibeteam-gateway -n vibeteam-openclaw-1 --timeout=180s
+KUBECONFIG=~/.kube/aks-1 kubectl rollout status deployment/openhands-svc -n vibeteam-openclaw-1 --timeout=180s
+KUBECONFIG=~/.kube/aks-1 kubectl rollout status deployment/openclaw-svc -n vibeteam-openclaw-1 --timeout=180s
 ```
 
 ### Prod Deploy
 
 ```bash
-kubectl --context aks-1 apply -k k8s/overlays/prod
-kubectl --context aks-1 rollout status deployment/vibeteam-gateway -n vibeteam-prod --timeout=180s
-kubectl --context aks-1 rollout status deployment/openhands-svc -n vibeteam-prod --timeout=180s
-kubectl --context aks-1 rollout status deployment/openclaw-svc -n vibeteam-prod --timeout=180s
+KUBECONFIG=~/.kube/aks-1 kubectl apply -k k8s/overlays/prod
+KUBECONFIG=~/.kube/aks-1 kubectl rollout status deployment/vibeteam-gateway -n vibeteam --timeout=180s
+KUBECONFIG=~/.kube/aks-1 kubectl rollout status deployment/openhands-svc -n vibeteam --timeout=180s
+KUBECONFIG=~/.kube/aks-1 kubectl rollout status deployment/openclaw-svc -n vibeteam --timeout=180s
 ```
 
 ## Testing Workflow
@@ -67,7 +70,7 @@ kubectl --context aks-1 rollout status deployment/openclaw-svc -n vibeteam-prod 
 Run tests in this order.
 
 1. Unit/integration tests locally.
-2. Slack eval against dev namespace deployments.
+2. Slack eval against the active Slack app target (normally `vibeteam`).
 3. Optional GitHub webhook evals for handoff flows.
 
 ### 1) Unit And Integration Tests
@@ -83,8 +86,8 @@ export $( < .env )
 Pause rollouts to avoid git-sync restarts mid-eval:
 
 ```bash
-kubectl --context aks-1 rollout pause deployment/vibeteam-gateway -n vibeteam-dev
-kubectl --context aks-1 rollout pause deployment/openhands-svc -n vibeteam-dev
+KUBECONFIG=~/.kube/aks-1 kubectl rollout pause deployment/vibeteam-gateway -n vibeteam
+KUBECONFIG=~/.kube/aks-1 kubectl rollout pause deployment/openhands-svc -n vibeteam
 ```
 
 Run eval:
@@ -98,8 +101,8 @@ export $( < .env )
 Resume rollouts after eval:
 
 ```bash
-kubectl --context aks-1 rollout resume deployment/vibeteam-gateway -n vibeteam-dev
-kubectl --context aks-1 rollout resume deployment/openhands-svc -n vibeteam-dev
+KUBECONFIG=~/.kube/aks-1 kubectl rollout resume deployment/vibeteam-gateway -n vibeteam
+KUBECONFIG=~/.kube/aks-1 kubectl rollout resume deployment/openhands-svc -n vibeteam
 ```
 
 ### 3) OpenClaw CDP Smoke Eval (Dev)
@@ -113,14 +116,14 @@ export $( < .env )
 ## Operational Checks
 
 ```bash
-kubectl --context aks-1 get pods -n vibeteam-dev
-kubectl --context aks-1 logs deployment/vibeteam-gateway -n vibeteam-dev --tail=200
-kubectl --context aks-1 logs deployment/openhands-svc -n vibeteam-dev --tail=200
-kubectl --context aks-1 logs deployment/openclaw-svc -n vibeteam-dev --tail=200
+KUBECONFIG=~/.kube/aks-1 kubectl get pods -n vibeteam
+KUBECONFIG=~/.kube/aks-1 kubectl logs deployment/vibeteam-gateway -n vibeteam --tail=200
+KUBECONFIG=~/.kube/aks-1 kubectl logs deployment/openhands-svc -n vibeteam --tail=200
+KUBECONFIG=~/.kube/aks-1 kubectl logs deployment/openclaw-svc -n vibeteam --tail=200
 ```
 
 ## Notes
 
-- `k8s/overlays/dev/kustomization.yaml` targets `vibeteam-dev`.
-- `k8s/overlays/prod/kustomization.yaml` targets `vibeteam-prod`.
+- `k8s/overlays/dev/kustomization.yaml` targets `vibeteam-openclaw-1`.
+- `k8s/overlays/prod/kustomization.yaml` targets `vibeteam`.
 - If you see commands elsewhere using `-n vibeteam`, treat this document as authoritative and use the namespace that matches your target environment.

--- a/docs/k8s.md
+++ b/docs/k8s.md
@@ -1,0 +1,110 @@
+# Kubernetes Deploy And Test Guide
+
+This document is the authoritative source for where VibeTeam is deployed and how to run deployment validation.
+
+## Cluster And Namespace Policy
+
+- Kubernetes context/cluster: `aks-1`
+- Dev namespace: `vibeteam-dev`
+- Prod namespace: `vibeteam-prod`
+- Do not deploy to any separate production cluster. Use `aks-1` only.
+
+## Preflight (Mandatory)
+
+Run these checks before any `kubectl apply`:
+
+```bash
+kubectl config current-context
+kubectl config get-contexts
+kubectl --context aks-1 get ns vibeteam-dev
+kubectl --context aks-1 get ns vibeteam-prod
+```
+
+If your active context is not `aks-1`, switch explicitly:
+
+```bash
+kubectl config use-context aks-1
+```
+
+## Deploy
+
+### Dev Deploy
+
+```bash
+kubectl --context aks-1 apply -k k8s/overlays/dev
+kubectl --context aks-1 rollout status deployment/vibeteam-gateway -n vibeteam-dev --timeout=180s
+kubectl --context aks-1 rollout status deployment/openhands-svc -n vibeteam-dev --timeout=180s
+kubectl --context aks-1 rollout status deployment/openclaw-svc -n vibeteam-dev --timeout=180s
+```
+
+### Prod Deploy
+
+```bash
+kubectl --context aks-1 apply -k k8s/overlays/prod
+kubectl --context aks-1 rollout status deployment/vibeteam-gateway -n vibeteam-prod --timeout=180s
+kubectl --context aks-1 rollout status deployment/openhands-svc -n vibeteam-prod --timeout=180s
+kubectl --context aks-1 rollout status deployment/openclaw-svc -n vibeteam-prod --timeout=180s
+```
+
+## Testing Workflow
+
+Run tests in this order.
+
+1. Unit/integration tests locally.
+2. Slack eval against dev namespace deployments.
+3. Optional GitHub webhook evals for handoff flows.
+
+### 1) Unit And Integration Tests
+
+```bash
+export $( < ~/.env.d/codex.env )
+export $( < .env )
+.venv/bin/python -m pytest tests/ -v -p no:rerunfailures --run-integration
+```
+
+### 2) Slack Evals (Dev)
+
+Pause rollouts to avoid git-sync restarts mid-eval:
+
+```bash
+kubectl --context aks-1 rollout pause deployment/vibeteam-gateway -n vibeteam-dev
+kubectl --context aks-1 rollout pause deployment/openhands-svc -n vibeteam-dev
+```
+
+Run eval:
+
+```bash
+export $( < ~/.env.d/codex.env )
+export $( < .env )
+.venv/bin/python scripts/eval_slack_e2e.py --scenario support_400_errors --channel C0AATPSADB8 --timeout 600
+```
+
+Resume rollouts after eval:
+
+```bash
+kubectl --context aks-1 rollout resume deployment/vibeteam-gateway -n vibeteam-dev
+kubectl --context aks-1 rollout resume deployment/openhands-svc -n vibeteam-dev
+```
+
+### 3) OpenClaw CDP Smoke Eval (Dev)
+
+```bash
+export $( < ~/.env.d/codex.env )
+export $( < .env )
+.venv/bin/python scripts/eval_slack_e2e.py --scenario openclaw_chrome_cdp_smoke --channel C0AATPSADB8 --timeout 600
+```
+
+## Operational Checks
+
+```bash
+kubectl --context aks-1 get pods -n vibeteam-dev
+kubectl --context aks-1 logs deployment/vibeteam-gateway -n vibeteam-dev --tail=200
+kubectl --context aks-1 logs deployment/openhands-svc -n vibeteam-dev --tail=200
+kubectl --context aks-1 logs deployment/openclaw-svc -n vibeteam-dev --tail=200
+```
+
+## Notes
+
+- `k8s/overlays/dev/kustomization.yaml` targets `vibeteam-dev`.
+- `k8s/overlays/prod/kustomization.yaml` targets `vibeteam-prod`.
+- If you see commands elsewhere using `-n vibeteam`, treat this document as authoritative and use the namespace that matches your target environment.

--- a/docs/slack.md
+++ b/docs/slack.md
@@ -13,6 +13,20 @@ This guide covers how to configure the Slack app for VibeTeam, including event s
 - A Slack workspace where you have admin permissions
 - The VibeTeam gateway deployed and reachable via HTTPS (e.g. `https://webhook.team.vibebrowser.app`)
 
+## Multi-Environment Constraint
+
+Slack Event Subscriptions use one Request URL per app. This means one Slack app cannot directly send events to both dev and prod gateways at the same time.
+
+Recommended:
+
+- Prod app -> prod gateway URL
+- Dev app -> dev gateway URL
+
+Alternative (single app):
+
+- Keep app Request URL on prod
+- Run dev validation via `/slack/trigger` against the dev gateway
+
 ## 1. Create the Slack App
 
 1. Go to [api.slack.com/apps](https://api.slack.com/apps) and create a new app

--- a/docs/slack.md
+++ b/docs/slack.md
@@ -19,13 +19,13 @@ Slack Event Subscriptions use one Request URL per app. This means one Slack app 
 
 Recommended:
 
-- Prod app -> prod gateway URL
-- Dev app -> dev gateway URL
+- Primary app -> `vibeteam` gateway URL
+- Optional secondary app -> `vibeteam-openclaw-1` gateway URL
 
 Alternative (single app):
 
-- Keep app Request URL on prod
-- Run dev validation via `/slack/trigger` against the dev gateway
+- Keep app Request URL on `vibeteam`
+- Run isolated validation via `/slack/trigger` against `vibeteam-openclaw-1`
 
 ## 1. Create the Slack App
 

--- a/docs/slack.md
+++ b/docs/slack.md
@@ -17,15 +17,11 @@ This guide covers how to configure the Slack app for VibeTeam, including event s
 
 Slack Event Subscriptions use one Request URL per app. This means one Slack app cannot directly send events to both dev and prod gateways at the same time.
 
-Recommended:
+Current deployment policy:
 
-- Primary app -> `vibeteam` gateway URL
-- Optional secondary app -> `vibeteam-openclaw-1` gateway URL
-
-Alternative (single app):
-
-- Keep app Request URL on `vibeteam`
-- Run isolated validation via `/slack/trigger` against `vibeteam-openclaw-1`
+- Use a single Slack app with Request URL pointing to the `vibeteam` gateway.
+- Run evaluation scenarios via `/slack/trigger` against that same gateway.
+- If you later add additional namespaces, you must add a routing proxy or separate Slack app.
 
 ## 1. Create the Slack App
 

--- a/k8s/base/network-policy.yaml
+++ b/k8s/base/network-policy.yaml
@@ -86,6 +86,9 @@ spec:
         - podSelector:
             matchLabels:
               component: agent-service
+        - podSelector:
+            matchLabels:
+              app: openclaw-gateway
       ports:
         - protocol: TCP
           port: 3000

--- a/k8s/base/openclaw-gateway.yaml
+++ b/k8s/base/openclaw-gateway.yaml
@@ -41,6 +41,27 @@ spec:
           volumeMounts:
             - name: openclaw-state
               mountPath: /home/node/.openclaw
+        - name: init-openclaw-config
+          image: ghcr.io/openclaw/openclaw:latest
+          command:
+            - sh
+            - -c
+            - |
+              cp /config/openclaw.json /home/node/.openclaw/openclaw.json
+              chmod 0644 /home/node/.openclaw/openclaw.json
+          securityContext:
+            allowPrivilegeEscalation: false
+            capabilities:
+              drop:
+                - ALL
+            runAsNonRoot: true
+            runAsUser: 1000
+            runAsGroup: 1000
+          volumeMounts:
+            - name: openclaw-state
+              mountPath: /home/node/.openclaw
+            - name: openclaw-config
+              mountPath: /config
       containers:
         - name: gateway
           image: ghcr.io/openclaw/openclaw:latest
@@ -75,23 +96,12 @@ spec:
                   key: OPENCLAW_GATEWAY_TOKEN
                   optional: true
             - name: LITELLM_BASE_URL
-              valueFrom:
-                secretKeyRef:
-                  name: vibeteam-secrets
-                  key: LITELLM_BASE_URL
-                  optional: true
+              value: http://litellm:4000
             - name: LITELLM_API_KEY
-              valueFrom:
-                secretKeyRef:
-                  name: vibeteam-secrets
-                  key: LITELLM_API_KEY
-                  optional: true
+              value: local
           volumeMounts:
             - name: openclaw-state
               mountPath: /home/node/.openclaw
-            - name: openclaw-config
-              mountPath: /home/node/.openclaw/openclaw.json
-              subPath: openclaw.json
             - name: openclaw-agent-prompts
               mountPath: /home/node/.openclaw/agents/product-manager/agent/AGENTS.md
               subPath: AGENTS.md

--- a/k8s/overlays/dev/kustomization.yaml
+++ b/k8s/overlays/dev/kustomization.yaml
@@ -3,7 +3,7 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
-namespace: vibeteam
+namespace: vibeteam-dev
 
 resources:
   - ../../base
@@ -11,6 +11,7 @@ resources:
 # Strategic merge patches for dev mode
 patches:
   - path: openhands-svc-patch.yaml
+  - path: openclaw-svc-patch.yaml
   - path: gateway-patch.yaml
   - path: agents-config-patch.yaml
 

--- a/k8s/overlays/dev/kustomization.yaml
+++ b/k8s/overlays/dev/kustomization.yaml
@@ -3,7 +3,7 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
-namespace: vibeteam-openclaw-1
+namespace: vibeteam
 
 resources:
   - ../../base

--- a/k8s/overlays/dev/kustomization.yaml
+++ b/k8s/overlays/dev/kustomization.yaml
@@ -3,7 +3,7 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
-namespace: vibeteam-dev
+namespace: vibeteam-openclaw-1
 
 resources:
   - ../../base

--- a/k8s/overlays/dev/openclaw-svc-patch.yaml
+++ b/k8s/overlays/dev/openclaw-svc-patch.yaml
@@ -1,14 +1,13 @@
-# Dev patch for vibeteam-gateway with git-sync sidecar
-# Continuously syncs code from GitHub - no pod restart needed for code changes
+# Dev patch for openclaw-svc to run from git-synced repo code
 apiVersion: apps/v1
 kind: Deployment
 metadata:
-  name: vibeteam-gateway
-  namespace: vibeteam
+  name: openclaw-svc
 spec:
   template:
     spec:
-      # Init container to do initial clone before main container starts
+      securityContext:
+        fsGroup: 65533
       initContainers:
         - name: git-sync-init
           image: registry.k8s.io/git-sync/git-sync:v4.2.1
@@ -25,10 +24,10 @@ spec:
             runAsUser: 65533
             runAsGroup: 65533
       containers:
-        # Patch the main container to use synced code
-        - name: gateway
+        - name: openclaw
+          image: ghcr.io/vibetechnologies/vibeteam-openhands:dev
+          imagePullPolicy: Always
           workingDir: /code/current
-          command: ["python", "-m", "vibeteam.gateway.server"]
           env:
             - name: PYTHONPATH
               value: "/code/current"
@@ -36,7 +35,6 @@ spec:
             - name: code
               mountPath: /code
               readOnly: true
-        # Git-sync sidecar for continuous updates
         - name: git-sync
           image: registry.k8s.io/git-sync/git-sync:v4.2.1
           args:

--- a/k8s/overlays/dev/openhands-svc-patch.yaml
+++ b/k8s/overlays/dev/openhands-svc-patch.yaml
@@ -57,6 +57,8 @@ spec:
               value: "/code/current/agents"
             - name: AGENTS_CONFIG_PATH
               value: "/code/current/agents/agents.yaml"
+            - name: OPENHANDS_SYNC_IDLE_TIMEOUT_SECONDS
+              value: "900"
           volumeMounts:
             - name: code
               mountPath: /code
@@ -70,6 +72,7 @@ spec:
             - --root=/git
             - --link=current
             - --period=30s
+            - --max-failures=-1
           volumeMounts:
             - name: code
               mountPath: /git

--- a/k8s/overlays/prod/kustomization.yaml
+++ b/k8s/overlays/prod/kustomization.yaml
@@ -3,7 +3,7 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
-namespace: vibeteam
+namespace: vibeteam-prod
 
 resources:
   - ../../base

--- a/k8s/overlays/prod/kustomization.yaml
+++ b/k8s/overlays/prod/kustomization.yaml
@@ -3,7 +3,7 @@
 apiVersion: kustomize.config.k8s.io/v1beta1
 kind: Kustomization
 
-namespace: vibeteam-prod
+namespace: vibeteam
 
 resources:
   - ../../base

--- a/tests/e2e/test_slack_routing.py
+++ b/tests/e2e/test_slack_routing.py
@@ -27,13 +27,13 @@ from typing import TYPE_CHECKING
 import httpx
 import pytest
 
-from vibeteam.agents_config import get_slack_handle
 from agent_service.shared.role_resolver import (
     ROLE_MENTION_MAP as ROLE_MAP,
 )
 from agent_service.shared.role_resolver import (
     ROLE_PATTERN,
 )
+from vibeteam.agents_config import get_slack_handle
 
 # Import DeepEval if available
 DEEPEVAL_AVAILABLE = False

--- a/tests/test_async_callback.py
+++ b/tests/test_async_callback.py
@@ -115,6 +115,23 @@ class TestBuildTaskPrompt:
         )
         assert template == "investigation"
 
+    def test_non_ops_roles_default_to_conversational(self):
+        """Product/marketing/software roles should not get ops investigation templates."""
+        assert (
+            classify_task_template(
+                "product_manager",
+                "@ProductManager use Chrome DevTools and report console errors",
+            )
+            == "conversational"
+        )
+        assert (
+            classify_task_template(
+                "software_engineer",
+                "@SoftwareEngineer create a PR for this issue",
+            )
+            == "conversational"
+        )
+
 
 # ==============================================================================
 # Tests for remove_reaction helper

--- a/tests/test_role_resolver.py
+++ b/tests/test_role_resolver.py
@@ -64,11 +64,26 @@ class TestParseRoleMentions:
     @pytest.mark.parametrize(
         "text,expected",
         [
-            (f"@{get_slack_handle('software_engineer') or 'SoftwareEngineer'} please fix this", ["software_engineer"]),
-            (f"@{get_slack_handle('release_engineer') or 'ReleaseEngineer'} deploy v2.1", ["release_engineer"]),
-            (f"@{get_slack_handle('support_engineer') or 'SupportEngineer'} check Sentry", ["support_engineer"]),
-            (f"@{get_slack_handle('product_manager') or 'ProductManager'} prioritize this", ["product_manager"]),
-            (f"@{get_slack_handle('marketing_manager') or 'MarketingManager'} draft announcement", ["marketing_manager"]),
+            (
+                f"@{get_slack_handle('software_engineer') or 'SoftwareEngineer'} please fix this",
+                ["software_engineer"],
+            ),
+            (
+                f"@{get_slack_handle('release_engineer') or 'ReleaseEngineer'} deploy v2.1",
+                ["release_engineer"],
+            ),
+            (
+                f"@{get_slack_handle('support_engineer') or 'SupportEngineer'} check Sentry",
+                ["support_engineer"],
+            ),
+            (
+                f"@{get_slack_handle('product_manager') or 'ProductManager'} prioritize this",
+                ["product_manager"],
+            ),
+            (
+                f"@{get_slack_handle('marketing_manager') or 'MarketingManager'} draft announcement",
+                ["marketing_manager"],
+            ),
         ],
     )
     def test_at_prefix_full_names(self, text, expected):
@@ -92,7 +107,10 @@ class TestParseRoleMentions:
     @pytest.mark.parametrize(
         "text,expected",
         [
-            (f"/{get_slack_handle('software_engineer') or 'SoftwareEngineer'} fix the bug", ["software_engineer"]),
+            (
+                f"/{get_slack_handle('software_engineer') or 'SoftwareEngineer'} fix the bug",
+                ["software_engineer"],
+            ),
             ("/SWE implement this", ["software_engineer"]),
             ("/PM check roadmap", ["product_manager"]),
         ],
@@ -199,11 +217,21 @@ class TestGetDisplayName:
     """Test get_display_name()."""
 
     def test_known_roles(self):
-        assert get_display_name("software_engineer") == (get_slack_handle("software_engineer") or "Software Engineer")
-        assert get_display_name("release_engineer") == (get_slack_handle("release_engineer") or "Release Engineer")
-        assert get_display_name("support_engineer") == (get_slack_handle("support_engineer") or "Support Engineer")
-        assert get_display_name("product_manager") == (get_slack_handle("product_manager") or "Product Manager")
-        assert get_display_name("marketing_manager") == (get_slack_handle("marketing_manager") or "Marketing Manager")
+        assert get_display_name("software_engineer") == (
+            get_slack_handle("software_engineer") or "Software Engineer"
+        )
+        assert get_display_name("release_engineer") == (
+            get_slack_handle("release_engineer") or "Release Engineer"
+        )
+        assert get_display_name("support_engineer") == (
+            get_slack_handle("support_engineer") or "Support Engineer"
+        )
+        assert get_display_name("product_manager") == (
+            get_slack_handle("product_manager") or "Product Manager"
+        )
+        assert get_display_name("marketing_manager") == (
+            get_slack_handle("marketing_manager") or "Marketing Manager"
+        )
 
     def test_fallback_for_unknown(self):
         # Should title-case with underscores replaced

--- a/tests/test_system_prompt.py
+++ b/tests/test_system_prompt.py
@@ -1049,9 +1049,9 @@ class TestAzureLLMConsolidation:
             f"{agent_file} must import from agent_service.shared.llm, "
             f"not define its own AzureLLM or use base LLM"
         )
-        assert "AzureLLM" in content.split("from agent_service.shared.llm import")[1].split("\n")[0], (
-            f"{agent_file} must import AzureLLM from agent_service.shared.llm"
-        )
+        assert (
+            "AzureLLM" in content.split("from agent_service.shared.llm import")[1].split("\n")[0]
+        ), f"{agent_file} must import AzureLLM from agent_service.shared.llm"
 
     @pytest.mark.parametrize("agent_file", ALL_AGENT_FILES)
     def test_agent_does_not_define_own_azure_llm(self, agent_file: str):
@@ -1139,7 +1139,6 @@ class TestSoftwareEngineerFileEditorTool:
             "_create_agent tools list must include FileEditorTool."
         )
 
-
     def test_phase1_mentions_orient_repo(self):
         """Phase 1 workflow should orient the agent in the repo."""
         content = self._read_swe_source()
@@ -1169,6 +1168,4 @@ class TestSoftwareEngineerFileEditorTool:
         ctx_end = content.find('"""', ctx_start + 30)
         ctx = content[ctx_start:ctx_end]
 
-        assert "Avoid full-file reads" in ctx, (
-            "Prompt must tell agent to avoid full-file reads"
-        )
+        assert "Avoid full-file reads" in ctx, "Prompt must tell agent to avoid full-file reads"

--- a/tests/test_task_routing.py
+++ b/tests/test_task_routing.py
@@ -73,7 +73,7 @@ class TestDeploymentNotTriggeredForOtherRoles:
             "software_engineer",
             "@SoftwareEngineer we need to deploy the latest changes.",
         )
-        assert result == "investigation"
+        assert result == "conversational"
 
     def test_support_deploy_message(self):
         result = classify_task_template(
@@ -87,7 +87,7 @@ class TestDeploymentNotTriggeredForOtherRoles:
             "product_manager",
             "@ProductManager when is the next release?",
         )
-        assert result == "investigation"
+        assert result == "conversational"
 
 
 class TestDeploymentExcludedByInvestigationKeywords:
@@ -177,11 +177,11 @@ class TestNotificationExcludedByInvestigation:
             "marketing_manager",
             "@MarketingManager investigate and then announce the fix.",
         )
-        assert result == "investigation"
+        assert result == "conversational"
 
 
 class TestInvestigationFallback:
-    """Messages without deployment or notification keywords → investigation."""
+    """Fallback behavior when no deploy/notification template applies."""
 
     def test_support_400_errors(self):
         result = classify_task_template(
@@ -195,7 +195,7 @@ class TestInvestigationFallback:
             "software_engineer",
             "@SoftwareEngineer issue #449 reports browser extension crashes.",
         )
-        assert result == "investigation"
+        assert result == "conversational"
 
     def test_sentry_alert(self):
         result = classify_task_template(
@@ -209,7 +209,7 @@ class TestInvestigationFallback:
             "software_engineer",
             "@SoftwareEngineer can you help with this?",
         )
-        assert result == "investigation"
+        assert result == "conversational"
 
 
 class TestEdgeCases:
@@ -341,7 +341,7 @@ class TestHealthCheckDetection:
             "software_engineer",
             "@SoftwareEngineer what's the status of the API?",
         )
-        assert result == "investigation"
+        assert result == "conversational"
 
     def test_health_check_in_thread_still_health_check(self):
         """Thread follow-up with health keywords for RE → health_check, not conversational."""
@@ -360,13 +360,13 @@ class TestHandoffPassthrough:
     in the agent's system prompt (AGENTS.md / agent_service), not the gateway.
     """
 
-    def test_handoff_message_gets_investigation_template(self):
-        """Handoff messages go through the normal investigation template."""
+    def test_handoff_message_gets_conversational_template(self):
+        """Non-ops handoff messages keep a conversational template."""
         result = classify_task_template(
             "software_engineer",
             "[Handoff from SupportEngineer]\n\nOriginal request: ...\n\nPrevious response: ...",
         )
-        assert result == "investigation"
+        assert result == "conversational"
 
     def test_handoff_with_deploy_keywords_for_release_engineer(self):
         """Handoff to ReleaseEngineer with deploy keywords gets deployment template."""

--- a/tests/test_webhook_integration.py
+++ b/tests/test_webhook_integration.py
@@ -149,7 +149,9 @@ class TestGitHubWebhookRouting:
         assert data["status"] == "accepted"
         assert "release_engineer" in data["message"].lower()
 
-    def test_discussion_created_with_role_mention(self, test_client, github_webhook_secret, monkeypatch):
+    def test_discussion_created_with_role_mention(
+        self, test_client, github_webhook_secret, monkeypatch
+    ):
         """Test that discussion body with /RoleName triggers appropriate agent."""
         monkeypatch.setenv("GITHUB_WEBHOOK_SECRET", github_webhook_secret)
         monkeypatch.setenv("GITHUB_BOT_USERNAME", "vibeteam-bot[bot]")

--- a/vibeteam/connectors/github.py
+++ b/vibeteam/connectors/github.py
@@ -159,14 +159,10 @@ class GitHubConnector:
 
         self.app_id = app_id or role_app_id or os.environ.get("GITHUB_APP_ID")
         self.private_key = (
-            private_key
-            or role_private_key
-            or os.environ.get("GITHUB_APP_PRIVATE_KEY")
+            private_key or role_private_key or os.environ.get("GITHUB_APP_PRIVATE_KEY")
         )
         self.installation_id = (
-            installation_id
-            or role_installation_id
-            or os.environ.get("GITHUB_APP_INSTALLATION_ID")
+            installation_id or role_installation_id or os.environ.get("GITHUB_APP_INSTALLATION_ID")
         )
 
         # Token management

--- a/vibeteam/gateway/routes/github.py
+++ b/vibeteam/gateway/routes/github.py
@@ -23,9 +23,9 @@ from typing import Any
 import httpx
 from fastapi import APIRouter, Header, HTTPException, Request
 
+from vibeteam.agents_config import get_slack_handle
 from vibeteam.gateway.server import call_agent_service, config
 from vibeteam.router import Router
-from vibeteam.agents_config import get_slack_handle
 from vibeteam.router.models import AgentRole
 
 logger = logging.getLogger(__name__)
@@ -100,7 +100,9 @@ async def get_installation_token(role: str | None = None) -> str | None:
     return None
 
 
-async def post_acknowledgment(repo: str, issue_number: int, role: str = "software_engineer") -> None:
+async def post_acknowledgment(
+    repo: str, issue_number: int, role: str = "software_engineer"
+) -> None:
     """Post a comment acknowledging the assignment."""
     token = await get_installation_token(role)
     if not token:
@@ -491,9 +493,7 @@ Discussion: #{discussion_number}
             response = result.get("response", "")
             if response:
                 formatted = f"[{display_name}] {response}"
-                await post_github_discussion_comment(
-                    repo, discussion_number, formatted, role=role
-                )
+                await post_github_discussion_comment(repo, discussion_number, formatted, role=role)
 
                 if handoff_depth < max_handoff_depth:
                     message_router = get_message_router()
@@ -655,7 +655,10 @@ async def handle_github_webhook(
         discussion_user_type = discussion.get("user", {}).get("type", "")
 
         # Ignore bot discussions
-        if discussion_user_type == "Bot" or config.BOT_USERNAME.replace("[bot]", "") in discussion_user:
+        if (
+            discussion_user_type == "Bot"
+            or config.BOT_USERNAME.replace("[bot]", "") in discussion_user
+        ):
             return {"status": "ignored", "reason": "own_comment"}
 
         if discussion_number:
@@ -670,9 +673,17 @@ async def handle_github_webhook(
         role_mentions = message_router.parse_role_mentions(discussion_body)
         if not role_mentions and discussion_body:
             fallback_roles: list[AgentRole] = []
-            for role in ("software_engineer", "support_engineer", "release_engineer", "product_manager", "marketing_manager"):
+            for role in (
+                "software_engineer",
+                "support_engineer",
+                "release_engineer",
+                "product_manager",
+                "marketing_manager",
+            ):
                 handle = get_slack_handle(role) or role.replace("_", " ").title()
-                if handle and re.search(rf"\\b{re.escape(handle)}\\b", discussion_body, re.IGNORECASE):
+                if handle and re.search(
+                    rf"\\b{re.escape(handle)}\\b", discussion_body, re.IGNORECASE
+                ):
                     fallback_roles.append(role)
             if fallback_roles:
                 role_mentions = fallback_roles
@@ -775,9 +786,7 @@ async def handle_github_webhook(
                         discussion_title=discussion_title,
                         role=role,
                         context=(
-                            "Discussion body:\n\n"
-                            f"{discussion_body}\n\n"
-                            f"New comment:\n{comment_body}"
+                            f"Discussion body:\n\n{discussion_body}\n\nNew comment:\n{comment_body}"
                         ),
                     )
                 )
@@ -796,9 +805,7 @@ async def handle_github_webhook(
                     discussion_title=discussion_title,
                     role="software_engineer",
                     context=(
-                        "Discussion body:\n\n"
-                        f"{discussion_body}\n\n"
-                        f"New comment:\n{comment_body}"
+                        f"Discussion body:\n\n{discussion_body}\n\nNew comment:\n{comment_body}"
                     ),
                 )
             )

--- a/vibeteam/gateway/routes/slack.py
+++ b/vibeteam/gateway/routes/slack.py
@@ -730,6 +730,9 @@ def classify_task_template(role: str, user_message: str, is_thread_reply: bool =
         and not is_explicit_investigation
     )
 
+    investigation_roles = {"support_engineer", "release_engineer"}
+    uses_investigation_template = role in investigation_roles
+
     if is_deployment:
         return "deployment"
     elif is_health_check:
@@ -740,8 +743,12 @@ def classify_task_template(role: str, user_message: str, is_thread_reply: bool =
         # Thread follow-ups get a conversational template unless the user
         # is explicitly asking for a new investigation (e.g., "check the pods")
         return "conversational"
-    else:
+    elif uses_investigation_template:
         return "investigation"
+    else:
+        # Non-ops roles (e.g. product/marketing/software) should not be forced
+        # into the strict incident-investigation prompt by default.
+        return "conversational"
 
 
 def _build_task_prompt(

--- a/vibeteam/gateway/routes/slack.py
+++ b/vibeteam/gateway/routes/slack.py
@@ -22,10 +22,10 @@ from typing import Any, cast
 import httpx
 from fastapi import APIRouter, Header, HTTPException, Request
 
-from vibeteam.gateway.server import call_agent_service, call_agent_service_async, config
 from agent_service.shared.role_resolver import ROLE_MENTION_MAP, get_display_name
-from vibeteam.router import Router
 from vibeteam.agents_config import get_slack_handle
+from vibeteam.gateway.server import call_agent_service, call_agent_service_async, config
+from vibeteam.router import Router
 from vibeteam.router.models import AgentRole, route_by_keywords
 
 logger = logging.getLogger(__name__)
@@ -157,7 +157,7 @@ def _extract_handoff_snippet(response: str, role_display: str) -> str:
                 break
             return "\n".join(snippet).strip()
     # Fallback: first few lines to keep context minimal.
-    return "\n".join(l.strip() for l in lines[:6] if l.strip())
+    return "\n".join(line.strip() for line in lines[:6] if line.strip())
 
 
 def _extract_sentry_urls(text: str) -> list[str]:

--- a/vibeteam/gateway/server.py
+++ b/vibeteam/gateway/server.py
@@ -16,6 +16,7 @@ from fastapi import FastAPI
 from pydantic import BaseModel, Field
 
 from vibeteam.agents_config import resolve_framework
+
 # Configure logging
 logging.basicConfig(
     level=logging.INFO,

--- a/vibeteam/utils/github_app.py
+++ b/vibeteam/utils/github_app.py
@@ -24,9 +24,8 @@ def _normalize_private_key(private_key: str) -> str:
     if not private_key:
         return private_key
     normalized = private_key.replace("\\n", "\n")
-    return (
-        normalized.replace("BEGIN_RSA_PRIVATE_KEY", "BEGIN RSA PRIVATE KEY")
-        .replace("END_RSA_PRIVATE_KEY", "END RSA PRIVATE KEY")
+    return normalized.replace("BEGIN_RSA_PRIVATE_KEY", "BEGIN RSA PRIVATE KEY").replace(
+        "END_RSA_PRIVATE_KEY", "END RSA PRIVATE KEY"
     )
 
 
@@ -77,9 +76,7 @@ def get_installation_token_for_role(role: str) -> str | None:
     default_private_key = os.environ.get("GITHUB_APP_PRIVATE_KEY")
     default_installation_id = os.environ.get("GITHUB_APP_INSTALLATION_ID")
     if default_app_id and default_private_key and default_installation_id:
-        return get_installation_token(
-            default_app_id, default_private_key, default_installation_id
-        )
+        return get_installation_token(default_app_id, default_private_key, default_installation_id)
     return None
 
 


### PR DESCRIPTION
## Summary
- route non-ops Slack prompts to conversational template (prevents ProductManager OpenClaw runs from inheriting strict ops investigation instructions)
- harden OpenClaw gateway config handling by copying config into writable state via init container
- set explicit LiteLLM defaults for OpenClaw gateway in k8s manifest
- allow `openclaw-gateway` ingress to `browserless` via NetworkPolicy
- improve sync Playwright browser-tool cleanup to avoid cross-event-loop reuse errors
- add dev OpenClaw git-sync patch and resilience flags for git-sync sidecars
- document and enforce AKS namespace policy (`aks-1`, `vibeteam-dev`, `vibeteam-prod`) via docs and overlay namespace updates

## Validation
- `.venv/bin/python -m pytest tests/ -v -p no:rerunfailures --run-integration`
  - result: `690 passed, 66 skipped`
- Slack eval (OpenClaw CDP smoke): `openclaw_chrome_cdp_smoke`
  - passed report: `results/eval_reports/eval_openclaw_chrome_cdp_smoke_20260303_224559.md`
- Slack eval (GitHub handoff): `github_issue_pr_handoff_slack`
  - passed report: `results/eval_reports/eval_github_issue_pr_handoff_slack_20260303_224759.md`
- GitHub webhook evals currently still failing (no bot replies observed)
  - `results/eval_reports/eval_github_github_issue_handoff_20260303_230124.md`
  - `results/eval_reports/eval_github_github_discussion_handoff_20260303_225734.md`
  - `results/eval_reports/eval_github_github_pr_comment_handoff_20260303_230442.md`

## Notes
- Excluded local-only artifacts from commit: `.env.prod`, `.opencode/package.json`, `node_modules/`.
