### PR TITLE
Set LANGFUSE_HOST from LANGFUSE_BASE_URL in k8s manifests

### DIFF
--- a/k8s/base/openhands-svc.yaml
+++ b/k8s/base/openhands-svc.yaml
@@ -158,6 +158,8 @@ spec:
                   name: vibeteam-secrets
                   key: LANGFUSE_BASE_URL
                   optional: true
+            - name: LANGFUSE_HOST
+              value: "$(LANGFUSE_BASE_URL)"
             - name: GMAIL_CREDENTIALS_PATH
               value: "/gmail/gmail-credentials.json"
             - name: GMAIL_TOKEN_PATH

--- a/k8s/base/vibeteam-gateway.yaml
+++ b/k8s/base/vibeteam-gateway.yaml
@@ -160,6 +160,8 @@ spec:
                   name: vibeteam-secrets
                   key: LANGFUSE_BASE_URL
                   optional: true
+            - name: LANGFUSE_HOST
+              value: "$(LANGFUSE_BASE_URL)"
             # Async callback configuration
             - name: GATEWAY_URL
               value: "http://vibeteam-gateway:8080"


### PR DESCRIPTION
## Summary
Set `LANGFUSE_HOST` explicitly from `$(LANGFUSE_BASE_URL)` for:
- `k8s/base/openhands-svc.yaml`
- `k8s/base/vibeteam-gateway.yaml`

This ensures Langfuse SDK/export paths that depend on `LANGFUSE_HOST` use the same endpoint as `LANGFUSE_BASE_URL`.

## Validation
- `kubectl apply --dry-run=client -f k8s/base/openhands-svc.yaml -f k8s/base/vibeteam-gateway.yaml`
- `uv run pytest tests/test_langfuse_integration.py -q` (68 passed)
- `uv run python scripts/eval_slack_e2e.py --scenario marketing_hn_ai_agents_copilot_pr --channel C0AATPSADB8 --timeout 300` ✅ passed
  - report: `results/eval_reports/eval_marketing_hn_ai_agents_copilot_pr_20260304_055111.md`