### PR TITLE
refactor(openhands): dedupe role agents with shared base engine

### DIFF
--- a/agent_service/openhands/release_engineer.py
+++ b/agent_service/openhands/release_engineer.py
@@ -16,12 +16,8 @@ Note: OpenHands SDK v1.2.1 uses:
 - LocalConversation: agent, workspace (both required)
 """
 
-import os
-import tempfile
-from typing import Any
 
 from agent_service.config import RELEASE_ENGINEER_CONFIG, AgentConfig
-from agent_service.sessions import get_or_create_session, get_session_store
 from agent_service.shared.kubectl_tools import get_multi_namespace_context
 
 
@@ -30,34 +26,7 @@ def fetch_kubectl_context() -> str:
     return get_multi_namespace_context()
 
 
-# OpenHands imports - will fail gracefully if not installed
-try:
-    from openhands.sdk import Agent, LocalConversation, Tool
-    from openhands.tools.file_editor import FileEditorTool
-    from openhands.tools.terminal import TerminalTool
-
-    OPENHANDS_AVAILABLE = True
-
-except ImportError:
-    OPENHANDS_AVAILABLE = False
-    Agent = None
-    LocalConversation = None
-    Tool = None
-    TerminalTool = None
-    FileEditorTool = None
-
-from agent_service.shared.agents_md_loader import compose_agent_context
-from agent_service.shared.llm import LLM, AzureLLM
-
-PROGRESS_IMPORT_ERROR: Exception | None = None
-try:
-    from .progress import create_heartbeat_callback, create_progress_callback
-except Exception as exc:
-    create_progress_callback = None  # type: ignore[assignment]
-    create_heartbeat_callback = None  # type: ignore[assignment]
-    PROGRESS_IMPORT_ERROR = exc
-
-from .utils import build_condenser, get_prompt_path
+from .role_agent import OpenHandsRoleAgent
 
 # OpenHands uses Jinja2 templates for system prompts.
 # We use agents/openhands/prompts/agent_system.j2 as a custom template
@@ -309,201 +278,19 @@ DO NOT try to use Slack/email tools. Your text response is automatically posted.
 """
 
 
-class OpenHandsReleaseEngineer:
-    """
-    Release Engineer agent using OpenHands SDK.
+class OpenHandsReleaseEngineer(OpenHandsRoleAgent):
+    """Release Engineer configured from AGENTS.md + shared role engine."""
 
-    Uses OpenHands' agentic loop with built-in tools for:
-    - Shell command execution
-    - File editing
-    - Web browsing (optional)
-    """
+    role = "release_engineer"
+    agent_label = "ReleaseEngineer"
+    default_config = RELEASE_ENGINEER_CONFIG
+    fallback_context = RELEASE_ENGINEER_CONTEXT_FALLBACK
+    include_workspace = True
+    force_tools = True
 
-    def __init__(self, config: AgentConfig | None = None):
-        if not OPENHANDS_AVAILABLE:
-            raise ImportError("OpenHands SDK not installed. Run: pip install openhands-ai")
-
-        self.config = config or RELEASE_ENGINEER_CONFIG
-
-    def _create_llm(self) -> LLM:
-        """Create LLM with Azure configuration."""
-        model_name = self.config.llm.model or "gpt-5.2"
-        # OpenHands uses litellm format: azure/<deployment>
-        if not model_name.startswith("azure/"):
-            model_name = f"azure/{model_name}"
-
-        return AzureLLM(
-            model=model_name,
-            api_key=self.config.llm.api_key,
-            base_url=self.config.llm.api_base,
-            api_version=os.getenv("AZURE_API_VERSION", "2024-08-01-preview"),
-            max_output_tokens=4096,  # Critical for Azure GPT-4 models
-            timeout=300,  # 5 min per LLM call — prevents infinite hangs
-            num_retries=3,  # Retry transient failures (overall timeout is the safety net)
-        )
-
-    def _create_agent(self, llm: LLM) -> Agent:
-        """Create Agent with LLM and tools."""
-        # Load agent context from AGENTS.md hierarchy
-        # Falls back to hardcoded context if files not found
-        agent_context = compose_agent_context(
-            "release_engineer", fallback_context=RELEASE_ENGINEER_CONTEXT_FALLBACK
-        )
-
-        return Agent(
-            llm=llm,
-            tools=[
-                Tool(name=TerminalTool.name),
-                Tool(name=FileEditorTool.name),
-            ],
-            condenser=build_condenser(llm),
-            # Use our custom template that renders agent_context into the system prompt.
-            # Without this, the default system_prompt.j2 ignores agent_context kwargs.
-            system_prompt_filename=get_prompt_path(),
-            system_prompt_kwargs={
-                "agent_context": agent_context,
-            },
-        )
-
-    def run(
-        self,
-        task: str,
-        context_type: str = "ephemeral",
-        context_id: str | None = None,
-        workspace: str | None = None,
-        **kwargs: Any,
-    ) -> dict[str, Any]:
-        """
-        Run a task with the Release Engineer agent.
-
-        Args:
-            task: The task description
-            context_type: Type of context (issue, pr, slack, ephemeral)
-            context_id: ID for the context (issue number, PR number, etc.)
-            workspace: Working directory for the agent
-
-        Returns:
-            dict with response, session_key, and metadata
-        """
-        import uuid
-
-        if context_id is None:
-            context_id = str(uuid.uuid4())[:8]
-
-        session = get_or_create_session(
-            framework="openhands",
-            role="release_engineer",
-            context_type=context_type,
-            context_id=context_id,
-        )
-
-        llm = self._create_llm()
-        agent = self._create_agent(llm)
-
-        # Use provided workspace or create temporary one
-        temp_dir = None
-        if not workspace:
-            temp_dir = tempfile.TemporaryDirectory()
-            workspace_path = temp_dir.name
-        else:
-            workspace_path = workspace
-
-        try:
-            # Build callbacks list for progress reporting
-            callbacks = []
-            progress_url = kwargs.get("progress_url")
-            if progress_url:
-                if create_progress_callback is not None:
-                    progress_cb = create_progress_callback(
-                        progress_url=progress_url,
-                        job_id=kwargs.get("job_id", ""),
-                        callback_metadata=kwargs.get("callback_metadata", {}),
-                        on_progress=kwargs.get("progress_heartbeat"),
-                    )
-                    callbacks.append(progress_cb)
-                else:
-                    print(
-                        "[ReleaseEngineer] Progress callback unavailable: "
-                        f"{PROGRESS_IMPORT_ERROR!r}"
-                    )
-            elif kwargs.get("progress_heartbeat"):
-                if create_heartbeat_callback is not None:
-                    callbacks.append(
-                        create_heartbeat_callback(on_progress=kwargs.get("progress_heartbeat"))
-                    )
-                else:
-                    print(
-                        "[ReleaseEngineer] Progress heartbeat unavailable: "
-                        f"{PROGRESS_IMPORT_ERROR!r}"
-                    )
-
-            # Create local conversation with required workspace
-            # max_iterations caps the number of agent iterations (tool calls)
-            # to prevent runaway execution. Default is 30; health checks use 15.
-            max_iterations = kwargs.get("max_iterations", 30)
-            conversation = LocalConversation(
-                agent=agent,
-                workspace=workspace_path,
-                callbacks=callbacks or None,
-                max_iteration_per_run=max_iterations,
-            )
-
-            # Build full task without pre-fetched context.
-            full_task = f"Task: {task}"
-
-            # Use send_message + run for the full agentic loop with tools
-            conversation.send_message(full_task)
-            conversation.run()
-
-            # Extract the agent's final response from conversation events
-            # Uses shared extraction that handles both FinishAction and MessageEvent
-            from .utils import extract_response_from_events
-
-            response = extract_response_from_events(conversation.state.events)
-
-            # Update session
-            session.add_message("user", task)
-            session.add_message("assistant", response)
-            get_session_store().save(session)
-
-            return {
-                "response": response,
-                "session_key": session.key,
-                "session_id": session.session_id,
-                "framework": "openhands",
-                "agent": "release_engineer",
-                "model": self.config.llm.model or "gpt-5.2",
-                "workspace": workspace_path,
-            }
-
-        finally:
-            # Clean up temp directory if we created one
-            if temp_dir:
-                try:
-                    conversation.close()
-                except Exception:
-                    pass
-                temp_dir.cleanup()
-
-    async def run_async(
-        self,
-        task: str,
-        context_type: str = "ephemeral",
-        context_id: str | None = None,
-        workspace: str | None = None,
-        **kwargs: Any,
-    ) -> dict[str, Any]:
-        """Async version of run."""
-        import asyncio
-
-        return await asyncio.to_thread(
-            self.run,
-            task,
-            context_type,
-            context_id,
-            workspace,
-            **kwargs,
-        )
+    def build_task_prompt(self, task: str, use_tools: bool) -> str:
+        del use_tools
+        return f"Task: {task}"
 
 
 def create_release_engineer(

--- a/agent_service/openhands/release_engineer.py
+++ b/agent_service/openhands/release_engineer.py
@@ -49,11 +49,13 @@ except ImportError:
 from agent_service.shared.agents_md_loader import compose_agent_context
 from agent_service.shared.llm import LLM, AzureLLM
 
+PROGRESS_IMPORT_ERROR: Exception | None = None
 try:
     from .progress import create_heartbeat_callback, create_progress_callback
-except Exception:
+except Exception as exc:
     create_progress_callback = None  # type: ignore[assignment]
     create_heartbeat_callback = None  # type: ignore[assignment]
+    PROGRESS_IMPORT_ERROR = exc
 
 from .utils import build_condenser, get_prompt_path
 
@@ -420,14 +422,20 @@ class OpenHandsReleaseEngineer:
                     )
                     callbacks.append(progress_cb)
                 else:
-                    print("[ReleaseEngineer] Progress callback unavailable")
+                    print(
+                        "[ReleaseEngineer] Progress callback unavailable: "
+                        f"{PROGRESS_IMPORT_ERROR!r}"
+                    )
             elif kwargs.get("progress_heartbeat"):
                 if create_heartbeat_callback is not None:
                     callbacks.append(
                         create_heartbeat_callback(on_progress=kwargs.get("progress_heartbeat"))
                     )
                 else:
-                    print("[ReleaseEngineer] Progress heartbeat unavailable")
+                    print(
+                        "[ReleaseEngineer] Progress heartbeat unavailable: "
+                        f"{PROGRESS_IMPORT_ERROR!r}"
+                    )
 
             # Create local conversation with required workspace
             # max_iterations caps the number of agent iterations (tool calls)

--- a/agent_service/openhands/role_agent.py
+++ b/agent_service/openhands/role_agent.py
@@ -1,0 +1,327 @@
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+import tempfile
+import threading
+import uuid
+from typing import Any
+
+from agent_service.config import AgentConfig, get_mcp_config_dict
+from agent_service.sessions import get_or_create_session, get_session_store
+from agent_service.shared.agents_md_loader import compose_agent_context
+from agent_service.shared.llm import LLM, AzureLLM
+
+from .utils import build_condenser, extract_response_from_events, get_prompt_path
+
+logger = logging.getLogger(__name__)
+
+try:
+    from openhands.sdk import Agent, LocalConversation, Tool
+    from openhands.tools.file_editor import FileEditorTool
+    from openhands.tools.terminal import TerminalTool
+
+    OPENHANDS_AVAILABLE = True
+except ImportError:
+    OPENHANDS_AVAILABLE = False
+    Agent = None
+    LocalConversation = None
+    Tool = None
+    TerminalTool = None
+    FileEditorTool = None
+
+PROGRESS_IMPORT_ERROR: Exception | None = None
+try:
+    from .progress import create_heartbeat_callback, create_progress_callback
+except Exception as exc:
+    create_progress_callback = None  # type: ignore[assignment]
+    create_heartbeat_callback = None  # type: ignore[assignment]
+    PROGRESS_IMPORT_ERROR = exc
+
+
+class OpenHandsRoleAgent:
+    """Shared OpenHands role engine configured by role + AGENTS.md context."""
+
+    role: str = ""
+    agent_label: str = "OpenHandsRole"
+    default_config: AgentConfig
+    fallback_context: str = ""
+
+    # Behavior flags for subclasses.
+    force_tools: bool = False
+    enable_mcp: bool = False
+    include_workspace: bool = False
+
+    # Optional generic iteration warning system.
+    iteration_warnings: dict[str, str] | None = None
+    iteration_warning_thresholds: dict[int, str] | None = None
+    handoff_iteration_warning_thresholds: dict[int, str] | None = None
+
+    def __init__(self, config: AgentConfig | None = None):
+        if not OPENHANDS_AVAILABLE:
+            raise ImportError("OpenHands SDK not installed. Run: pip install openhands-ai")
+        self.config = config or self.default_config
+
+    def _extra_llm_kwargs(self) -> dict[str, Any]:
+        return {}
+
+    def _create_llm(self) -> LLM:
+        model_name = self.config.llm.model or "gpt-5.2"
+        if not model_name.startswith("azure/"):
+            model_name = f"azure/{model_name}"
+
+        llm_kwargs: dict[str, Any] = {
+            "model": model_name,
+            "api_key": self.config.llm.api_key,
+            "base_url": self.config.llm.api_base,
+            "api_version": os.getenv("AZURE_API_VERSION", "2024-08-01-preview"),
+            "max_output_tokens": 4096,
+            "timeout": 300,
+            "num_retries": 3,
+        }
+        llm_kwargs.update(self._extra_llm_kwargs())
+        return AzureLLM(**llm_kwargs)
+
+    def _resolve_use_tools(self, use_tools: bool | None, kwargs: dict[str, Any]) -> bool:
+        if use_tools is not None:
+            return bool(use_tools)
+        if "use_tools" in kwargs:
+            return bool(kwargs["use_tools"])
+        return True
+
+    def _build_tools(self, use_tools: bool) -> list[Any]:
+        if not (self.force_tools or use_tools):
+            return []
+        return [
+            Tool(name=TerminalTool.name),
+            Tool(name=FileEditorTool.name),
+        ]
+
+    def _create_agent(self, llm: LLM, use_tools: bool) -> Any:
+        agent_context = compose_agent_context(self.role, fallback_context=self.fallback_context)
+        agent_kwargs: dict[str, Any] = {
+            "llm": llm,
+            "tools": self._build_tools(use_tools),
+            "condenser": build_condenser(llm),
+            "system_prompt_filename": get_prompt_path(),
+            "system_prompt_kwargs": {
+                "agent_context": agent_context,
+            },
+        }
+        if self.enable_mcp and use_tools:
+            mcp_config = get_mcp_config_dict(self.config.mcp_servers)
+            if mcp_config.get("mcpServers"):
+                agent_kwargs["mcp_config"] = mcp_config
+        return Agent(**agent_kwargs)
+
+    def _build_progress_callbacks(self, kwargs: dict[str, Any]) -> list[Any]:
+        callbacks: list[Any] = []
+        progress_url = kwargs.get("progress_url")
+        if progress_url:
+            if create_progress_callback is not None:
+                callbacks.append(
+                    create_progress_callback(
+                        progress_url=progress_url,
+                        job_id=kwargs.get("job_id", ""),
+                        callback_metadata=kwargs.get("callback_metadata", {}),
+                        on_progress=kwargs.get("progress_heartbeat"),
+                    )
+                )
+            else:
+                logger.warning(
+                    "[%s] Progress callback unavailable: %r",
+                    self.agent_label,
+                    PROGRESS_IMPORT_ERROR,
+                )
+        elif kwargs.get("progress_heartbeat"):
+            if create_heartbeat_callback is not None:
+                callbacks.append(
+                    create_heartbeat_callback(on_progress=kwargs.get("progress_heartbeat"))
+                )
+            else:
+                logger.warning(
+                    "[%s] Progress heartbeat unavailable: %r",
+                    self.agent_label,
+                    PROGRESS_IMPORT_ERROR,
+                )
+        return callbacks
+
+    def _inject_iteration_warning(self, conversation: Any, level: str) -> None:
+        if not self.iteration_warnings:
+            return
+        msg = self.iteration_warnings.get(level, "")
+        if not msg:
+            return
+        try:
+            logger.info("[%s] Injecting iteration warning: %s", self.agent_label, level)
+            conversation.send_message(msg)
+        except Exception as exc:
+            logger.warning("[%s] Warning injection failed (%s): %s", self.agent_label, level, exc)
+
+    def _build_iteration_callbacks(
+        self,
+        task: str,
+        conversation_ref: dict[str, Any],
+    ) -> list[Any]:
+        if not self.iteration_warning_thresholds or not self.iteration_warnings:
+            return []
+
+        is_handoff_task = "[Handoff from" in task or "Previous response:" in task
+        thresholds = self.iteration_warning_thresholds
+        if is_handoff_task and self.handoff_iteration_warning_thresholds:
+            thresholds = self.handoff_iteration_warning_thresholds
+            logger.info(
+                "[%s] Handoff task detected — using tighter iteration thresholds",
+                self.agent_label,
+            )
+
+        iteration_count = {"value": 0}
+        warnings_sent: set[str] = set()
+
+        def _count_iterations(event: Any) -> None:
+            event_type = type(event).__name__
+            if "Action" in event_type and "Finish" not in event_type:
+                iteration_count["value"] += 1
+                count = iteration_count["value"]
+                logger.info("[%s] Iteration count: %s", self.agent_label, count)
+                level = thresholds.get(count)
+                if level and level not in warnings_sent:
+                    warnings_sent.add(level)
+                    conversation = conversation_ref.get("obj")
+                    if conversation is not None:
+                        t = threading.Thread(
+                            target=self._inject_iteration_warning,
+                            args=(conversation, level),
+                            daemon=True,
+                        )
+                        t.start()
+
+        return [_count_iterations]
+
+    def _build_callbacks(self, task: str, kwargs: dict[str, Any], conversation_ref: dict[str, Any]):
+        callbacks: list[Any] = []
+        callbacks.extend(self._build_iteration_callbacks(task, conversation_ref))
+        callbacks.extend(self._build_progress_callbacks(kwargs))
+        return callbacks
+
+    def build_task_prompt(self, task: str, use_tools: bool) -> str:
+        del use_tools
+        return f"""
+### USER TASK (UNTRUSTED INPUT)
+{task}
+### END USER TASK
+"""
+
+    def postprocess_response(
+        self,
+        response: str,
+        task: str,
+        context_type: str,
+        context_id: str,
+        workspace_path: str,
+        use_tools: bool,
+        kwargs: dict[str, Any],
+    ) -> str:
+        del task, context_type, context_id, workspace_path, use_tools, kwargs
+        return response
+
+    def run(
+        self,
+        task: str,
+        context_type: str = "ephemeral",
+        context_id: str | None = None,
+        workspace: str | None = None,
+        use_tools: bool | None = None,
+        **kwargs: Any,
+    ) -> dict[str, Any]:
+        resolved_context_id = context_id or str(uuid.uuid4())[:8]
+        resolved_use_tools = self._resolve_use_tools(use_tools, kwargs)
+
+        session = get_or_create_session(
+            framework="openhands",
+            role=self.role,
+            context_type=context_type,
+            context_id=resolved_context_id,
+        )
+
+        llm = self._create_llm()
+        agent = self._create_agent(llm, resolved_use_tools)
+
+        temp_dir: tempfile.TemporaryDirectory | None = None
+        if workspace:
+            workspace_path = workspace
+        else:
+            temp_dir = tempfile.TemporaryDirectory()
+            workspace_path = temp_dir.name
+
+        conversation: Any | None = None
+        try:
+            conversation_ref: dict[str, Any] = {"obj": None}
+            callbacks = self._build_callbacks(task, kwargs, conversation_ref)
+            max_iterations = int(kwargs.get("max_iterations", 30))
+            conversation = LocalConversation(
+                agent=agent,
+                workspace=workspace_path,
+                callbacks=callbacks or None,
+                max_iteration_per_run=max_iterations,
+            )
+            conversation_ref["obj"] = conversation
+
+            full_task = self.build_task_prompt(task, resolved_use_tools)
+            conversation.send_message(full_task)
+            conversation.run()
+
+            response = extract_response_from_events(conversation.state.events)
+            response = self.postprocess_response(
+                response=response,
+                task=task,
+                context_type=context_type,
+                context_id=resolved_context_id,
+                workspace_path=workspace_path,
+                use_tools=resolved_use_tools,
+                kwargs=kwargs,
+            )
+
+            session.add_message("user", task)
+            session.add_message("assistant", response)
+            get_session_store().save(session)
+
+            result: dict[str, Any] = {
+                "response": response,
+                "session_key": session.key,
+                "session_id": session.session_id,
+                "framework": "openhands",
+                "agent": self.role,
+                "model": self.config.llm.model or "gpt-5.2",
+            }
+            if self.include_workspace:
+                result["workspace"] = workspace_path
+            return result
+        finally:
+            if conversation is not None:
+                try:
+                    conversation.close()
+                except Exception:
+                    pass
+            if temp_dir is not None:
+                temp_dir.cleanup()
+
+    async def run_async(
+        self,
+        task: str,
+        context_type: str = "ephemeral",
+        context_id: str | None = None,
+        workspace: str | None = None,
+        use_tools: bool | None = None,
+        **kwargs: Any,
+    ) -> dict[str, Any]:
+        return await asyncio.to_thread(
+            self.run,
+            task,
+            context_type,
+            context_id,
+            workspace,
+            use_tools,
+            **kwargs,
+        )

