### PR TITLE
Fix framework-compat routing and OpenHands progress import crash

### DIFF
--- a/agent_service/openhands/release_engineer.py
+++ b/agent_service/openhands/release_engineer.py
@@ -49,6 +49,12 @@ except ImportError:
 from agent_service.shared.agents_md_loader import compose_agent_context
 from agent_service.shared.llm import LLM, AzureLLM
 
+try:
+    from .progress import create_heartbeat_callback, create_progress_callback
+except Exception:
+    create_progress_callback = None  # type: ignore[assignment]
+    create_heartbeat_callback = None  # type: ignore[assignment]
+
 from .utils import build_condenser, get_prompt_path
 
 # OpenHands uses Jinja2 templates for system prompts.
@@ -405,21 +411,23 @@ class OpenHandsReleaseEngineer:
             callbacks = []
             progress_url = kwargs.get("progress_url")
             if progress_url:
-                from .progress import create_progress_callback
-
-                progress_cb = create_progress_callback(
-                    progress_url=progress_url,
-                    job_id=kwargs.get("job_id", ""),
-                    callback_metadata=kwargs.get("callback_metadata", {}),
-                    on_progress=kwargs.get("progress_heartbeat"),
-                )
-                callbacks.append(progress_cb)
+                if create_progress_callback is not None:
+                    progress_cb = create_progress_callback(
+                        progress_url=progress_url,
+                        job_id=kwargs.get("job_id", ""),
+                        callback_metadata=kwargs.get("callback_metadata", {}),
+                        on_progress=kwargs.get("progress_heartbeat"),
+                    )
+                    callbacks.append(progress_cb)
+                else:
+                    print("[ReleaseEngineer] Progress callback unavailable")
             elif kwargs.get("progress_heartbeat"):
-                from .progress import create_heartbeat_callback
-
-                callbacks.append(
-                    create_heartbeat_callback(on_progress=kwargs.get("progress_heartbeat"))
-                )
+                if create_heartbeat_callback is not None:
+                    callbacks.append(
+                        create_heartbeat_callback(on_progress=kwargs.get("progress_heartbeat"))
+                    )
+                else:
+                    print("[ReleaseEngineer] Progress heartbeat unavailable")
 
             # Create local conversation with required workspace
             # max_iterations caps the number of agent iterations (tool calls)

--- a/agent_service/openhands/software_engineer.py
+++ b/agent_service/openhands/software_engineer.py
@@ -49,6 +49,12 @@ except ImportError:
 from agent_service.shared.agents_md_loader import compose_agent_context
 from agent_service.shared.llm import LLM, AzureLLM
 
+try:
+    from .progress import create_heartbeat_callback, create_progress_callback
+except Exception:
+    create_progress_callback = None  # type: ignore[assignment]
+    create_heartbeat_callback = None  # type: ignore[assignment]
+
 from .utils import build_condenser, get_prompt_path
 
 # Fallback context if AGENTS.md files not found
@@ -1095,10 +1101,8 @@ class OpenHandsSoftwareEngineer:
             agent_callbacks: list[Any] = [_count_iterations]
             progress_url = kwargs.get("progress_url")
             if progress_url:
-                try:
-                    from .progress import create_progress_callback
-                except Exception as exc:
-                    print(f"[SoftwareEngineer] Progress callback unavailable: {exc}")
+                if create_progress_callback is None:
+                    print("[SoftwareEngineer] Progress callback unavailable")
                 else:
                     progress_cb = create_progress_callback(
                         progress_url=progress_url,
@@ -1108,10 +1112,8 @@ class OpenHandsSoftwareEngineer:
                     )
                     agent_callbacks.append(progress_cb)
             elif kwargs.get("progress_heartbeat"):
