### PR TITLE
Fix dev agents-config PVC storage class for AKS rollout safety

### DIFF
--- a/k8s/overlays/dev/agents-config-patch.yaml
+++ b/k8s/overlays/dev/agents-config-patch.yaml
@@ -4,5 +4,6 @@ metadata:
   name: agents-config
 spec:
   accessModes:
-    - ReadWriteOnce
-  storageClassName: local-path
+    - ReadWriteMany
+  # AKS: use Azure Files CSI for RWMany shared mounts across gateway/agent pods.
+  storageClassName: azurefile-csi


### PR DESCRIPTION
## Summary
`k8s/overlays/dev/agents-config-patch.yaml` hardcoded `storageClassName: local-path` with `ReadWriteOnce`.

On AKS this caused rollout failures:
- `storageclass.storage.k8s.io "local-path" not found`
- new `openhands-svc` / `vibeteam-gateway` pods stuck `Pending` when overlay was applied.

## Changes
- Set `agents-config` PVC patch to:
  - `accessModes: [ReadWriteMany]`
  - `storageClassName: azurefile-csi`

This matches AKS RWX requirements for shared mounts across gateway/agent pods.

## Validation
- `kubectl kustomize k8s/overlays/dev` renders PVC with `azurefile-csi`.
- Applied overlay to AKS and verified rollouts complete for gateway/openhands/scheduler.

Refs #318