### PR TITLE
Enforce secret hygiene with CI scanning and safer env example

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -9,7 +9,7 @@ AZURE_API_VERSION=2024-08-01-preview
 
 # Langfuse Observability (optional)
 # Get keys from https://langfuse.vibebrowser.app
-LANGFUSE_PUBLIC_KEY=pk-lf-6e1a58bf-537c-4b25-9171-7f16aef25560
+LANGFUSE_PUBLIC_KEY=pk-lf-your-public-key
 LANGFUSE_SECRET_KEY=your-langfuse-secret-key
 LANGFUSE_HOST=https://langfuse.vibebrowser.app
 

--- a/.github/workflows/secret-scan.yml
+++ b/.github/workflows/secret-scan.yml
@@ -1,0 +1,40 @@
+name: Secret Scan
+
+on:
+  pull_request:
+  push:
+    branches: [master, main]
+  workflow_dispatch:
+
+permissions:
+  contents: read
+  security-events: write
+
+jobs:
+  gitleaks:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Install gitleaks
+        run: |
+          set -euo pipefail
+          GITLEAKS_VERSION="8.24.2"
+          curl -sSL "https://github.com/gitleaks/gitleaks/releases/download/v${GITLEAKS_VERSION}/gitleaks_${GITLEAKS_VERSION}_linux_x64.tar.gz" -o /tmp/gitleaks.tar.gz
+          tar -xzf /tmp/gitleaks.tar.gz -C /tmp
+          sudo mv /tmp/gitleaks /usr/local/bin/gitleaks
+          gitleaks version
+
+      - name: Run gitleaks
+        run: |
+          set -euo pipefail
+          gitleaks dir --source . --redact --verbose --report-format sarif --report-path gitleaks.sarif
+
+      - name: Upload SARIF report
+        if: always()
+        uses: github/codeql-action/upload-sarif@v3
+        with:
+          sarif_file: gitleaks.sarif


### PR DESCRIPTION
## Summary
- Added CI secret scanning workflow: `.github/workflows/secret-scan.yml`
  - Runs gitleaks on PRs and pushes to `master`/`main`
  - Uploads SARIF report to GitHub code scanning
- Replaced concrete Langfuse public key value in `.env.example` with placeholder:
  - `LANGFUSE_PUBLIC_KEY=pk-lf-your-public-key`

This keeps repo examples non-sensitive and adds automated prevention against committing secrets.

## Validation
- `uv run pytest tests/test_langfuse_integration.py -q` (68 passed)
- Regex sanity scan for known secret patterns on working tree returned no matches

## Tracking
Closes #315