-                try:
-                    from .progress import create_heartbeat_callback
-                except Exception as exc:
-                    print(f"[SoftwareEngineer] Progress heartbeat unavailable: {exc}")
+                if create_heartbeat_callback is None:
+                    print("[SoftwareEngineer] Progress heartbeat unavailable")
                 else:
                     agent_callbacks.append(
                         create_heartbeat_callback(on_progress=kwargs.get("progress_heartbeat"))

--- a/agent_service/openhands/support_engineer.py
+++ b/agent_service/openhands/support_engineer.py
@@ -36,6 +36,12 @@ from agent_service.shared.kubectl_tools import (
 from agent_service.shared.langfuse_tools import get_langfuse_context
 from agent_service.shared.sentry_tools import SentryClient, get_sentry_context
 
+try:
+    from .progress import create_heartbeat_callback, create_progress_callback
+except Exception:
+    create_progress_callback = None  # type: ignore[assignment]
+    create_heartbeat_callback = None  # type: ignore[assignment]
+
 
 def fetch_sentry_context(
     hours: int = 24, limit: int = 10, include_top_issue_details: bool = False
@@ -788,21 +794,23 @@ class OpenHandsSupportEngineer:
             callbacks = []
             progress_url = kwargs.get("progress_url")
             if progress_url:
-                from .progress import create_progress_callback
-
-                progress_cb = create_progress_callback(
-                    progress_url=progress_url,
-                    job_id=kwargs.get("job_id", ""),
-                    callback_metadata=kwargs.get("callback_metadata", {}),
-                    on_progress=kwargs.get("progress_heartbeat"),
-                )
-                callbacks.append(progress_cb)
+                if create_progress_callback is not None:
+                    progress_cb = create_progress_callback(
+                        progress_url=progress_url,
+                        job_id=kwargs.get("job_id", ""),
+                        callback_metadata=kwargs.get("callback_metadata", {}),
+                        on_progress=kwargs.get("progress_heartbeat"),
+                    )
+                    callbacks.append(progress_cb)
+                else:
+                    print("[SupportEngineer] Progress callback unavailable")
             elif kwargs.get("progress_heartbeat"):
-                from .progress import create_heartbeat_callback
-
-                callbacks.append(
-                    create_heartbeat_callback(on_progress=kwargs.get("progress_heartbeat"))
-                )
+                if create_heartbeat_callback is not None:
+                    callbacks.append(
+                        create_heartbeat_callback(on_progress=kwargs.get("progress_heartbeat"))
+                    )
+                else:
+                    print("[SupportEngineer] Progress heartbeat unavailable")
 
             # max_iterations caps the number of agent iterations (tool calls)
             # to prevent runaway execution. Default is 30.

--- a/agent_service/scheduler/server.py
+++ b/agent_service/scheduler/server.py
@@ -37,8 +37,10 @@ class ScheduleRequest(BaseModel):
     delay_minutes: int = Field(0, description="Minutes from now to run")
     cron: str | None = Field(None, description="Cron expression for recurring tasks")
     interval_minutes: int | None = Field(None, description="Interval in minutes for recurring")
-    agent_service: str = Field(
-        "autogen-svc", description="Target agent service (autogen-svc or crewai-svc)"
+    agent_service: str | None = Field(
+        None,
+        description="Target agent service (openhands-svc or openclaw-svc). "
+        "If role is provided, service is resolved from agents/agents.yaml.",
     )
     role: str | None = Field(None, description="Specific agent role")
     context_type: str = Field("scheduled", description="Context type")
@@ -95,15 +97,52 @@ def get_database_url() -> str:
 # Global scheduler instance
 _scheduler: AsyncScheduler | None = None
 _job_metadata: dict[str, dict[str, Any]] = {}  # Store job metadata (task, service, etc.)
+LEGACY_SERVICE_ALIASES = {
+    "autogen-svc": "openhands-svc",
+    "crewai-svc": "openhands-svc",
+}
+SUPPORTED_AGENT_SERVICES = {"openhands-svc", "openclaw-svc"}
+OPENCLAW_ROLE_NAMES = {
+    role.strip().lower()
+    for role in os.getenv("OPENCLAW_ROLE_NAMES", "product_manager").split(",")
+    if role.strip()
+}
+
+
+def normalize_agent_service_name(service: str | None) -> str:
+    if not service:
+        return "openhands-svc"
+    normalized = service.strip().lower()
+    if not normalized:
+        return "openhands-svc"
+    return LEGACY_SERVICE_ALIASES.get(normalized, normalized)
 
 
 def get_agent_service_url(service: str) -> str:
     """Get URL for agent service."""
     urls = {
-        "autogen-svc": os.getenv("AUTOGEN_SERVICE_URL", "http://autogen-svc:8080"),
-        "crewai-svc": os.getenv("CREWAI_SERVICE_URL", "http://crewai-svc:8080"),
+        "openhands-svc": os.getenv("OPENHANDS_SERVICE_URL", "http://openhands-svc:8080"),
+        "openclaw-svc": os.getenv("OPENCLAW_SERVICE_URL", "http://openclaw-svc:8080"),
     }
-    return urls.get(service, urls["autogen-svc"])
+    normalized = normalize_agent_service_name(service)
+    return urls.get(normalized, urls["openhands-svc"])
+
+
+def resolve_agent_service(role: str | None, requested_service: str | None = None) -> str:
+    """Resolve target service from role config with legacy fallback support."""
+    normalized = normalize_agent_service_name(requested_service)
+    if normalized in SUPPORTED_AGENT_SERVICES:
+        return normalized
+
+    normalized_role = (role or "").strip().lower()
+    if normalized_role in OPENCLAW_ROLE_NAMES:
+        return "openclaw-svc"
+
+    logger.warning(
+        "Requested agent_service '%s' is unsupported; falling back to openhands-svc",
+        requested_service,
+    )
+    return "openhands-svc"
 
 
 async def execute_scheduled_task(job_id: str) -> None:
@@ -114,7 +153,7 @@ async def execute_scheduled_task(job_id: str) -> None:
         return
 
     task = metadata.get("task", "")
-    service = metadata.get("agent_service", "autogen-svc")
+    service = resolve_agent_service(metadata.get("role"), metadata.get("agent_service"))
     role = metadata.get("role")
     context_type = metadata.get("context_type", "scheduled")
     context_id = metadata.get("context_id") or job_id
@@ -179,7 +218,7 @@ async def register_default_tasks() -> None:
             "job_id": "support-emails",
             "task": "Process support emails from Gmail inbox and respond to customer inquiries",
             "cron": "*/15 * * * *",  # Every 15 minutes
-            "agent_service": "autogen-svc",
+            "agent_service": "openhands-svc",
             "role": "support_engineer",
             "context_type": "scheduled",
         },
@@ -187,7 +226,7 @@ async def register_default_tasks() -> None:
             "job_id": "product-analysis",
             "task": "Analyze customer feedback, feature requests, and prioritize backlog items",
             "cron": "0 */2 * * *",  # Every 2 hours
-            "agent_service": "autogen-svc",
+            "agent_service": "openhands-svc",
             "role": "support_engineer",  # PM role uses support tools
             "context_type": "scheduled",
         },
@@ -195,7 +234,7 @@ async def register_default_tasks() -> None:
             "job_id": "release-check",
             "task": "Check for pending releases, review changelogs, and prepare release notes",
             "cron": "0 9 * * *",  # Daily at 9am UTC
-            "agent_service": "autogen-svc",
+            "agent_service": "openhands-svc",
             "role": "release_engineer",
             "context_type": "scheduled",
         },
@@ -203,7 +242,7 @@ async def register_default_tasks() -> None:
             "job_id": "health-check",
             "task": "Check system health, Sentry errors, and Langfuse traces for anomalies",
             "cron": "*/5 * * * *",  # Every 5 minutes
-            "agent_service": "autogen-svc",
+            "agent_service": "openhands-svc",
             "role": "support_engineer",
             "context_type": "scheduled",
         },
