### PR TITLE
Wire Langfuse env vars into gateway and openhands deployments

### DIFF
--- a/k8s/base/openhands-svc.yaml
+++ b/k8s/base/openhands-svc.yaml
@@ -140,6 +140,24 @@ spec:
                 secretKeyRef:
                   name: vibeteam-secrets
                   key: SENTRY_AUTH_TOKEN
+            - name: LANGFUSE_PUBLIC_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: vibeteam-secrets
+                  key: LANGFUSE_PUBLIC_KEY
+                  optional: true
+            - name: LANGFUSE_SECRET_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: vibeteam-secrets
+                  key: LANGFUSE_SECRET_KEY
+                  optional: true
+            - name: LANGFUSE_BASE_URL
+              valueFrom:
+                secretKeyRef:
+                  name: vibeteam-secrets
+                  key: LANGFUSE_BASE_URL
+                  optional: true
             - name: GMAIL_CREDENTIALS_PATH
               value: "/gmail/gmail-credentials.json"
             - name: GMAIL_TOKEN_PATH

--- a/k8s/base/vibeteam-gateway.yaml
+++ b/k8s/base/vibeteam-gateway.yaml
@@ -142,6 +142,24 @@ spec:
                   name: vibeteam-secrets
                   key: SENTRY_CLIENT_SECRET
                   optional: true
+            - name: LANGFUSE_PUBLIC_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: vibeteam-secrets
+                  key: LANGFUSE_PUBLIC_KEY
+                  optional: true
+            - name: LANGFUSE_SECRET_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: vibeteam-secrets
+                  key: LANGFUSE_SECRET_KEY
+                  optional: true
+            - name: LANGFUSE_BASE_URL
+              valueFrom:
+                secretKeyRef:
+                  name: vibeteam-secrets
+                  key: LANGFUSE_BASE_URL
+                  optional: true
             # Async callback configuration
             - name: GATEWAY_URL
               value: "http://vibeteam-gateway:8080"


### PR DESCRIPTION
## Summary
Runtime pods had no `LANGFUSE_*` env vars even though `vibeteam-secrets` contained them, so Langfuse tracing/tools were effectively disabled.

This PR adds secret-backed env vars to both deployments:
- `k8s/base/openhands-svc.yaml`
- `k8s/base/vibeteam-gateway.yaml`

Vars injected:
- `LANGFUSE_PUBLIC_KEY`
- `LANGFUSE_SECRET_KEY`
- `LANGFUSE_BASE_URL`

## Validation
- `kubectl apply --dry-run=client -f k8s/base/openhands-svc.yaml -f k8s/base/vibeteam-gateway.yaml`
- `uv run pytest tests/test_langfuse_integration.py -q` (68 passed)

## Tracking
Closes #311