### PR TITLE
Set LANGFUSE_HOST from LANGFUSE_BASE_URL in k8s manifests

### DIFF
--- a/k8s/base/openhands-svc.yaml
+++ b/k8s/base/openhands-svc.yaml
@@ -158,6 +158,8 @@ spec:
                   name: vibeteam-secrets
                   key: LANGFUSE_BASE_URL
                   optional: true
+            - name: LANGFUSE_HOST
+              value: "$(LANGFUSE_BASE_URL)"
             - name: GMAIL_CREDENTIALS_PATH
               value: "/gmail/gmail-credentials.json"
             - name: GMAIL_TOKEN_PATH

--- a/k8s/base/openhands-svc.yaml
+++ b/k8s/base/openhands-svc.yaml
@@ -140,6 +140,24 @@ spec:
                 secretKeyRef:
                   name: vibeteam-secrets
                   key: SENTRY_AUTH_TOKEN
+            - name: LANGFUSE_PUBLIC_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: vibeteam-secrets
+                  key: LANGFUSE_PUBLIC_KEY
+                  optional: true
+            - name: LANGFUSE_SECRET_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: vibeteam-secrets
+                  key: LANGFUSE_SECRET_KEY
+                  optional: true
+            - name: LANGFUSE_BASE_URL
+              valueFrom:
+                secretKeyRef:
+                  name: vibeteam-secrets
+                  key: LANGFUSE_BASE_URL
+                  optional: true
             - name: GMAIL_CREDENTIALS_PATH
               value: "/gmail/gmail-credentials.json"
             - name: GMAIL_TOKEN_PATH

--- a/k8s/base/vibeteam-gateway.yaml
+++ b/k8s/base/vibeteam-gateway.yaml
@@ -160,6 +160,8 @@ spec:
                   name: vibeteam-secrets
                   key: LANGFUSE_BASE_URL
                   optional: true
+            - name: LANGFUSE_HOST
+              value: "$(LANGFUSE_BASE_URL)"
             # Async callback configuration
             - name: GATEWAY_URL
               value: "http://vibeteam-gateway:8080"

--- a/k8s/base/vibeteam-gateway.yaml
+++ b/k8s/base/vibeteam-gateway.yaml
@@ -142,6 +142,24 @@ spec:
                   name: vibeteam-secrets
                   key: SENTRY_CLIENT_SECRET
                   optional: true
+            - name: LANGFUSE_PUBLIC_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: vibeteam-secrets
+                  key: LANGFUSE_PUBLIC_KEY
+                  optional: true
+            - name: LANGFUSE_SECRET_KEY
+              valueFrom:
+                secretKeyRef:
+                  name: vibeteam-secrets
+                  key: LANGFUSE_SECRET_KEY
+                  optional: true
+            - name: LANGFUSE_BASE_URL
+              valueFrom:
+                secretKeyRef:
+                  name: vibeteam-secrets
+                  key: LANGFUSE_BASE_URL
+                  optional: true
             # Async callback configuration
             - name: GATEWAY_URL
               value: "http://vibeteam-gateway:8080"


### PR DESCRIPTION
Superseded by #314 (same change rebased cleanly on latest `master`).