@@ -211,7 +250,7 @@ async def register_default_tasks() -> None:
             "job_id": "issue-triage",
             "task": "Review and triage new GitHub issues, assign priorities and labels",
             "cron": "0 */4 * * *",  # Every 4 hours
-            "agent_service": "autogen-svc",
+            "agent_service": "openhands-svc",
             "role": "support_engineer",
             "context_type": "scheduled",
         },
@@ -299,10 +338,12 @@ async def schedule_task(request: ScheduleRequest):
         )
         trigger = DateTrigger(run_time=run_at)
 
+    agent_service = resolve_agent_service(request.role, request.agent_service)
+
     # Store metadata
     _job_metadata[job_id] = {
         "task": request.task,
-        "agent_service": request.agent_service,
+        "agent_service": agent_service,
         "role": request.role,
         "context_type": request.context_type,
         "context_id": request.context_id or job_id,
@@ -324,7 +365,7 @@ async def schedule_task(request: ScheduleRequest):
         task=request.task,
         run_at=run_at,
         schedule_type=schedule_type,
-        agent_service=request.agent_service,
+        agent_service=agent_service,
         status="scheduled",
     )
 
@@ -340,7 +381,7 @@ async def list_tasks():
                 task=metadata.get("task", ""),
                 next_run=None,  # Would need to query scheduler for this
                 schedule_type="unknown",