--- a/agent_service/openhands/software_engineer.py
+++ b/agent_service/openhands/software_engineer.py
@@ -49,11 +49,13 @@ except ImportError:
 from agent_service.shared.agents_md_loader import compose_agent_context
 from agent_service.shared.llm import LLM, AzureLLM
 
+PROGRESS_IMPORT_ERROR: Exception | None = None
 try:
     from .progress import create_heartbeat_callback, create_progress_callback
-except Exception:
+except Exception as exc:
     create_progress_callback = None  # type: ignore[assignment]
     create_heartbeat_callback = None  # type: ignore[assignment]
+    PROGRESS_IMPORT_ERROR = exc
 
 from .utils import build_condenser, get_prompt_path
 
@@ -1102,7 +1104,10 @@ class OpenHandsSoftwareEngineer:
             progress_url = kwargs.get("progress_url")
             if progress_url:
                 if create_progress_callback is None:
-                    print("[SoftwareEngineer] Progress callback unavailable")
+                    print(
+                        "[SoftwareEngineer] Progress callback unavailable: "
+                        f"{PROGRESS_IMPORT_ERROR!r}"
+                    )
                 else:
                     progress_cb = create_progress_callback(
                         progress_url=progress_url,
@@ -1113,7 +1118,10 @@ class OpenHandsSoftwareEngineer:
                     agent_callbacks.append(progress_cb)
             elif kwargs.get("progress_heartbeat"):
                 if create_heartbeat_callback is None:
-                    print("[SoftwareEngineer] Progress heartbeat unavailable")
+                    print(
+                        "[SoftwareEngineer] Progress heartbeat unavailable: "
+                        f"{PROGRESS_IMPORT_ERROR!r}"
+                    )
                 else:
                     agent_callbacks.append(
                         create_heartbeat_callback(on_progress=kwargs.get("progress_heartbeat"))

--- a/agent_service/openhands/software_engineer.py
+++ b/agent_service/openhands/software_engineer.py
@@ -16,13 +16,10 @@ Note: OpenHands SDK v1.2.1 uses:
 """
 
 import os
-import tempfile
-import threading
 import time
 from typing import Any
 
-from agent_service.config import SOFTWARE_ENGINEER_CONFIG, AgentConfig, get_mcp_config_dict
-from agent_service.sessions import get_or_create_session, get_session_store
+from agent_service.config import SOFTWARE_ENGINEER_CONFIG, AgentConfig
 from agent_service.shared.kubectl_tools import get_multi_namespace_context
 
 
@@ -31,33 +28,7 @@ def fetch_kubectl_context() -> str:
     return get_multi_namespace_context()
 
 
-try:
-    from openhands.sdk import Agent, LocalConversation, Tool
-    from openhands.tools.file_editor import FileEditorTool
-    from openhands.tools.terminal import TerminalTool
-
-    OPENHANDS_AVAILABLE = True
-
-except ImportError:
-    OPENHANDS_AVAILABLE = False
-    Agent = None
-    LocalConversation = None
-    Tool = None
-    TerminalTool = None
-    FileEditorTool = None
-
-from agent_service.shared.agents_md_loader import compose_agent_context
-from agent_service.shared.llm import LLM, AzureLLM
-
-PROGRESS_IMPORT_ERROR: Exception | None = None
-try:
-    from .progress import create_heartbeat_callback, create_progress_callback
-except Exception as exc:
-    create_progress_callback = None  # type: ignore[assignment]
-    create_heartbeat_callback = None  # type: ignore[assignment]
-    PROGRESS_IMPORT_ERROR = exc
-
-from .utils import build_condenser, get_prompt_path
+from .role_agent import OpenHandsRoleAgent
 
 # Fallback context if AGENTS.md files not found
 SOFTWARE_ENGINEER_CONTEXT_FALLBACK = """You are Alan, the Software Engineer for VibeTeam.
@@ -445,89 +416,19 @@ ITERATION_WARNING_THRESHOLDS = {50: "wrap_up", 75: "emergency", 100: "critical"}
 ITERATION_WARNING_THRESHOLDS_HANDOFF = {15: "wrap_up", 25: "emergency", 35: "critical"}
 
 
-def _inject_warning(conversation: Any, level: str) -> None:
-    """Inject a warning message into the conversation from a background thread.
+class OpenHandsSoftwareEngineer(OpenHandsRoleAgent):
+    """Software Engineer configured from AGENTS.md + shared role engine."""
 
-    Uses conversation.send_message() which acquires the state lock. Since callbacks
-    fire inside the lock during agent.step(), we spawn a thread that blocks until
-    the current step releases the lock, then injects before the next step.
-    """
-    try:
-        msg = ITERATION_WARNINGS.get(level, "")
-        if msg:
-            print(f"[SoftwareEngineer] Injecting iteration warning: {level}")
-            conversation.send_message(msg)
-    except Exception as e:
-        print(f"[SoftwareEngineer] Warning injection failed ({level}): {e}")
-
-
-class OpenHandsSoftwareEngineer:
-    """
-    Software Engineer agent using OpenHands SDK.
-
-    Uses OpenHands' agentic loop with built-in tools for:
-    - Shell command execution
-    - File editing and creation
-    - Web browsing (optional)
-    """
-
-    def __init__(self, config: AgentConfig | None = None):
-        if not OPENHANDS_AVAILABLE:
-            raise ImportError("OpenHands SDK not installed. Run: pip install openhands-ai")
-
-        self.config = config or SOFTWARE_ENGINEER_CONFIG
-
-    def _create_llm(self) -> LLM:
-        """Create LLM with Azure configuration.
-
-        Uses AzureLLM which forces completion API since Azure OpenAI
-        doesn't support the Responses API endpoint.
-        """
-        model_name = self.config.llm.model or "gpt-5.2"
-        if not model_name.startswith("azure/"):
-            model_name = f"azure/{model_name}"
-
-        return AzureLLM(
-            model=model_name,
-            api_key=self.config.llm.api_key,
-            base_url=self.config.llm.api_base,
-            api_version=os.getenv("AZURE_API_VERSION", "2024-08-01-preview"),
-            max_output_tokens=4096,
-            timeout=300,  # 5 min per LLM call — prevents infinite hangs
-            num_retries=3,  # Retry transient failures (overall timeout is the safety net)
-        )
-
-    def _create_agent(self, llm: LLM, *, use_tools: bool = True) -> Agent:
-        """Create Agent with LLM and tools (MCP when available)."""
-        # Load agent context from AGENTS.md hierarchy
-        # Falls back to hardcoded context if files not found
-        agent_context = compose_agent_context(
-            "software_engineer", fallback_context=SOFTWARE_ENGINEER_CONTEXT_FALLBACK
-        )
-
-        agent_kwargs: dict[str, Any] = {
-            "llm": llm,
-            "condenser": build_condenser(llm),
-            # Use our custom template that renders agent_context into the system prompt.
-            # Without this, the default system_prompt.j2 ignores agent_context kwargs.
-            "system_prompt_filename": get_prompt_path(),
-            "system_prompt_kwargs": {
-                "agent_context": agent_context,
-            },
-        }
-
-        if use_tools:
-            mcp_config = get_mcp_config_dict(self.config.mcp_servers)
-            if mcp_config.get("mcpServers"):
-                agent_kwargs["mcp_config"] = mcp_config
-
-        return Agent(
-            tools=[
-                Tool(name=TerminalTool.name),
-                Tool(name=FileEditorTool.name),
-            ],
-            **agent_kwargs,
-        )
+    role = "software_engineer"
+    agent_label = "SoftwareEngineer"
+    default_config = SOFTWARE_ENGINEER_CONFIG
+    fallback_context = SOFTWARE_ENGINEER_CONTEXT_FALLBACK
+    include_workspace = True
+    force_tools = True
+    enable_mcp = True
+    iteration_warnings = ITERATION_WARNINGS
+    iteration_warning_thresholds = ITERATION_WARNING_THRESHOLDS
+    handoff_iteration_warning_thresholds = ITERATION_WARNING_THRESHOLDS_HANDOFF
 
     def _extract_repo_from_task(self, task: str, context_id: str | None = None) -> str:
         """Extract repo owner/name from task text or context_id."""
@@ -1011,212 +912,36 @@ class OpenHandsSoftwareEngineer:
         except Exception:
             return None
 
-    def run(
+    def postprocess_response(
         self,
+        response: str,
         task: str,
-        context_type: str = "ephemeral",
-        context_id: str | None = None,
-        workspace: str | None = None,
-        **kwargs: Any,
-    ) -> dict[str, Any]:
-        """
-        Run a task with the Software Engineer agent.
+        context_type: str,
+        context_id: str,
+        workspace_path: str,
+        use_tools: bool,
+        kwargs: dict[str, Any],
+    ) -> str:
+        del context_type, use_tools, kwargs
+        pr_required = self._task_requires_pr(task)
+        if not pr_required or self._response_has_pr(response):
+            return response
 
-        Args:
-            task: The task description
-            context_type: Type of context (issue, pr, slack, ephemeral)
-            context_id: ID for the context (issue number, PR number, etc.)
-            workspace: Working directory for the agent
+        repo = self._extract_repo_from_task(task, context_id)
+        auto_pr = self._attempt_auto_pr_for_no_output(task, repo, workspace_path)
+        if not auto_pr:
+            auto_pr = self._attempt_auto_pr_for_quota(task, repo, workspace_path)
+        if not auto_pr:
+            auto_pr = self._attempt_auto_pr_for_litellm_fetch(task, repo, workspace_path)
+        if not auto_pr:
+            return response
 
-        Returns:
-            dict with response, session_key, and metadata
-        """
-        import uuid
-
-        if context_id is None:
-            context_id = str(uuid.uuid4())[:8]
-
-        session = get_or_create_session(
-            framework="openhands",
-            role="software_engineer",
-            context_type=context_type,
-            context_id=context_id,
-        )
-
-        llm = self._create_llm()
-        use_tools = bool(kwargs.get("use_tools", True))
-        agent = self._create_agent(llm, use_tools=use_tools)
-
-        # Use provided workspace or create temporary one
-        temp_dir = None
-        if not workspace:
-            temp_dir = tempfile.TemporaryDirectory()
-            workspace_path = temp_dir.name
-        else:
-            workspace_path = workspace
-
-        try:
-            # Create iteration-counting callback that injects warnings at thresholds.
-            # The LLM cannot count its own tool calls, so we inject explicit messages
-            # at iterations 50, 75, and 100 to nudge it toward wrapping up and calling finish().
-            # For handoff tasks, use tighter thresholds (15/25/35) since the requesting
-            # agent is waiting for our response.
-            is_handoff_task = "[Handoff from" in task or "Previous response:" in task
-            thresholds = (
-                ITERATION_WARNING_THRESHOLDS_HANDOFF
-                if is_handoff_task
-                else ITERATION_WARNING_THRESHOLDS
-            )
-            if is_handoff_task:
-                print(
-                    "[SoftwareEngineer] Handoff task detected — using tighter iteration thresholds"
-                )
-            iteration_count = {"value": 0}  # mutable counter for closure
-            warnings_sent: set[str] = set()
-
-            def _count_iterations(event: Any) -> None:
-                """Callback fired on each event. Count ActionEvents (excluding FinishAction)."""
-                event_type = type(event).__name__
-                # Count action events (tool calls), not observations or messages
-                if "Action" in event_type and "Finish" not in event_type:
-                    iteration_count["value"] += 1
-                    count = iteration_count["value"]
-                    print(f"[SoftwareEngineer] Iteration count: {count}")
-
-                    # Check if we've hit a warning threshold
-                    level = thresholds.get(count)
-                    if level and level not in warnings_sent:
-                        warnings_sent.add(level)
-                        # Spawn background thread to inject warning via send_message().
-                        # send_message() acquires the state lock, which is held during
-                        # agent.step(). The thread blocks until the lock is released
-                        # (end of current step), then injects before the next step.
-                        t = threading.Thread(
-                            target=_inject_warning,
-                            args=(conversation, level),
-                            daemon=True,
-                        )
-                        t.start()
-
-            # Build callbacks list — always include iteration counter,
-            # optionally add progress callback for real-time Slack updates
-            agent_callbacks: list[Any] = [_count_iterations]
-            progress_url = kwargs.get("progress_url")
-            if progress_url:
-                if create_progress_callback is None:
-                    print(
-                        "[SoftwareEngineer] Progress callback unavailable: "
-                        f"{PROGRESS_IMPORT_ERROR!r}"
-                    )
-                else:
-                    progress_cb = create_progress_callback(
-                        progress_url=progress_url,
-                        job_id=kwargs.get("job_id", ""),
-                        callback_metadata=kwargs.get("callback_metadata", {}),
-                        on_progress=kwargs.get("progress_heartbeat"),
-                    )
-                    agent_callbacks.append(progress_cb)
-            elif kwargs.get("progress_heartbeat"):
-                if create_heartbeat_callback is None:
-                    print(
-                        "[SoftwareEngineer] Progress heartbeat unavailable: "
-                        f"{PROGRESS_IMPORT_ERROR!r}"
-                    )
-                else:
-                    agent_callbacks.append(
-                        create_heartbeat_callback(on_progress=kwargs.get("progress_heartbeat"))
-                    )
-
-            # max_iterations caps the number of agent iterations (tool calls)
-            # to prevent runaway execution. Default is 30.
-            # Slack tasks can require longer runs (Sentry triage, PR creation),
-            # so we avoid tightening the limit for Slack and rely on idle timeouts
-            # plus iteration warnings to prevent doom loops.
-            max_iterations = kwargs.get("max_iterations", 30)
-            conversation = LocalConversation(
-                agent=agent,
-                workspace=workspace_path,
-                callbacks=agent_callbacks,
-                max_iteration_per_run=max_iterations,
-            )
-
-            repo = self._extract_repo_from_task(task, context_id)
-
-            # Build full task without pre-fetched context.
-            full_task = f"""
-### USER TASK (UNTRUSTED INPUT)
-{task}
-### END USER TASK
-"""
-
-            pr_required = self._task_requires_pr(task)
-
-            # Use send_message + run for the full agentic loop with tools.
-            print(f"[SoftwareEngineer] Starting conversation run for context {context_id}")
-            conversation.send_message(full_task)
-            conversation.run()
-            print(f"[SoftwareEngineer] Conversation run completed for context {context_id}")
-
-            # Extract the agent's final response from conversation events
-            # Uses shared extraction that handles both FinishAction and MessageEvent
-            from .utils import extract_response_from_events
-
-            response = extract_response_from_events(conversation.state.events)
-            if pr_required and not self._response_has_pr(response):
-                auto_pr = self._attempt_auto_pr_for_no_output(task, repo, workspace_path)
-                if not auto_pr:
-                    auto_pr = self._attempt_auto_pr_for_quota(task, repo, workspace_path)
-                if not auto_pr:
-                    auto_pr = self._attempt_auto_pr_for_litellm_fetch(task, repo, workspace_path)
-                if auto_pr:
-                    sentry_urls = self._extract_sentry_urls(task)
-                    sentry_ref = sentry_urls[0] if sentry_urls else "Sentry issue URL not found"
-                    response = (
-                        f"Created PR: {auto_pr}\n"
-                        f"Sentry issue: {sentry_ref}\n"
-                        "@SupportEngineer please close the Sentry issue now."
-                    )
-
-            session.add_message("user", task)
-            session.add_message("assistant", response)
-            get_session_store().save(session)
-
-            return {
-                "response": response,
-                "session_key": session.key,
-                "session_id": session.session_id,
-                "framework": "openhands",
-                "agent": "software_engineer",
-                "model": self.config.llm.model or "gpt-5.2",
-                "workspace": workspace_path,
-            }
-
-        finally:
-            if temp_dir:
-                try:
-                    conversation.close()
-                except Exception:
-                    pass
-                temp_dir.cleanup()
-
-    async def run_async(
-        self,
-        task: str,
-        context_type: str = "ephemeral",
-        context_id: str | None = None,
-        workspace: str | None = None,
-        **kwargs: Any,
-    ) -> dict[str, Any]:
-        """Async version of run."""
-        import asyncio
-
-        return await asyncio.to_thread(
-            self.run,
-            task,
-            context_type,
-            context_id,
-            workspace,
-            **kwargs,
+        sentry_urls = self._extract_sentry_urls(task)
+        sentry_ref = sentry_urls[0] if sentry_urls else "Sentry issue URL not found"
+        return (
+            f"Created PR: {auto_pr}\n"
+            f"Sentry issue: {sentry_ref}\n"
+            "@SupportEngineer please close the Sentry issue now."
         )
 
 

--- a/agent_service/openhands/support_engineer.py
+++ b/agent_service/openhands/support_engineer.py
@@ -36,11 +36,13 @@ from agent_service.shared.kubectl_tools import (
 from agent_service.shared.langfuse_tools import get_langfuse_context
 from agent_service.shared.sentry_tools import SentryClient, get_sentry_context
 
+PROGRESS_IMPORT_ERROR: Exception | None = None
 try:
     from .progress import create_heartbeat_callback, create_progress_callback
-except Exception:
+except Exception as exc:
     create_progress_callback = None  # type: ignore[assignment]
     create_heartbeat_callback = None  # type: ignore[assignment]
+    PROGRESS_IMPORT_ERROR = exc
 
 
 def fetch_sentry_context(
@@ -803,14 +805,20 @@ class OpenHandsSupportEngineer:
                     )
                     callbacks.append(progress_cb)
                 else:
-                    print("[SupportEngineer] Progress callback unavailable")
+                    print(
+                        "[SupportEngineer] Progress callback unavailable: "
+                        f"{PROGRESS_IMPORT_ERROR!r}"
+                    )
             elif kwargs.get("progress_heartbeat"):
                 if create_heartbeat_callback is not None:
                     callbacks.append(
                         create_heartbeat_callback(on_progress=kwargs.get("progress_heartbeat"))
                     )
                 else:
-                    print("[SupportEngineer] Progress heartbeat unavailable")
+                    print(
+                        "[SupportEngineer] Progress heartbeat unavailable: "
+                        f"{PROGRESS_IMPORT_ERROR!r}"
+                    )
 
             # max_iterations caps the number of agent iterations (tool calls)
             # to prevent runaway execution. Default is 30.

--- a/agent_service/openhands/support_engineer.py
+++ b/agent_service/openhands/support_engineer.py
@@ -17,12 +17,10 @@ Note: OpenHands SDK v1.2.1 uses:
 
 import os
 import re
-import tempfile
 from dataclasses import dataclass
 from typing import Any
 
 from agent_service.config import SUPPORT_ENGINEER_CONFIG, AgentConfig
-from agent_service.sessions import get_or_create_session, get_session_store
 from agent_service.shared.calendar_tools import get_calendar_context
 from agent_service.shared.docs_tools import get_docs_context
 
@@ -529,25 +527,7 @@ def convert_numbered_lists_to_bullets(text: str) -> str:
     return re.sub(pattern, r"\1- ", text, flags=re.MULTILINE)
 
 
-try:
-    from openhands.sdk import Agent, LocalConversation, Tool
-    from openhands.tools.file_editor import FileEditorTool
-    from openhands.tools.terminal import TerminalTool
-
-    OPENHANDS_AVAILABLE = True
-
-except ImportError:
-    OPENHANDS_AVAILABLE = False
-    Agent = None
-    LocalConversation = None
-    Tool = None
-    TerminalTool = None
-    FileEditorTool = None
-
-from agent_service.shared.agents_md_loader import compose_agent_context
-from agent_service.shared.llm import LLM, AzureLLM
-
-from .utils import build_condenser, get_prompt_path
+from .role_agent import OpenHandsRoleAgent
 
 # Fallback context if AGENTS.md files not found
 SUPPORT_ENGINEER_CONTEXT_FALLBACK = """You are Grace, the Support Engineer for VibeTeam.
@@ -680,70 +660,111 @@ DO NOT try to use Slack/email tools. Your text response is automatically posted.
 """
 
 
-class OpenHandsSupportEngineer:
-    """
-    Support Engineer agent using OpenHands SDK.
+class OpenHandsSupportEngineer(OpenHandsRoleAgent):
+    """Support Engineer configured from AGENTS.md + shared role engine."""
 
-    Uses OpenHands' agentic loop for customer support tasks.
-    """
+    role = "support_engineer"
+    agent_label = "SupportEngineer"
+    default_config = SUPPORT_ENGINEER_CONFIG
+    fallback_context = SUPPORT_ENGINEER_CONTEXT_FALLBACK
+    include_workspace = False
 
-    def __init__(self, config: AgentConfig | None = None):
-        if not OPENHANDS_AVAILABLE:
-            raise ImportError("OpenHands SDK not installed. Run: pip install openhands-ai")
+    def _extra_llm_kwargs(self) -> dict[str, Any]:
+        return {
+            "reasoning_effort": "medium",
+            "extended_thinking_budget": 10000,
+        }
 
-        self.config = config or SUPPORT_ENGINEER_CONFIG
+    def build_task_prompt(self, task: str, use_tools: bool) -> str:
+        full_task = super().build_task_prompt(task, use_tools)
+        if not use_tools:
+            return convert_numbered_lists_to_bullets(full_task)
+        return full_task
 
-    def _create_llm(self) -> LLM:
-        """Create LLM with Azure configuration."""
-        model_name = self.config.llm.model or "gpt-5.2"
-        if not model_name.startswith("azure/"):
-            model_name = f"azure/{model_name}"
+    def postprocess_response(
+        self,
+        response: str,
+        task: str,
+        context_type: str,
+        context_id: str,
+        workspace_path: str,
+        use_tools: bool,
+        kwargs: dict[str, Any],
+    ) -> str:
+        del context_type, context_id, workspace_path, use_tools, kwargs
+        fallback_prefix = "I investigated but ran out of iterations before completing."
+        response_needs_fallback = not response.strip() or response.startswith(fallback_prefix)
+        if response_needs_fallback:
+            task_lower = task.lower()
+            is_explicit_investigation = any(
+                kw in task_lower
+                for kw in [
+                    "investigate",
+                    "check",
+                    "debug",
+                    "analyze",
+                    "why",
+                    "error",
+                    "fail",
+                ]
+            )
+            if is_explicit_investigation:
+                namespace = os.environ.get("VIBETEAM_NAMESPACE") or DEFAULT_NAMESPACE
+                response = _build_investigation_fallback(task, [], namespace)
 
-        return AzureLLM(
-            model=model_name,
-            api_key=self.config.llm.api_key,
-            base_url=self.config.llm.api_base,
-            api_version=os.getenv("AZURE_API_VERSION", "2024-08-01-preview"),
-            max_output_tokens=4096,
-            # Reduce reasoning overhead for faster responses in benchmark scenarios
-            reasoning_effort="medium",
-            extended_thinking_budget=10000,
-            timeout=300,  # 5 min per LLM call — prevents infinite hangs
-            num_retries=3,  # Retry transient failures (overall timeout is the safety net)
-        )
-
-    def _create_agent(self, llm: LLM, use_tools: bool = True) -> Agent:
-        """Create Agent with LLM and optionally tools.
-
-        Args:
-            llm: The LLM instance to use
-            use_tools: If True, include TerminalTool and FileEditorTool.
-                      If False, create agent without tools for direct responses.
-        """
-        tools = []
-        if use_tools:
-            tools = [
-                Tool(name=TerminalTool.name),
-                Tool(name=FileEditorTool.name),
+        task_lower = task.lower()
+        if any(
+            kw in task_lower
+            for kw in [
+                "gmail",
+                "inbox",
+                "sentry issues",
+                "stripe",
+                "webhook",
             ]
+        ):
+            response = re.sub(
+                r"[@/](ProductManager|MarketingManager|SupportEngineer|ReleaseEngineer|SoftwareEngineer)\b",
+                r"\1",
+                response,
+                flags=re.IGNORECASE,
+            )
 
-        # Load agent context from AGENTS.md hierarchy
-        # Falls back to hardcoded context if files not found
-        agent_context = compose_agent_context(
-            "support_engineer", fallback_context=SUPPORT_ENGINEER_CONTEXT_FALLBACK
+        pr_requested = _task_mentions_pr(task_lower)
+        is_notification = any(
+            kw in task_lower
+            for kw in [
+                "notify",
+                "announce",
+                "tell the team",
+                "tell the customer",
+                "confirm to",
+            ]
         )
+        is_explicit_investigation = any(
+            kw in task_lower
+            for kw in ["investigate", "check", "debug", "analyze", "why", "error", "fail"]
+        )
+        if is_notification and not is_explicit_investigation:
+            response = build_notification_message(task)
 
-        return Agent(
-            llm=llm,
-            tools=tools,
-            condenser=build_condenser(llm),
-            # Use our custom template that renders agent_context into the system prompt.
-            # Without this, the default system_prompt.j2 ignores agent_context kwargs.
-            system_prompt_filename=get_prompt_path(),
-            system_prompt_kwargs={
-                "agent_context": agent_context,
-            },
-        )
+        if pr_requested and not re.search(r"https?://github\.com/\S+/pull/\d+", task, re.IGNORECASE):
+            response = _build_pr_handoff_response(task)
+
+        if re.search(r"https?://github\.com/\S+/pull/\d+", task, re.IGNORECASE):
+            issue_ids = _extract_sentry_issue_ids(task)
+            pr_urls = _extract_pr_urls(task)
+            pr_url = pr_urls[0] if pr_urls else "PR link not found"
+            if issue_ids:
+                try:
+                    client = SentryClient(timeout=10.0)
+                    closed_id = issue_ids[0]
+                    client.resolve_issue(closed_id)
+                    response = f"Closed Sentry issue {closed_id}. PR: {pr_url}."
+                except Exception as exc:
+                    response = f"Sentry: failed to close issue ({exc}). PR: {pr_url}."
+
+        return response
 
     def run(
         self,
@@ -754,236 +775,12 @@ class OpenHandsSupportEngineer:
         use_tools: bool = True,
         **kwargs: Any,
     ) -> dict[str, Any]:
-        """
-        Run a task with the Support Engineer agent.
-
-        Args:
-            task: The task description
-            context_type: Type of context (issue, pr, slack, ephemeral)
-            context_id: ID for the context
-            workspace: Working directory for the agent
-            use_tools: If True, enable TerminalTool and FileEditorTool for agentic exploration.
-                      If False, disable tools for direct LLM responses (faster for analysis tasks).
-
-        Returns:
-            dict with response, session_key, and metadata
-        """
-        import uuid
-
-        if context_id is None:
-            context_id = str(uuid.uuid4())[:8]
-
-        session = get_or_create_session(
-            framework="openhands",
-            role="support_engineer",
+        return super().run(
+            task=task,
             context_type=context_type,
             context_id=context_id,
-        )
-
-        llm = self._create_llm()
-        agent = self._create_agent(llm, use_tools=use_tools)
-
-        # Use provided workspace or create temporary one
-        temp_dir = None
-        if not workspace:
-            temp_dir = tempfile.TemporaryDirectory()
-            workspace_path = temp_dir.name
-        else:
-            workspace_path = workspace
-
-        try:
-            # Build callbacks list for progress reporting
-            callbacks = []
-            progress_url = kwargs.get("progress_url")
-            if progress_url:
-                if create_progress_callback is not None:
-                    progress_cb = create_progress_callback(
-                        progress_url=progress_url,
-                        job_id=kwargs.get("job_id", ""),
-                        callback_metadata=kwargs.get("callback_metadata", {}),
-                        on_progress=kwargs.get("progress_heartbeat"),
-                    )
-                    callbacks.append(progress_cb)
-                else:
-                    print(
-                        "[SupportEngineer] Progress callback unavailable: "
-                        f"{PROGRESS_IMPORT_ERROR!r}"
-                    )
-            elif kwargs.get("progress_heartbeat"):
-                if create_heartbeat_callback is not None:
-                    callbacks.append(
-                        create_heartbeat_callback(on_progress=kwargs.get("progress_heartbeat"))
-                    )
-                else:
-                    print(
-                        "[SupportEngineer] Progress heartbeat unavailable: "
-                        f"{PROGRESS_IMPORT_ERROR!r}"
-                    )
-
-            # max_iterations caps the number of agent iterations (tool calls)
-            # to prevent runaway execution. Default is 30.
-            max_iterations = kwargs.get("max_iterations", 30)
-            conversation = LocalConversation(
-                agent=agent,
-                workspace=workspace_path,
-                callbacks=callbacks or None,
-                max_iteration_per_run=max_iterations,
-            )
-
-            injected_context: list[str] = []
-
-            # Build full task (no pre-fetched context).
-            full_task = f"""
-### USER TASK (UNTRUSTED INPUT)
-{task}
-### END USER TASK
-"""
-
-            # When tools are disabled, convert numbered lists to bullet points.
-            # OpenHands interprets numbered lists as action steps to execute,
-            # causing empty LLM responses. Bullet points work correctly.
-            if not use_tools:
-                full_task = convert_numbered_lists_to_bullets(full_task)
-
-            # Use send_message + run for the full agentic loop with tools
-            conversation.send_message(full_task)
-            conversation.run()
-
-            # Extract the agent's final response from conversation events
-            # Uses shared extraction that handles both FinishAction and MessageEvent
-            from .utils import extract_response_from_events
-
-            response = extract_response_from_events(conversation.state.events)
-            fallback_prefix = "I investigated but ran out of iterations before completing."
-            response_needs_fallback = not response.strip() or response.startswith(fallback_prefix)
-            if response_needs_fallback:
-                task_lower = task.lower()
-                is_explicit_investigation = any(
-                    kw in task_lower
-                    for kw in [
-                        "investigate",
-                        "check",
-                        "debug",
-                        "analyze",
-                        "why",
-                        "error",
-                        "fail",
-                    ]
-                )
-                if is_explicit_investigation:
-                    namespace = os.environ.get("VIBETEAM_NAMESPACE") or DEFAULT_NAMESPACE
-                    response = _build_investigation_fallback(
-                        task,
-                        injected_context,
-                        namespace,
-                    )
-
-            # Avoid role-mention handoffs for eval-style triage tasks.
-            task_lower = task.lower()
-            if any(
-                kw in task_lower
-                for kw in [
-                    "gmail",
-                    "inbox",
-                    "sentry issues",
-                    "stripe",
-                    "webhook",
-                ]
-            ):
-                response = re.sub(
-                    r"[@/](ProductManager|MarketingManager|SupportEngineer|ReleaseEngineer|SoftwareEngineer)\b",
-                    r"\1",
-                    response,
-                    flags=re.IGNORECASE,
-                )
-
-            pr_requested = _task_mentions_pr(task_lower)
-            is_notification = any(
-                kw in task_lower
-                for kw in [
-                    "notify",
-                    "announce",
-                    "tell the team",
-                    "tell the customer",
-                    "confirm to",
-                ]
-            )
-            is_explicit_investigation = any(
-                kw in task_lower
-                for kw in ["investigate", "check", "debug", "analyze", "why", "error", "fail"]
-            )
-            if is_notification and not is_explicit_investigation:
-                response = build_notification_message(task)
-
-            if pr_requested and not re.search(
-                r"https?://github\.com/\S+/pull/\d+", task, re.IGNORECASE
-            ):
-                # Keep PR request responses short and focused on a single issue + handoff.
-                response = _build_pr_handoff_response(task)
-
-            # Auto-close Sentry issue when a PR link is present in the task.
-            if re.search(r"https?://github\.com/\S+/pull/\d+", task, re.IGNORECASE):
-                issue_ids = _extract_sentry_issue_ids(task)
-                pr_urls = _extract_pr_urls(task)
-                pr_url = pr_urls[0] if pr_urls else "PR link not found"
-                if issue_ids:
-                    try:
-                        client = SentryClient(timeout=10.0)
-                        closed_id = issue_ids[0]
-                        client.resolve_issue(closed_id)
-                        response = f"Closed Sentry issue {closed_id}. PR: {pr_url}."
-                    except Exception as exc:
-                        response = f"Sentry: failed to close issue ({exc}). PR: {pr_url}."
-
-            session.add_message("user", task)
-            session.add_message("assistant", response)
-            get_session_store().save(session)
-
-            return {
-                "response": response,
-                "session_key": session.key,
-                "session_id": session.session_id,
-                "framework": "openhands",
-                "agent": "support_engineer",
-                "model": self.config.llm.model or "gpt-5.2",
-            }
-
-        finally:
-            if temp_dir:
-                try:
-                    conversation.close()
-                except Exception:
-                    pass
-                temp_dir.cleanup()
-
-    async def run_async(
-        self,
-        task: str,
-        context_type: str = "ephemeral",
-        context_id: str | None = None,
-        workspace: str | None = None,
-        use_tools: bool = True,
-        **kwargs: Any,
-    ) -> dict[str, Any]:
-        """Async version of run.
-
-        Args:
-            task: The task description
-            context_type: Type of context (issue, pr, slack, ephemeral)
-            context_id: ID for the context
-            workspace: Working directory for the agent
-            use_tools: If True, enable tools for agentic exploration.
-                      If False, disable tools for direct LLM responses.
-        """
-        import asyncio
-
-        return await asyncio.to_thread(
-            self.run,
-            task,
-            context_type,
-            context_id,
-            workspace,
-            use_tools,
+            workspace=workspace,
+            use_tools=use_tools,
             **kwargs,
         )
 

--- a/tests/test_system_prompt.py
+++ b/tests/test_system_prompt.py
@@ -22,6 +22,17 @@ PROMPTS_DIR = os.path.join(
     "prompts",
 )
 TEMPLATE_PATH = os.path.join(PROMPTS_DIR, "agent_system.j2")
+OPENHANDS_DIR = os.path.join(
+    os.path.dirname(__file__),
+    os.pardir,
+    "agent_service",
+    "openhands",
+)
+ROLE_BASE_AGENTS = {
+    "release_engineer.py",
+    "software_engineer.py",
+    "support_engineer.py",
+}
 
 
 class TestTemplateExists:
@@ -78,36 +89,31 @@ class TestAgentPromptFilenameConstruction:
         "product_manager.py",
     ]
 
+    @staticmethod
+    def _read_openhands_source(filename: str) -> str:
+        with open(os.path.join(OPENHANDS_DIR, filename)) as f:
+            return f.read()
+
     @pytest.mark.parametrize("agent_file", AGENT_FILES)
     def test_agent_has_system_prompt_filename(self, agent_file: str):
-        """Each agent must set system_prompt_filename in _create_agent."""
-        filepath = os.path.join(
-            os.path.dirname(__file__),
-            os.pardir,
-            "agent_service",
-            "openhands",
-            agent_file,
-        )
-        with open(filepath) as f:
-            content = f.read()
-
-        assert "system_prompt_filename" in content, (
-            f"{agent_file} does not set system_prompt_filename"
-        )
+        """Agents may set system prompt config directly or via shared role base."""
+        content = self._read_openhands_source(agent_file)
+        if agent_file in ROLE_BASE_AGENTS:
+            role_base = self._read_openhands_source("role_agent.py")
+            assert "OpenHandsRoleAgent" in content
+            assert "system_prompt_filename" in role_base
+            return
+        assert "system_prompt_filename" in content, f"{agent_file} does not set system_prompt_filename"
 
     @pytest.mark.parametrize("agent_file", AGENT_FILES)
     def test_agent_uses_correct_template_path(self, agent_file: str):
-        """Each agent must reference prompts/agent_system.j2."""
-        filepath = os.path.join(
-            os.path.dirname(__file__),
-            os.pardir,
-            "agent_service",
-            "openhands",
-            agent_file,
-        )
-        with open(filepath) as f:
-            content = f.read()
-
+        """Agents may reference get_prompt_path directly or through shared role base."""
+        content = self._read_openhands_source(agent_file)
+        if agent_file in ROLE_BASE_AGENTS:
+            role_base = self._read_openhands_source("role_agent.py")
+            assert "OpenHandsRoleAgent" in content
+            assert "get_prompt_path" in role_base
+            return
         assert "get_prompt_path" in content, (
             f"{agent_file} should use get_prompt_path() from utils for git-sync compatible path resolution"
         )
@@ -128,16 +134,14 @@ class TestAgentPromptFilenameConstruction:
 
     @pytest.mark.parametrize("agent_file", AGENT_FILES)
     def test_agent_has_system_prompt_kwargs(self, agent_file: str):
-        """Each agent must also set system_prompt_kwargs with agent_context."""
-        filepath = os.path.join(
-            os.path.dirname(__file__),
-            os.pardir,
-            "agent_service",
-            "openhands",
-            agent_file,
-        )
-        with open(filepath) as f:
-            content = f.read()
+        """Agents may set prompt kwargs directly or inherit them from shared base."""
+        content = self._read_openhands_source(agent_file)
+        if agent_file in ROLE_BASE_AGENTS:
+            role_base = self._read_openhands_source("role_agent.py")
+            assert "OpenHandsRoleAgent" in content
+            assert "system_prompt_kwargs" in role_base
+            assert '"agent_context"' in role_base
+            return
 
         assert "system_prompt_kwargs" in content, f"{agent_file} does not set system_prompt_kwargs"
         assert '"agent_context"' in content, (
@@ -572,6 +576,11 @@ class TestSoftwareEngineerIterationBudget:
             'SOFTWARE_ENGINEER_CONTEXT = """',
         )
 
+    @staticmethod
+    def _read_role_agent_source() -> str:
+        with open(os.path.join(OPENHANDS_DIR, "role_agent.py")) as f:
+            return f.read()
+
     def test_has_final_reminder_section(self):
         """Prompt must have a FINAL REMINDER section near the end."""
         content = self._read_swe_context()
@@ -655,9 +664,7 @@ class TestSoftwareEngineerIterationBudget:
 
     def test_no_explicit_max_iteration_per_run(self):
         """max_iteration_per_run should be set via kwargs, not hardcoded in the source."""
-        content = self._read_swe_context()
-        # The agent should read max_iterations from kwargs and pass to LocalConversation.
-        # It should NOT hardcode a specific value — the gateway controls the limit.
+        content = self._read_role_agent_source()
         assert "max_iterations" in content, (
             "SWE agent must read max_iterations from kwargs and pass to LocalConversation. "
             "This prevents runaway execution when asyncio.wait_for timeout cannot kill the thread."
@@ -679,38 +686,20 @@ class TestSoftwareEngineerIterationBudget:
         )
 
     def test_other_agents_no_explicit_max_iteration(self):
-        """SupportEngineer and ReleaseEngineer must use max_iterations from kwargs."""
-        # SupportEngineer — reads max_iterations from kwargs, passes to LocalConversation
-        se_filepath = os.path.join(
-            os.path.dirname(__file__),
-            os.pardir,
-            "agent_service",
-            "openhands",
-            "support_engineer.py",
-        )
-        with open(se_filepath) as f:
-            se_content = f.read()
-        assert "max_iterations" in se_content, (
-            "support_engineer.py must read max_iterations from kwargs. "
+        """Role agents must inherit max_iterations handling from shared base."""
+        role_base = self._read_role_agent_source()
+        assert "max_iterations" in role_base, (
+            "role_agent.py must read max_iterations from kwargs. "
             "asyncio.wait_for timeout cannot kill the agent thread; "
             "max_iteration_per_run is the real safety net."
         )
 
-        # ReleaseEngineer — reads max_iterations from kwargs, passes to LocalConversation
-        re_filepath = os.path.join(
-            os.path.dirname(__file__),
-            os.pardir,
-            "agent_service",
-            "openhands",
-            "release_engineer.py",
-        )
-        with open(re_filepath) as f:
+        with open(os.path.join(OPENHANDS_DIR, "support_engineer.py")) as f:
+            se_content = f.read()
+        with open(os.path.join(OPENHANDS_DIR, "release_engineer.py")) as f:
             re_content = f.read()
-        assert "max_iterations" in re_content, (
-            "release_engineer.py must read max_iterations from kwargs. "
-            "asyncio.wait_for timeout cannot kill the agent thread; "
-            "max_iteration_per_run is the real safety net."
-        )
+        assert "OpenHandsRoleAgent" in se_content
+        assert "OpenHandsRoleAgent" in re_content
 
     def test_has_forbidden_actions_section(self):
         """Prompt must have a FORBIDDEN ACTIONS section to prevent sequential file reading."""
@@ -848,29 +837,29 @@ class TestSoftwareEngineerIterationBudget:
         )
 
     def test_inject_warning_function_exists(self):
-        """_inject_warning function must exist at module level."""
-        content = self._read_swe_context()
-        assert "def _inject_warning(" in content, (
-            "_inject_warning function must be defined to inject warnings via send_message()"
+        """Shared role base must define warning injection helper."""
+        content = self._read_role_agent_source()
+        assert "def _inject_iteration_warning(" in content, (
+            "role_agent.py must define warning injection helper via send_message()"
         )
 
     def test_inject_warning_uses_send_message(self):
-        """_inject_warning must use conversation.send_message() to inject warnings."""
-        content = self._read_swe_context()
-        func_start = content.find("def _inject_warning(")
+        """Warning injection helper must use conversation.send_message()."""
+        content = self._read_role_agent_source()
+        func_start = content.find("def _inject_iteration_warning(")
         assert func_start != -1
         # Find next def at module level
-        next_def = content.find("\ndef ", func_start + 10)
+        next_def = content.find("\n    def ", func_start + 10)
         if next_def == -1:
             next_def = content.find("\nclass ", func_start + 10)
         func_body = content[func_start:next_def] if next_def != -1 else content[func_start:]
         assert "send_message" in func_body, (
-            "_inject_warning must call conversation.send_message() to inject warnings"
+            "_inject_iteration_warning must call conversation.send_message() to inject warnings"
         )
 
     def test_run_passes_callbacks_to_local_conversation(self):
-        """run() must pass callbacks=[_count_iterations] to LocalConversation."""
-        content = self._read_swe_context()
+        """Shared run() must pass callbacks to LocalConversation."""
+        content = self._read_role_agent_source()
         run_start = content.find("def run(")
         assert run_start != -1
         next_def = content.find("\n    def ", run_start + 10)
@@ -879,20 +868,21 @@ class TestSoftwareEngineerIterationBudget:
         assert "callbacks=" in run_body, "run() must pass callbacks parameter to LocalConversation"
 
     def test_run_has_iteration_counter(self):
-        """run() must create an iteration counter for the callback closure."""
-        content = self._read_swe_context()
-        run_start = content.find("def run(")
-        assert run_start != -1
-        next_def = content.find("\n    def ", run_start + 10)
-        run_body = content[run_start:next_def] if next_def != -1 else content[run_start:]
-
-        assert "iteration_count" in run_body, (
-            "run() must have an iteration counter for the callback"
+        """Shared iteration callback builder must maintain an iteration counter."""
+        content = self._read_role_agent_source()
+        callback_start = content.find("def _build_iteration_callbacks(")
+        assert callback_start != -1
+        next_def = content.find("\n    def ", callback_start + 10)
+        callback_body = (
+            content[callback_start:next_def] if next_def != -1 else content[callback_start:]
+        )
+        assert "iteration_count" in callback_body, (
+            "_build_iteration_callbacks() must have an iteration counter for callbacks"
         )
 
     def test_threading_import_exists(self):
         """threading module must be imported for background warning injection."""
-        content = self._read_swe_context()
+        content = self._read_role_agent_source()
         assert "import threading" in content, (
             "threading must be imported for spawning background warning threads"
         )
@@ -927,13 +917,14 @@ class TestSoftwareEngineerIterationBudget:
 
     def test_callback_spawns_background_thread(self):
         """The iteration callback must spawn a background thread for warning injection."""
-        content = self._read_swe_context()
-        run_start = content.find("def run(")
-        assert run_start != -1
-        next_def = content.find("\n    def ", run_start + 10)
-        run_body = content[run_start:next_def] if next_def != -1 else content[run_start:]
-
-        assert "threading.Thread" in run_body, (
+        content = self._read_role_agent_source()
+        callback_start = content.find("def _build_iteration_callbacks(")
+        assert callback_start != -1
+        next_def = content.find("\n    def ", callback_start + 10)
+        callback_body = (
+            content[callback_start:next_def] if next_def != -1 else content[callback_start:]
+        )
+        assert "threading.Thread" in callback_body, (
             "Callback must spawn a threading.Thread to call _inject_warning. "
             "send_message() acquires the state lock, so it must run in a separate thread."
         )
@@ -1043,8 +1034,17 @@ class TestAzureLLMConsolidation:
 
     @pytest.mark.parametrize("agent_file", ALL_AGENT_FILES)
     def test_agent_imports_from_shared_llm(self, agent_file: str):
-        """Every agent must import AzureLLM from agent_service.shared.llm."""
+        """Agents may import AzureLLM directly or through the shared role base."""
         content = self._read_agent(agent_file)
+        if agent_file in ROLE_BASE_AGENTS:
+            role_base = self._read_agent("role_agent.py")
+            assert "OpenHandsRoleAgent" in content
+            assert "from agent_service.shared.llm import" in role_base
+            assert (
+                "AzureLLM" in role_base.split("from agent_service.shared.llm import")[1].split("\n")[0]
+            )
+            return
+
         assert "from agent_service.shared.llm import" in content, (
             f"{agent_file} must import from agent_service.shared.llm, "
             f"not define its own AzureLLM or use base LLM"
@@ -1064,11 +1064,13 @@ class TestAzureLLMConsolidation:
 
     @pytest.mark.parametrize("agent_file", ALL_AGENT_FILES)
     def test_agent_create_llm_returns_azure_llm(self, agent_file: str):
-        """Every agent's _create_llm must return AzureLLM(), not LLM()."""
+        """_create_llm may live in the agent module or shared role base."""
         content = self._read_agent(agent_file)
+        if agent_file in ROLE_BASE_AGENTS:
+            content = self._read_agent("role_agent.py")
         # Find the _create_llm method body
         method_start = content.find("def _create_llm")
-        assert method_start != -1, f"{agent_file} must have a _create_llm method"
+        assert method_start != -1, f"{agent_file} must have access to a _create_llm method"
         # Find the next method or class definition
         next_def = content.find("\n    def ", method_start + 10)
         method_body = content[method_start:next_def] if next_def != -1 else content[method_start:]
@@ -1121,22 +1123,17 @@ class TestSoftwareEngineerFileEditorTool:
         )
 
     def test_create_agent_includes_file_editor_tool(self):
-        """_create_agent must include FileEditorTool in the tools list."""
-        content = self._read_swe_source()
-        # Find the _create_agent method
-        method_start = content.find("def _create_agent")
-        assert method_start != -1, "_create_agent method not found"
-        next_def = content.find("\n    def ", method_start + 10)
-        method_body = content[method_start:next_def] if next_def != -1 else content[method_start:]
+        """Shared role base must include FileEditorTool, SWE must force tool usage."""
+        swe_content = self._read_swe_source()
+        with open(os.path.join(OPENHANDS_DIR, "role_agent.py")) as f:
+            role_base = f.read()
 
-        assert "TerminalTool" in method_body, "_create_agent must include TerminalTool"
-        # Check only the tools=[...] portion, not the docstring
-        tools_start = method_body.find("tools=[")
-        assert tools_start != -1, "_create_agent must have a tools=[...] list"
-        tools_end = method_body.find("]", tools_start)
-        tools_section = method_body[tools_start : tools_end + 1]
-        assert "FileEditorTool" in tools_section, (
-            "_create_agent tools list must include FileEditorTool."
+        assert "force_tools = True" in swe_content, "SoftwareEngineer must force tools on"
+        assert "def _build_tools" in role_base
+        assert "TerminalTool" in role_base
+        assert "FileEditorTool" in role_base
+        assert '"tools": self._build_tools(use_tools)' in role_base, (
+            "Role base _create_agent must wire tools from _build_tools"
         )
 
     def test_phase1_mentions_orient_repo(self):


### PR DESCRIPTION
## Summary
- add `OpenHandsRoleAgent` shared engine for OpenHands role agents
- migrate support/release/software agents to inherit shared run lifecycle, LLM creation, prompt wiring, callbacks, and session handling
- keep role-specific behavior in subclasses (`build_task_prompt`, `postprocess_response`, warning thresholds, auto-PR fallbacks)
- update `tests/test_system_prompt.py` to validate shared-base architecture while preserving safety/LLM/tooling guarantees

## Validation
- `uv run ruff check agent_service/openhands/role_agent.py agent_service/openhands/support_engineer.py agent_service/openhands/software_engineer.py agent_service/openhands/release_engineer.py tests/test_system_prompt.py`
- `uv run pytest tests/test_system_prompt.py tests/test_async_callback.py tests/test_gateway_trigger.py tests/test_module_paths.py -q`
- Slack eval (pass): `uv run python scripts/eval_slack_e2e.py --scenario release_health_check --channel C0AATPSADB8 --timeout 600`

## Notes
- Support eval scenario `support_400_errors` still scores below threshold in dev environment (`InvestigationQuality` and `ResponseEfficiency`), with reports in `results/eval_reports/`.
