### PR TITLE
Fail secret-scan CI when gitleaks finds leaks

### DIFF
--- a/.github/workflows/secret-scan.yml
+++ b/.github/workflows/secret-scan.yml
@@ -31,7 +31,7 @@ jobs:
       - name: Run gitleaks
         run: |
           set -euo pipefail
-          gitleaks dir --source . --redact --verbose --report-format sarif --report-path gitleaks.sarif
+          gitleaks dir --source . --redact --verbose --exit-code 1 --report-format sarif --report-path gitleaks.sarif
 
       - name: Upload SARIF report
         if: always()


### PR DESCRIPTION
## Summary
Follow-up hardening to secret-scan workflow:

- Added `--exit-code 1` to gitleaks invocation in `.github/workflows/secret-scan.yml`

Without this, findings could be uploaded as SARIF while the job still passes. With this change, secret findings fail CI as intended.

## Validation
- `uv run pytest tests/test_langfuse_integration.py -q` (68 passed)
- YAML parse sanity check for `.github/workflows/secret-scan.yml` passed