-                agent_service=metadata.get("agent_service", "autogen-svc"),
+                agent_service=metadata.get("agent_service", "openhands-svc"),
                 role=metadata.get("role"),
                 context_type=metadata.get("context_type", "scheduled"),
                 context_id=metadata.get("context_id"),
@@ -362,7 +403,7 @@ async def get_task(job_id: str):
         task=metadata.get("task", ""),
         next_run=None,
         schedule_type="unknown",
-        agent_service=metadata.get("agent_service", "autogen-svc"),
+        agent_service=metadata.get("agent_service", "openhands-svc"),
         role=metadata.get("role"),
         context_type=metadata.get("context_type", "scheduled"),
         context_id=metadata.get("context_id"),

--- a/agent_service/shared/scheduler_tools.py
+++ b/agent_service/shared/scheduler_tools.py
@@ -16,7 +16,7 @@ async def schedule_task(
     task: str,
     delay_hours: int = 0,
     delay_minutes: int = 0,
-    agent_service: str = "autogen-svc",
+    agent_service: str = "openhands-svc",
     role: str | None = None,
     context_type: str = "scheduled",
     context_id: str | None = None,
@@ -28,7 +28,7 @@ async def schedule_task(
         task: The task description
         delay_hours: Hours from now to execute
         delay_minutes: Minutes from now to execute
-        agent_service: Target service (autogen-svc or crewai-svc)
+        agent_service: Target service (openhands-svc or openclaw-svc)
         role: Specific agent role
         context_type: Context type for session tracking
         context_id: Context ID for session tracking
@@ -57,7 +57,7 @@ def schedule_task_sync(
     task: str,
     delay_hours: int = 0,
     delay_minutes: int = 0,
-    agent_service: str = "autogen-svc",
+    agent_service: str = "openhands-svc",
     role: str | None = None,
 ) -> dict[str, Any]:
     """Sync version of schedule_task for use as agent tool."""

--- a/k8s/base/scheduler-svc.yaml
+++ b/k8s/base/scheduler-svc.yaml
@@ -30,10 +30,10 @@ spec:
                 secretKeyRef:
                   name: postgres-secret
                   key: DATABASE_URL
-            - name: AUTOGEN_SERVICE_URL
-              value: "http://autogen-svc:8080"
-            - name: CREWAI_SERVICE_URL
-              value: "http://crewai-svc:8080"
+            - name: OPENHANDS_SERVICE_URL
+              value: "http://openhands-svc:8080"
+            - name: OPENCLAW_SERVICE_URL
+              value: "http://openclaw-svc:8080"
           resources:
             requests:
               memory: "256Mi"

--- a/k8s/base/vibeteam-gateway.yaml
+++ b/k8s/base/vibeteam-gateway.yaml
@@ -70,6 +70,8 @@ spec:
               value: "http://crewai-svc:8080"
             - name: OPENHANDS_SERVICE_URL
               value: "http://openhands-svc:8080"
+            - name: OPENCLAW_SERVICE_URL
+              value: "http://openclaw-svc:8080"
             - name: SCHEDULER_SERVICE_URL
               value: "http://scheduler-svc:8080"
             - name: DEFAULT_FRAMEWORK

--- a/scripts/deploy-dev.sh
+++ b/scripts/deploy-dev.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 # Build and deploy dev images that pull fresh code from GitHub on restart
 # Usage: ./scripts/deploy-dev.sh [target]
-#   target: openhands, autogen, crewai, gateway, all (default: all), or deploy
+#   target: openhands, openclaw, autogen, crewai, gateway, all (default: all), or deploy
 
 set -euo pipefail
 
@@ -93,12 +93,17 @@ deploy_dev() {
     restart_if_exists "vibeteam-gateway"
     restart_if_exists "openhands-svc"
     restart_if_exists "openhands-agents"
+    restart_if_exists "openclaw-svc"
     restart_if_exists "autogen-svc"
     restart_if_exists "crewai-svc"
 }
 
 case "$TARGET" in
     openhands)
+        build_and_push "openhands" "$PROJECT_DIR/agent_service/openhands/Dockerfile" "$PROJECT_DIR"
+        ;;
+    openclaw)
+        # OpenClaw service uses the OpenHands dev image in the dev overlay.
         build_and_push "openhands" "$PROJECT_DIR/agent_service/openhands/Dockerfile" "$PROJECT_DIR"
         ;;
     autogen)
