### PR TITLE
fix: keep KB ingestion confirmation responses concise

### DIFF
--- a/agent_service/openhands/support_engineer.py
+++ b/agent_service/openhands/support_engineer.py
@@ -520,14 +520,20 @@ def _compact_knowledgebase_ingestion_response(task: str, response: str) -> str:
     if not _is_knowledgebase_ingestion_task(task):
         return response
 
-    path_match = re.search(r"`(agents/shared/knowledgebase/[^`]+)`", task)
-    fact_match = re.search(r"`(KB_EVAL_FACT_[A-Za-z0-9_]+)\s*:\s*([^`]+)`", task)
+    # Prefer the first response line when the model already produced a concise
+    # KB confirmation and then appended unrelated diagnostics.
+    first_line = next((line.strip() for line in response.splitlines() if line.strip()), "")
+    if first_line and ("kb update" in first_line.lower() or "knowledgebase update" in first_line.lower()):
+        return first_line
+
+    path_match = re.search(r"`?(agents/shared/knowledgebase/\S+?)`?(?:\s|$)", task)
+    fact_match = re.search(r"`?(KB_EVAL_FACT_[A-Za-z0-9_]+)\s*:\s*([^`\n]+)`?", task)
     if not path_match or not fact_match:
-        return response
+        return first_line or response
 
     rel_path = path_match.group(1).strip()
     fact_key = fact_match.group(1).strip()
-    fact_value = fact_match.group(2).strip()
+    fact_value = fact_match.group(2).strip().rstrip(".")
     runtime_path = f"/app/{rel_path}" if not rel_path.startswith("/app/") else rel_path
 
     # If the agent clearly failed to perform the request, preserve the original response.

--- a/tests/test_support_engineer_kb_response.py
+++ b/tests/test_support_engineer_kb_response.py
@@ -24,13 +24,15 @@ def test_compacts_knowledgebase_ingestion_response() -> None:
         "the file path and fact key in your response."
     )
     noisy = (
-        "- Knowledgebase update done.\n"
-        "- Sentry findings: none.\n"
-        "- kubectl findings: unrelated details.\n"
+        "KB update: created `/app/agents/shared/knowledgebase/inbox/kb_eval_123.md` "
+        "with `KB_EVAL_FACT_123: cobalt-lotus-914` and rebuilt the docs index.\n\n"
+        "Sentry findings: none.\n"
+        "kubectl findings: unrelated details.\n"
     )
     compact = _compact_knowledgebase_ingestion_response(task, noisy)
 
-    assert "Knowledgebase update complete:" in compact
+    assert compact.startswith("KB update: created")
+    assert "\n" not in compact
     assert "`/app/agents/shared/knowledgebase/inbox/kb_eval_123.md`" in compact
     assert "`KB_EVAL_FACT_123: cobalt-lotus-914`" in compact
     assert "Sentry findings" not in compact


### PR DESCRIPTION
## Summary
- tighten KB-ingestion response compaction in `OpenHandsSupportEngineer`
- when the agent already outputs a concise KB update line, keep only that first line and drop unrelated trailing diagnostics
- broaden task parsing fallback and keep deterministic one-line confirmation behavior
- update unit test to validate single-line compaction behavior

## Validation
- `uv run python -m pytest tests/test_support_engineer_kb_response.py tests/test_agents_md_loader.py tests/test_docs_tools.py tests/test_openclaw_docs_context.py -v`

Follow-up to #328 / PR #329.