### PR TITLE
Hotfix: prevent /api/run crashes when git-sync invalidates process CWD

### DIFF
--- a/tests/test_agents_config.py
+++ b/tests/test_agents_config.py
@@ -1,0 +1,22 @@
+from __future__ import annotations
+
+from unittest.mock import patch
+
+from vibeteam import agents_config
+
+
+def test_get_agents_config_path_falls_back_when_cwd_missing():
+    with patch("vibeteam.agents_config.Path.cwd", side_effect=FileNotFoundError(2, "missing")):
+        config_path = agents_config._get_agents_config_path()
+
+    assert config_path.is_absolute()
+    assert str(config_path).endswith("agents/agents.yaml")
+
+
+def test_resolve_framework_handles_missing_cwd_without_crashing():
+    # Clear cache so this test always exercises config path resolution.
+    agents_config._get_agents_map.cache_clear()
+    with patch("vibeteam.agents_config.Path.cwd", side_effect=FileNotFoundError(2, "missing")):
+        framework = agents_config.resolve_framework("support_engineer", None, "openhands")
+
+    assert framework in {"openhands", "openclaw", "autogen", "crewai"}

--- a/vibeteam/agents_config.py
+++ b/vibeteam/agents_config.py
@@ -32,11 +32,27 @@ class AgentEntry:
 AGENTS_CONFIG_PATH = os.environ.get("AGENTS_CONFIG_PATH", "agents/agents.yaml")
 
 
+def _repo_root() -> Path:
+    """Return repository root relative to this module, independent of process CWD."""
+    return Path(__file__).resolve().parent.parent
+
+
 def _get_agents_config_path() -> Path:
     path = Path(AGENTS_CONFIG_PATH)
-    if not path.is_absolute():
-        path = Path.cwd() / path
-    return path
+    if path.is_absolute():
+        return path
+
+    # Prefer CWD-relative path when available (dev workflows), but git-sync based
+    # deployments can invalidate process CWD between revisions. Fall back to a
+    # stable module-relative repository root in that case.
+    try:
+        cwd_candidate = Path.cwd() / path
+        if cwd_candidate.exists():
+            return cwd_candidate
+    except FileNotFoundError:
+        pass
+
+    return _repo_root() / path
 
 
 def _get_agents_config_dir() -> Path:


### PR DESCRIPTION
## Root Cause
`vibeteam/agents_config.py` resolved relative `AGENTS_CONFIG_PATH` via `Path.cwd()`. In git-sync rollouts, process CWD can point to an old revision directory that disappears, causing `FileNotFoundError: [Errno 2] No such file or directory` during framework resolution when `framework` is omitted.

This manifested as production `POST /api/run` failures with:
`{"detail":"[Errno 2] No such file or directory"}`

## Fix
- make `_get_agents_config_path()` resilient:
  - still supports CWD-relative resolution when valid
  - falls back to module-relative repo root when CWD is missing/invalid
- add regression tests in `tests/test_agents_config.py`:
  - verifies fallback when `Path.cwd()` raises `FileNotFoundError`
  - verifies `resolve_framework()` does not crash in that condition

## Validation
- `python -m py_compile vibeteam/agents_config.py tests/test_agents_config.py`
- `uv run pytest tests/test_agents_config.py tests/test_role_resolver.py -q` (87 passed)

Related production incident: #308