@@ -119,7 +124,7 @@ case "$TARGET" in
         deploy_dev
         ;;
     *)
-        echo "Usage: $0 [openhands|autogen|crewai|gateway|all|deploy]"
+        echo "Usage: $0 [openhands|openclaw|autogen|crewai|gateway|all|deploy]"
         exit 1
         ;;
 esac

--- a/tests/test_agents_config.py
+++ b/tests/test_agents_config.py
@@ -20,3 +20,14 @@ def test_resolve_framework_handles_missing_cwd_without_crashing():
         framework = agents_config.resolve_framework("support_engineer", None, "openhands")
 
     assert framework in {"openhands", "openclaw", "autogen", "crewai"}
+
+
+def test_normalize_framework_name_maps_legacy_frameworks():
+    assert agents_config.normalize_framework_name("autogen") == "openhands"
+    assert agents_config.normalize_framework_name("crewai") == "openhands"
+    assert agents_config.normalize_framework_name("openclaw") == "openclaw"
+
+
+def test_resolve_framework_applies_alias_to_framework_override():
+    framework = agents_config.resolve_framework(None, "crewai", "openclaw")
+    assert framework == "openhands"

--- a/tests/test_eval_rescore.py
+++ b/tests/test_eval_rescore.py
@@ -598,7 +598,9 @@ class TestPerScenarioTimeout:
         allowed_overrides = {
             "release_deploy",
             "marketing_reddit_engagement",
+            "marketing_reddit_ai_agents_copilot_pr",
             "marketing_hn_engagement",
+            "marketing_hn_ai_agents_copilot_pr",
             "marketing_google_finance_news",
         }
         for name, config in SCENARIOS.items():

--- a/vibeteam/agents_config.py
+++ b/vibeteam/agents_config.py
@@ -30,6 +30,10 @@ class AgentEntry:
 
 
 AGENTS_CONFIG_PATH = os.environ.get("AGENTS_CONFIG_PATH", "agents/agents.yaml")
