### PR TITLE
Preserve progress-import exception details in OpenHands role logs

### DIFF
--- a/agent_service/openhands/release_engineer.py
+++ b/agent_service/openhands/release_engineer.py
@@ -49,11 +49,13 @@ except ImportError:
 from agent_service.shared.agents_md_loader import compose_agent_context
 from agent_service.shared.llm import LLM, AzureLLM
 
+PROGRESS_IMPORT_ERROR: Exception | None = None
 try:
     from .progress import create_heartbeat_callback, create_progress_callback
-except Exception:
+except Exception as exc:
     create_progress_callback = None  # type: ignore[assignment]
     create_heartbeat_callback = None  # type: ignore[assignment]
+    PROGRESS_IMPORT_ERROR = exc
 
 from .utils import build_condenser, get_prompt_path
 
@@ -420,14 +422,20 @@ class OpenHandsReleaseEngineer:
                     )
                     callbacks.append(progress_cb)
                 else:
-                    print("[ReleaseEngineer] Progress callback unavailable")
+                    print(
+                        "[ReleaseEngineer] Progress callback unavailable: "
+                        f"{PROGRESS_IMPORT_ERROR!r}"
+                    )
             elif kwargs.get("progress_heartbeat"):
                 if create_heartbeat_callback is not None:
                     callbacks.append(
                         create_heartbeat_callback(on_progress=kwargs.get("progress_heartbeat"))
                     )
                 else:
-                    print("[ReleaseEngineer] Progress heartbeat unavailable")
+                    print(
+                        "[ReleaseEngineer] Progress heartbeat unavailable: "
+                        f"{PROGRESS_IMPORT_ERROR!r}"
+                    )
 
             # Create local conversation with required workspace
             # max_iterations caps the number of agent iterations (tool calls)

--- a/agent_service/openhands/software_engineer.py
+++ b/agent_service/openhands/software_engineer.py
@@ -49,11 +49,13 @@ except ImportError:
 from agent_service.shared.agents_md_loader import compose_agent_context
 from agent_service.shared.llm import LLM, AzureLLM
 
+PROGRESS_IMPORT_ERROR: Exception | None = None
 try:
     from .progress import create_heartbeat_callback, create_progress_callback
-except Exception:
+except Exception as exc:
     create_progress_callback = None  # type: ignore[assignment]
     create_heartbeat_callback = None  # type: ignore[assignment]
+    PROGRESS_IMPORT_ERROR = exc
 
 from .utils import build_condenser, get_prompt_path
 
@@ -1102,7 +1104,10 @@ class OpenHandsSoftwareEngineer:
             progress_url = kwargs.get("progress_url")
             if progress_url:
                 if create_progress_callback is None:
-                    print("[SoftwareEngineer] Progress callback unavailable")
+                    print(
+                        "[SoftwareEngineer] Progress callback unavailable: "
+                        f"{PROGRESS_IMPORT_ERROR!r}"
+                    )
                 else:
                     progress_cb = create_progress_callback(
                         progress_url=progress_url,
@@ -1113,7 +1118,10 @@ class OpenHandsSoftwareEngineer:
                     agent_callbacks.append(progress_cb)
             elif kwargs.get("progress_heartbeat"):
                 if create_heartbeat_callback is None:
-                    print("[SoftwareEngineer] Progress heartbeat unavailable")
+                    print(
+                        "[SoftwareEngineer] Progress heartbeat unavailable: "
+                        f"{PROGRESS_IMPORT_ERROR!r}"
+                    )
                 else:
                     agent_callbacks.append(
                         create_heartbeat_callback(on_progress=kwargs.get("progress_heartbeat"))

--- a/agent_service/openhands/support_engineer.py
+++ b/agent_service/openhands/support_engineer.py
@@ -36,11 +36,13 @@ from agent_service.shared.kubectl_tools import (
 from agent_service.shared.langfuse_tools import get_langfuse_context
 from agent_service.shared.sentry_tools import SentryClient, get_sentry_context
 
+PROGRESS_IMPORT_ERROR: Exception | None = None
 try:
     from .progress import create_heartbeat_callback, create_progress_callback
-except Exception:
+except Exception as exc:
     create_progress_callback = None  # type: ignore[assignment]
     create_heartbeat_callback = None  # type: ignore[assignment]
+    PROGRESS_IMPORT_ERROR = exc
 
 
 def fetch_sentry_context(
@@ -803,14 +805,20 @@ class OpenHandsSupportEngineer:
                     )
                     callbacks.append(progress_cb)
                 else:
-                    print("[SupportEngineer] Progress callback unavailable")
+                    print(
+                        "[SupportEngineer] Progress callback unavailable: "
+                        f"{PROGRESS_IMPORT_ERROR!r}"
+                    )
             elif kwargs.get("progress_heartbeat"):
                 if create_heartbeat_callback is not None:
                     callbacks.append(
                         create_heartbeat_callback(on_progress=kwargs.get("progress_heartbeat"))
                     )
                 else:
-                    print("[SupportEngineer] Progress heartbeat unavailable")
+                    print(
+                        "[SupportEngineer] Progress heartbeat unavailable: "
+                        f"{PROGRESS_IMPORT_ERROR!r}"
+                    )
 
             # max_iterations caps the number of agent iterations (tool calls)
             # to prevent runaway execution. Default is 30.


### PR DESCRIPTION
## Summary
Follow-up hardening for #319: keep startup import error details when progress callbacks are unavailable.

## Changes
In `software_engineer`, `support_engineer`, and `release_engineer`:
- capture import exception in `PROGRESS_IMPORT_ERROR`
- include that exception in fallback log lines for both progress callback and heartbeat callback paths

This preserves root-cause context instead of only logging a generic "callback unavailable" message.

## Validation
- `uv run ruff check` (changed files)
- `uv run pytest tests/test_gateway_trigger.py tests/test_async_callback.py -q` (58 passed)

Refs #318