+FRAMEWORK_ALIASES = {
+    "autogen": "openhands",
+    "crewai": "openhands",
+}
 
 
 def _repo_root() -> Path:
@@ -123,13 +127,24 @@ def resolve_openclaw_agent_id(role: str | None) -> str | None:
     return entry.openclaw_agent_id
 
 
+def normalize_framework_name(framework: str | None) -> str | None:
+    """Normalize framework names and apply legacy aliases."""
+    if framework is None:
+        return None
+    normalized = framework.strip().lower()
+    if not normalized:
+        return None
+    return FRAMEWORK_ALIASES.get(normalized, normalized)
+
+
 def resolve_framework(role: str | None, framework_override: str | None, default: str) -> str:
-    if framework_override:
-        return framework_override
+    override = normalize_framework_name(framework_override)
+    if override:
+        return override
     entry = get_agent_entry(role)
     if entry and entry.framework:
-        return entry.framework
-    return default
+        return normalize_framework_name(entry.framework) or "openhands"
+    return normalize_framework_name(default) or "openhands"
 
 
 def get_slack_handle(role: str | None) -> str | None:
@@ -181,6 +196,7 @@ __all__ = [
     "AgentEntry",
     "get_agent_entry",
     "resolve_openclaw_agent_id",
+    "normalize_framework_name",
     "resolve_framework",
     "get_slack_handle",
     "get_agent_dir",

--- a/vibeteam/gateway/__init__.py
+++ b/vibeteam/gateway/__init__.py
@@ -8,7 +8,7 @@ This module provides a FastAPI gateway that handles:
 - REST API for manual task invocation
 
 Instead of running agents as subprocesses, it routes requests to
-the agent microservices (autogen-svc, crewai-svc) via HTTP.
+the agent microservices (openhands-svc, openclaw-svc) via HTTP.
 """
 
 from vibeteam.gateway.server import app

--- a/vibeteam/gateway/routes/api.py
+++ b/vibeteam/gateway/routes/api.py
@@ -15,6 +15,7 @@ from typing import Any
 from fastapi import APIRouter, HTTPException
 from pydantic import BaseModel, Field
 
+from vibeteam.agents_config import resolve_framework
 from vibeteam.gateway.server import (
     RunRequest,
     RunResponse,
@@ -40,7 +41,11 @@ class ScheduleRequest(BaseModel):
     task: str = Field(..., description="The task to execute")
     run_at: str | None = Field(None, description="ISO datetime to run (None for immediate)")
     role: str | None = Field(None, description="Agent role")
-    framework: str | None = Field(None, description="Agent framework (autogen, crewai)")
+    framework: str | None = Field(
+        None,
+        description="Optional framework override (legacy). "
+        "Aliases autogen/crewai map to openhands.",
+    )
     context_type: str = Field("api", description="Context type")
     context_id: str | None = Field(None, description="Context ID")
 
@@ -77,8 +82,8 @@ async def run_task(request: RunRequest):
     """
     Execute a task with an agent microservice.
 
-    This endpoint routes the task to the appropriate agent service
-    (autogen-svc or crewai-svc) based on the framework parameter.
+    This endpoint routes the task to the appropriate agent service based on
+    role mapping in agents/agents.yaml, with optional legacy framework override.
     """
     try:
         result = await call_agent_service(
@@ -96,7 +101,10 @@ async def run_task(request: RunRequest):
         return RunResponse(
             response=result.get("response", ""),
             session_id=result.get("session_id", ""),
-            framework=result.get("framework", request.framework or config.DEFAULT_FRAMEWORK),
+            framework=result.get(
+                "framework",
+                resolve_framework(request.role, request.framework, config.DEFAULT_FRAMEWORK),
+            ),
             agents_used=result.get("agents_used", []),
             metadata=result.get("metadata", {}),
         )
@@ -145,6 +153,7 @@ async def schedule_task(request: ScheduleRequest):
 
 @router.get("/sessions", response_model=SessionListResponse)
 async def list_sessions(
+    role: str | None = None,
     framework: str | None = None,
     prefix: str = "",
     limit: int = 100,
@@ -156,7 +165,8 @@ async def list_sessions(
     """
     try:
         client = get_http_client()
-        service_url = config.get_agent_service_url(framework)
+        resolved_framework = resolve_framework(role, framework, config.DEFAULT_FRAMEWORK)
+        service_url = config.get_agent_service_url(resolved_framework)
 
         response = await client.get(
             f"{service_url}/sessions",

--- a/vibeteam/gateway/server.py
+++ b/vibeteam/gateway/server.py
@@ -2,7 +2,8 @@
 VibeTeam Gateway Server.
 
 FastAPI server that receives external events and routes them to agent microservices.
-Replaces the subprocess-based approach with HTTP calls to autogen-svc/crewai-svc.
+Framework routing is role-driven via agents/agents.yaml with legacy framework
+override support.
 """
 
 import logging
@@ -15,7 +16,7 @@ import httpx
 from fastapi import FastAPI
 from pydantic import BaseModel, Field
 
-from vibeteam.agents_config import resolve_framework
+from vibeteam.agents_config import normalize_framework_name, resolve_framework
 
 # Configure logging
 logging.basicConfig(
@@ -34,8 +35,6 @@ class GatewayConfig:
     """Gateway configuration from environment variables."""
 
     # Agent service URLs
-    AUTOGEN_SERVICE_URL = os.environ.get("AUTOGEN_SERVICE_URL", "http://autogen-svc:8080")
-    CREWAI_SERVICE_URL = os.environ.get("CREWAI_SERVICE_URL", "http://crewai-svc:8080")
     OPENHANDS_SERVICE_URL = os.environ.get("OPENHANDS_SERVICE_URL", "http://openhands-svc:8080")
     OPENCLAW_SERVICE_URL = os.environ.get("OPENCLAW_SERVICE_URL", "http://openclaw-svc:8080")
     SCHEDULER_SERVICE_URL = os.environ.get("SCHEDULER_SERVICE_URL", "http://scheduler-svc:8080")
@@ -77,15 +76,12 @@ class GatewayConfig:
 
     @classmethod
     def get_agent_service_url(cls, framework: str | None = None) -> str:
-        """Get the URL for the specified agent framework."""
-        fw = framework or cls.DEFAULT_FRAMEWORK
-        if fw == "crewai":
-            return cls.CREWAI_SERVICE_URL
-        elif fw == "openhands":
-            return cls.OPENHANDS_SERVICE_URL
-        elif fw == "openclaw":
+        """Get the URL for the specified (normalized) agent framework."""
+        fw = normalize_framework_name(framework) or normalize_framework_name(cls.DEFAULT_FRAMEWORK)
+        if fw == "openclaw":
             return cls.OPENCLAW_SERVICE_URL
-        return cls.AUTOGEN_SERVICE_URL
+        # Default everything else to OpenHands for legacy compatibility.
+        return cls.OPENHANDS_SERVICE_URL
 
 
 config = GatewayConfig()
@@ -105,7 +101,9 @@ class RunRequest(BaseModel):
         description="Agent role (support_engineer, release_engineer, software_engineer, etc.)",
     )
     framework: str | None = Field(
-        None, description="Agent framework (autogen, crewai, openhands, openclaw)"
+        None,
+        description="Optional framework override (legacy). "
+        "Aliases autogen/crewai map to openhands.",
     )
     context_type: str = Field("api", description="Context type")
     context_id: str | None = Field(None, description="Context ID")
@@ -181,7 +179,7 @@ async def call_agent_service(
     Args:
         task: Task description
         role: Agent role (determines routing)
-        framework: Agent framework (autogen, crewai)
+        framework: Optional framework override (legacy)
         context_type: Context type for session tracking
         context_id: Context ID for session tracking
         stream: Whether to stream the response
@@ -313,7 +311,7 @@ async def call_agent_service_async(
     Args:
         task: Task description
         role: Agent role
-        framework: Agent framework
+        framework: Optional framework override (legacy)
         context_type: Context type for session tracking
         context_id: Context ID for session tracking
         callback_url: URL where agent should POST results
@@ -398,7 +396,7 @@ async def call_scheduler_service(
         task: Task description
         run_at: ISO datetime to run (None for immediate)
         role: Agent role
-        framework: Agent framework
+        framework: Optional framework override (legacy)
         context_type: Context type
         context_id: Context ID
 
@@ -407,12 +405,13 @@ async def call_scheduler_service(
     """
     client = get_http_client()
 
+    fw = resolve_framework(role, framework, config.DEFAULT_FRAMEWORK)
+    service_name = "openclaw-svc" if fw == "openclaw" else "openhands-svc"
+
     payload = {
         "task": task,
         "role": role,
-        "agent_service": (
-            "autogen-svc" if framework not in ("crewai", "openhands") else f"{framework}-svc"
-        ),
+        "agent_service": service_name,
         "context_type": context_type,
         "context_id": context_id,
     }
@@ -456,9 +455,8 @@ async def check_service_health(url: str) -> str:
 async def lifespan(app: FastAPI):
     """Application lifespan manager."""
     logger.info("Starting VibeTeam Gateway...")
-    logger.info(f"AutoGen service: {config.AUTOGEN_SERVICE_URL}")
-    logger.info(f"CrewAI service: {config.CREWAI_SERVICE_URL}")
     logger.info(f"OpenHands service: {config.OPENHANDS_SERVICE_URL}")
+    logger.info(f"OpenClaw service: {config.OPENCLAW_SERVICE_URL}")
     logger.info(f"Scheduler service: {config.SCHEDULER_SERVICE_URL}")
     logger.info(f"Default framework: {config.DEFAULT_FRAMEWORK}")
 
@@ -495,9 +493,8 @@ async def health_check():
     """Health check endpoint with downstream service status."""
     # Check downstream services
     services = {
-        "autogen-svc": await check_service_health(config.AUTOGEN_SERVICE_URL),
-        "crewai-svc": await check_service_health(config.CREWAI_SERVICE_URL),
         "openhands-svc": await check_service_health(config.OPENHANDS_SERVICE_URL),
+        "openclaw-svc": await check_service_health(config.OPENCLAW_SERVICE_URL),
         "scheduler-svc": await check_service_health(config.SCHEDULER_SERVICE_URL),
     }
 


### PR DESCRIPTION
## Summary
This PR fixes the production/dev breakages introduced during framework-to-role migration and restores backward compatibility for legacy framework callers.

### Included fixes
- Normalize legacy framework aliases (`autogen`, `crewai`) to `openhands` in routing resolution.
- Keep `/api/sessions` compatibility for legacy `?framework=` while supporting role-based routing.
- Remove hard dependency on removed autogen/crewai service URLs in gateway routing paths.
- Fix scheduler service defaults and aliases to target `openhands-svc`/`openclaw-svc`.
- Add missing `OPENCLAW_SERVICE_URL` to gateway/scheduler manifests.
- Fix `scripts/deploy-dev.sh` openclaw path to avoid non-existent Dockerfile usage.
- Harden OpenHands role handlers (`support`, `release`, `software`) to avoid request-time lazy imports of `.progress` that were causing 500s in Slack runs.

## Validation
- `uv run ruff check` on all changed Python files
- `uv run pytest tests/test_agents_config.py tests/test_gateway_trigger.py tests/test_async_callback.py tests/test_eval_rescore.py -q` (115 passed)

## Runtime issue addressed
- `ModuleNotFoundError: No module named 'agent_service.openhands.progress'` seen in `openhands-svc` logs during Slack eval runs.

Closes #318