### PR TITLE
fix(eval): enforce assignment-first GitHub issue evaluation semantics

### DIFF
--- a/scripts/eval_github_e2e.py
+++ b/scripts/eval_github_e2e.py
@@ -26,6 +26,7 @@ import httpx
 
 DEFAULT_REPO = os.environ.get("GITHUB_TEST_REPO", "VibeTechnologies/vibeteam-eval-hello-world")
 DEFAULT_PR = int(os.environ.get("GITHUB_TEST_PR", "1"))
+DEFAULT_ISSUE_ASSIGNEE = os.environ.get("GITHUB_ISSUE_ASSIGNEE", "").strip()
 NATIVE_GITHUB_HANDOFF_MENTIONS = "@SoftwareEngineer @SupportEngineer"
 
 SCENARIOS = {
@@ -98,6 +99,16 @@ def _collect_bot_logins(items: Iterable[dict]) -> set[str]:
             if login:
                 logins.add(login)
     return logins
+
+
+def _build_issue_trigger_comment() -> str:
+    """Build issue trigger text using role mentions only (never app handles)."""
+    return (
+        "Triggering issue handoff + assignment check.\n"
+        "Please triage this issue and assign it to the SoftwareEngineer role owner.\n"
+        f"{NATIVE_GITHUB_HANDOFF_MENTIONS}\n"
+        "Do not @mention any GitHub App bot handle."
+    )
 
 
 def _wait_for_bot_authors(
@@ -208,6 +219,79 @@ def _fetch_issue_comments(
         response = client.get(url, headers=_headers(token), params=params)
         response.raise_for_status()
         return response.json()
+
+
+def _fetch_issue_assignees(owner: str, repo: str, number: int, token: str) -> list[str]:
+    url = f"https://api.github.com/repos/{owner}/{repo}/issues/{number}"
+    with httpx.Client(timeout=20.0) as client:
+        response = client.get(url, headers=_headers(token))
+        response.raise_for_status()
+        data = response.json()
+    assignees = data.get("assignees") or []
+    return [str(a.get("login")) for a in assignees if a.get("login")]
+
+
+def _pick_issue_assignee(bot_logins: set[str], preferred_assignee: str | None = None) -> str | None:
+    preferred = (preferred_assignee or "").strip()
+    if preferred:
+        return preferred
+    if not bot_logins:
+        return None
+    for login in sorted(bot_logins):
+        lowered = login.lower()
+        if "swe" in lowered or "software" in lowered:
+            return login
+    return sorted(bot_logins)[0]
+
+
+def _evaluate_issue_assignment(
+    owner: str,
+    repo: str,
+    token: str,
+    issue_number: int,
+    bot_logins: set[str],
+    preferred_assignee: str | None = None,
+    wait_seconds: int = 0,
+    poll_interval: int = 5,
+) -> dict:
+    target_assignee = _pick_issue_assignee(bot_logins, preferred_assignee)
+    issue_assignees: list[str] = []
+    assignment_error = ""
+    assignment_passed = False
+
+    if not target_assignee:
+        return {
+            "target_assignee": "n/a",
+            "issue_assignees": issue_assignees,
+            "assignment_passed": False,
+            "assignment_error": "No candidate assignee available (no bot author detected).",
+        }
+
+    deadline = time.time() + max(wait_seconds, 0)
+    try:
+        while True:
+            issue_assignees = _fetch_issue_assignees(owner, repo, issue_number, token)
+            assignment_passed = target_assignee in issue_assignees
+            if assignment_passed:
+                break
+            if time.time() >= deadline:
+                break
+            time.sleep(max(poll_interval, 1))
+
+        if not assignment_passed:
+            assignment_error = (
+                f"Expected assignee {target_assignee}, but current assignees are: "
+                f"{', '.join(issue_assignees) or 'n/a'}"
+            )
+    except Exception as exc:
+        assignment_error = str(exc)
+
+    return {
+        "target_assignee": target_assignee,
+        "issue_assignees": issue_assignees,
+        "assignment_passed": assignment_passed,
+        "assignment_error": assignment_error,
+    }
 
 
 def _create_discussion(owner: str, repo: str, token: str) -> tuple[int, str, str, datetime]:
@@ -331,43 +415,77 @@ def _create_pr_comment(owner: str, repo: str, token: str, pr_number: int, body: 
     return _parse_ts(data["created_at"])
 
 
-def _run_issue_handoff(owner: str, repo: str, token: str, timeout: int) -> dict:
+def _run_issue_handoff(
+    owner: str, repo: str, token: str, timeout: int, issue_assignee: str | None = None
+) -> dict:
     issue_number, issue_url, _ = _create_issue(owner, repo, token)
-    trigger_body = (
-        "Triggering handoff via issue comment.\n"
-        f"{NATIVE_GITHUB_HANDOFF_MENTIONS}"
-    )
+    trigger_body = _build_issue_trigger_comment()
     trigger_ts = _create_issue_comment(owner, repo, token, issue_number, trigger_body)
 
     def fetch() -> list[dict]:
         return _fetch_issue_comments(owner, repo, issue_number, token, since=trigger_ts)
 
     bot_logins = _wait_for_bot_authors(fetch, trigger_ts, 2, timeout)
+    assignment = _evaluate_issue_assignment(
+        owner,
+        repo,
+        token,
+        issue_number,
+        bot_logins,
+        issue_assignee,
+        wait_seconds=min(timeout, 60),
+    )
+
     return {
         "thread": issue_url,
         "bot_logins": sorted(bot_logins),
-        "passed": len(bot_logins) >= 2,
+        "target_assignee": assignment["target_assignee"],
+        "issue_assignees": assignment["issue_assignees"],
+        "assignment_passed": assignment["assignment_passed"],
+        "assignment_error": assignment["assignment_error"],
+        "passed": bool(bot_logins) and bool(assignment["assignment_passed"]),
     }
 
 
 def _run_issue_handoff_existing(
-    owner: str, repo: str, token: str, issue_number: int, timeout: int
+    owner: str,
+    repo: str,
+    token: str,
+    issue_number: int,
+    timeout: int,
+    issue_assignee: str | None = None,
+    post_trigger_comment: bool = False,
 ) -> dict:
     issue_url = f"https://github.com/{owner}/{repo}/issues/{issue_number}"
-    trigger_body = (
-        "Triggering handoff via issue comment.\n"
-        f"{NATIVE_GITHUB_HANDOFF_MENTIONS}"
+    if post_trigger_comment:
+        trigger_body = _build_issue_trigger_comment()
+        trigger_ts = _create_issue_comment(owner, repo, token, issue_number, trigger_body)
+
+        def fetch() -> list[dict]:
+            return _fetch_issue_comments(owner, repo, issue_number, token, since=trigger_ts)
+
+        bot_logins = _wait_for_bot_authors(fetch, trigger_ts, 2, timeout)
+    else:
+        comments = _fetch_issue_comments(owner, repo, issue_number, token, since=None)
+        bot_logins = _collect_bot_logins(comments)
+    assignment = _evaluate_issue_assignment(
+        owner,
+        repo,
+        token,
+        issue_number,
+        bot_logins,
+        issue_assignee,
+        wait_seconds=min(timeout, 60),
     )
-    trigger_ts = _create_issue_comment(owner, repo, token, issue_number, trigger_body)
 
-    def fetch() -> list[dict]:
-        return _fetch_issue_comments(owner, repo, issue_number, token, since=trigger_ts)
-
-    bot_logins = _wait_for_bot_authors(fetch, trigger_ts, 2, timeout)
     return {
         "thread": issue_url,
         "bot_logins": sorted(bot_logins),
-        "passed": len(bot_logins) >= 2,
+        "target_assignee": assignment["target_assignee"],
+        "issue_assignees": assignment["issue_assignees"],
+        "assignment_passed": assignment["assignment_passed"],
+        "assignment_error": assignment["assignment_error"],
+        "passed": bool(bot_logins) and bool(assignment["assignment_passed"]),
     }
 
 
@@ -439,27 +557,50 @@ def _run_pr_comment_handoff(owner: str, repo: str, token: str, pr_number: int, t
 
 
 def _run_issue_handoff_presence(
-    owner: str, repo: str, token: str, issue_number: int, timeout: int
+    owner: str,
+    repo: str,
+    token: str,
+    issue_number: int,
+    timeout: int,
+    issue_assignee: str | None = None,
+    post_trigger_comment: bool = False,
 ) -> dict:
     issue_url = f"https://github.com/{owner}/{repo}/issues/{issue_number}"
-    trigger_body = (
-        "Triggering issue handoff presence check.\n"
-        f"{NATIVE_GITHUB_HANDOFF_MENTIONS}"
-    )
-    trigger_ts = _create_issue_comment(owner, repo, token, issue_number, trigger_body)
+    if post_trigger_comment:
+        trigger_body = _build_issue_trigger_comment()
+        trigger_ts = _create_issue_comment(owner, repo, token, issue_number, trigger_body)
 
-    def fetch_recent() -> list[dict]:
-        return _fetch_issue_comments(owner, repo, issue_number, token, since=trigger_ts)
+        def fetch_recent() -> list[dict]:
+            return _fetch_issue_comments(owner, repo, issue_number, token, since=trigger_ts)
 
-    recent_bot_logins = _wait_for_bot_authors(fetch_recent, trigger_ts, 1, timeout)
-    all_bot_logins = _collect_bot_logins(
-        _fetch_issue_comments(owner, repo, issue_number, token, since=None)
+        recent_bot_logins = _wait_for_bot_authors(fetch_recent, trigger_ts, 1, timeout)
+        all_bot_logins = _collect_bot_logins(
+            _fetch_issue_comments(owner, repo, issue_number, token, since=None)
+        )
+    else:
+        all_bot_logins = _collect_bot_logins(
+            _fetch_issue_comments(owner, repo, issue_number, token, since=None)
+        )
+        recent_bot_logins = set(all_bot_logins)
+    assignment = _evaluate_issue_assignment(
+        owner,
+        repo,
+        token,
+        issue_number,
+        all_bot_logins,
+        issue_assignee,
+        wait_seconds=min(timeout, 60),
     )
-    passed = bool(recent_bot_logins) and len(all_bot_logins) >= 2
+
+    passed = bool(recent_bot_logins) and bool(assignment["assignment_passed"])
     return {
         "thread": issue_url,
         "bot_logins": sorted(all_bot_logins),
         "recent_bot_logins": sorted(recent_bot_logins),
+        "target_assignee": assignment["target_assignee"],
+        "issue_assignees": assignment["issue_assignees"],
+        "assignment_passed": assignment["assignment_passed"],
+        "assignment_error": assignment["assignment_error"],
         "passed": passed,
     }
 
@@ -491,16 +632,35 @@ def _run_pr_handoff_presence(
 
 
 def _run_issue_pr_handoff(
-    owner: str, repo: str, token: str, issue_number: int, pr_number: int, timeout: int
+    owner: str,
+    repo: str,
+    token: str,
+    issue_number: int,
+    pr_number: int,
+    timeout: int,
+    issue_assignee: str | None = None,
+    post_issue_trigger_comment: bool = False,
 ) -> dict:
     if issue_number:
         issue_results = _run_issue_handoff_presence(
-            owner, repo, token, issue_number, timeout
+            owner,
+            repo,
+            token,
+            issue_number,
+            timeout,
+            issue_assignee,
+            post_issue_trigger_comment,
         )
     else:
         created_issue_number, issue_url, _ = _create_issue(owner, repo, token)
         issue_results = _run_issue_handoff_presence(
-            owner, repo, token, created_issue_number, timeout
+            owner,
+            repo,
+            token,
+            created_issue_number,
+            timeout,
+            issue_assignee,
+            True,
         )
         issue_results["thread"] = issue_url
 
@@ -513,6 +673,10 @@ def _run_issue_pr_handoff(
     return {
         "thread": f"{issue_results.get('thread')} | {pr_results.get('thread')}",
         "bot_logins": combined_logins,
+        "target_assignee": issue_results.get("target_assignee", "n/a"),
+        "issue_assignees": issue_results.get("issue_assignees", []),
+        "assignment_passed": issue_results.get("assignment_passed", False),
+        "assignment_error": issue_results.get("assignment_error", ""),
         "passed": passed,
         "threads": {
             "issue": issue_results,
@@ -559,8 +723,16 @@ def _write_report(scenario: str, results: dict) -> str:
         f"**Thread:** {results.get('thread', 'n/a')}",
         f"**Passed:** {'✅' if results.get('passed') else '❌'}",
         f"**Bot authors:** {', '.join(results.get('bot_logins', [])) or 'n/a'}",
-        "",
     ]
+    if "assignment_passed" in results:
+        lines.append(f"**Issue assigned:** {'✅' if results.get('assignment_passed') else '❌'}")
+        lines.append(f"**Target assignee:** {results.get('target_assignee', 'n/a')}")
+        lines.append(
+            f"**Current assignees:** {', '.join(results.get('issue_assignees', [])) or 'n/a'}"
+        )
+    if results.get("assignment_error"):
+        lines.append(f"**Assignment error:** {results.get('assignment_error')}")
+    lines.append("")
     links = _collect_thread_links(results)
     lines.extend(
         [
@@ -599,9 +771,18 @@ def _write_report(scenario: str, results: dict) -> str:
                         "- Recent bot authors after trigger: "
                         f"{', '.join(thread_result.get('recent_bot_logins', [])) or 'n/a'}"
                     ),
-                    "",
                 ]
             )
+            if "assignment_passed" in thread_result:
+                lines.append(f"- Issue assigned: {'✅' if thread_result.get('assignment_passed') else '❌'}")
+                lines.append(f"- Target assignee: {thread_result.get('target_assignee', 'n/a')}")
+                lines.append(
+                    "- Current assignees: "
+                    f"{', '.join(thread_result.get('issue_assignees', [])) or 'n/a'}"
+                )
+            if thread_result.get("assignment_error"):
+                lines.append(f"- Assignment error: {thread_result.get('assignment_error')}")
+            lines.append("")
 
     os.makedirs("results/eval_reports", exist_ok=True)
     with open(filename, "w", encoding="utf-8") as handle:
@@ -615,6 +796,12 @@ def main() -> int:
     parser.add_argument("--scenario", choices=SCENARIOS.keys(), default="github_issue_handoff")
     parser.add_argument("--repo", default=DEFAULT_REPO)
     parser.add_argument("--pr", type=int, default=DEFAULT_PR)
+    parser.add_argument("--issue-assignee", default=DEFAULT_ISSUE_ASSIGNEE)
+    parser.add_argument(
+        "--post-trigger-comment",
+        action="store_true",
+        help="Post trigger mentions on existing issue threads (default: disabled for existing issues).",
+    )
     parser.add_argument("--timeout", type=int, default=600)
     parser.add_argument("--issue", type=int, default=0, help="Existing issue number to use")
     parser.add_argument(
@@ -642,13 +829,28 @@ def main() -> int:
         if scenario == "github_issue_handoff":
             if args.issue:
                 results = _run_issue_handoff_existing(
-                    owner, repo, token, args.issue, args.timeout
+                    owner,
+                    repo,
+                    token,
+                    args.issue,
+                    args.timeout,
+                    args.issue_assignee,
+                    args.post_trigger_comment,
                 )
             else:
-                results = _run_issue_handoff(owner, repo, token, args.timeout)
+                results = _run_issue_handoff(
+                    owner, repo, token, args.timeout, args.issue_assignee
+                )
         elif scenario == "github_issue_pr_handoff_github":
             results = _run_issue_pr_handoff(
-                owner, repo, token, args.issue, args.pr, args.timeout
+                owner,
+                repo,
+                token,
+                args.issue,
+                args.pr,
+                args.timeout,
+                args.issue_assignee,
+                args.post_trigger_comment,
             )
         elif scenario == "github_discussion_handoff":
             if args.discussion:
@@ -665,7 +867,15 @@ def main() -> int:
         report_path = _write_report(scenario, results)
         status = "PASSED" if results.get("passed") else "FAILED"
         print(
-            f"Scenario {scenario}: {status} - thread {results.get('thread')} | bots: {', '.join(results.get('bot_logins', [])) or 'n/a'}"
+            f"Scenario {scenario}: {status} - thread {results.get('thread')} | "
+            f"bots: {', '.join(results.get('bot_logins', [])) or 'n/a'}"
+            + (
+                " | "
+                f"assigned: {results.get('target_assignee', 'n/a')} "
+                f"({'ok' if results.get('assignment_passed') else 'missing'})"
+                if "assignment_passed" in results
+                else ""
+            )
         )
         print(f"Report saved: {report_path}")
         overall_passed = overall_passed and bool(results.get("passed"))

--- a/tests/test_eval_github_e2e.py
+++ b/tests/test_eval_github_e2e.py
@@ -1,64 +1,280 @@
 from __future__ import annotations
 
+from datetime import datetime, timezone
 from pathlib import Path
 
 from scripts import eval_github_e2e
 
 
-def test_run_issue_pr_handoff_uses_existing_issue(monkeypatch):
-    issue_called = {"presence": False}
+def test_issue_trigger_comment_uses_role_mentions_only():
+    trigger = eval_github_e2e._build_issue_trigger_comment()
+    assert "@SoftwareEngineer" in trigger
+    assert "@SupportEngineer" in trigger
+    assert "-bot" not in trigger
+    assert "[bot]" not in trigger
 
-    def fake_issue_presence(owner, repo, token, issue_number, timeout):
-        issue_called["presence"] = True
+
+def test_pick_issue_assignee_prefers_explicit_assignee():
+    bot_logins = {
+        "vibeteam-support-bot-260301[bot]",
+        "vibeteam-swe-bot-260301[bot]",
+    }
+    selected = eval_github_e2e._pick_issue_assignee(
+        bot_logins,
+        preferred_assignee="vibeteam-github-app[bot]",
+    )
+    assert selected == "vibeteam-github-app[bot]"
+
+
+def test_pick_issue_assignee_prefers_software_bot():
+    bot_logins = {
+        "vibeteam-support-bot-260301[bot]",
+        "vibeteam-swe-bot-260301[bot]",
+    }
+    selected = eval_github_e2e._pick_issue_assignee(bot_logins)
+    assert selected == "vibeteam-swe-bot-260301[bot]"
+
+
+def test_evaluate_issue_assignment_uses_existing_assignee(monkeypatch):
+    def fake_fetch_assignees(owner, repo, number, token):
+        return ["vibeteam-swe-bot-260301[bot]"]
+
+    monkeypatch.setattr(eval_github_e2e, "_fetch_issue_assignees", fake_fetch_assignees)
+
+    result = eval_github_e2e._evaluate_issue_assignment(
+        owner="VibeTechnologies",
+        repo="vibeteam-eval-hello-world",
+        token="token",
+        issue_number=92,
+        bot_logins={"vibeteam-swe-bot-260301[bot]"},
+    )
+
+    assert result["assignment_passed"] is True
+    assert result["target_assignee"] == "vibeteam-swe-bot-260301[bot]"
+    assert result["issue_assignees"] == ["vibeteam-swe-bot-260301[bot]"]
+
+
+def test_evaluate_issue_assignment_fails_when_assignee_not_present(monkeypatch):
+    def fake_fetch_assignees(owner, repo, number, token):
+        return ["some-other-user"]
+
+    monkeypatch.setattr(eval_github_e2e, "_fetch_issue_assignees", fake_fetch_assignees)
+
+    result = eval_github_e2e._evaluate_issue_assignment(
+        owner="VibeTechnologies",
+        repo="vibeteam-eval-hello-world",
+        token="token",
+        issue_number=92,
+        bot_logins={"vibeteam-swe-bot-260301[bot]"},
+    )
+
+    assert result["assignment_passed"] is False
+    assert result["target_assignee"] == "vibeteam-swe-bot-260301[bot]"
+    assert "Expected assignee vibeteam-swe-bot-260301[bot]" in result["assignment_error"]
+
+
+def test_run_issue_handoff_presence_requires_assignment(monkeypatch):
+    now = datetime.now(timezone.utc)
+
+    def fake_create_issue_comment(owner, repo, token, number, body):
+        return now
+
+    def fake_fetch_issue_comments(owner, repo, number, token, since=None):
+        return [
+            {
+                "created_at": now.isoformat().replace("+00:00", "Z"),
+                "user": {"login": "vibeteam-support-bot-260301[bot]", "type": "Bot"},
+            },
+            {
+                "created_at": now.isoformat().replace("+00:00", "Z"),
+                "user": {"login": "vibeteam-swe-bot-260301[bot]", "type": "Bot"},
+            },
+        ]
+
+    def fake_wait_for_bot_authors(fetch_comments, since, min_bots, timeout, poll_interval=10):
+        return {"vibeteam-support-bot-260301[bot]"}
+
+    def fake_assignment(*args, **kwargs):
         return {
-            "thread": "https://github.com/VibeTechnologies/vibeteam-eval-hello-world/issues/3",
-            "bot_logins": ["vibeteam-software-engineer-bot[bot]"],
+            "target_assignee": "vibeteam-swe-bot-260301[bot]",
+            "issue_assignees": [],
+            "assignment_passed": False,
+            "assignment_error": "assignment failed",
+        }
+
+    monkeypatch.setattr(eval_github_e2e, "_create_issue_comment", fake_create_issue_comment)
+    monkeypatch.setattr(eval_github_e2e, "_fetch_issue_comments", fake_fetch_issue_comments)
+    monkeypatch.setattr(eval_github_e2e, "_wait_for_bot_authors", fake_wait_for_bot_authors)
+    monkeypatch.setattr(eval_github_e2e, "_evaluate_issue_assignment", fake_assignment)
+
+    result = eval_github_e2e._run_issue_handoff_presence(
+        owner="VibeTechnologies",
+        repo="vibeteam-eval-hello-world",
+        token="token",
+        issue_number=92,
+        timeout=60,
+    )
+
+    assert result["passed"] is False
+    assert result["assignment_passed"] is False
+    assert result["target_assignee"] == "vibeteam-swe-bot-260301[bot]"
+
+
+def test_run_issue_handoff_presence_passes_with_assignment_and_recent_activity(monkeypatch):
+    now = datetime.now(timezone.utc)
+
+    def fake_create_issue_comment(owner, repo, token, number, body):
+        return now
+
+    def fake_fetch_issue_comments(owner, repo, number, token, since=None):
+        return [
+            {
+                "created_at": now.isoformat().replace("+00:00", "Z"),
+                "user": {"login": "vibeteam-support-bot-260301[bot]", "type": "Bot"},
+            }
+        ]
+
+    def fake_wait_for_bot_authors(fetch_comments, since, min_bots, timeout, poll_interval=10):
+        return {"vibeteam-support-bot-260301[bot]"}
+
+    def fake_assignment(*args, **kwargs):
+        return {
+            "target_assignee": "vibeteam-swe-bot-260301[bot]",
+            "issue_assignees": ["vibeteam-swe-bot-260301[bot]"],
+            "assignment_passed": True,
+            "assignment_error": "",
+        }
+
+    monkeypatch.setattr(eval_github_e2e, "_create_issue_comment", fake_create_issue_comment)
+    monkeypatch.setattr(eval_github_e2e, "_fetch_issue_comments", fake_fetch_issue_comments)
+    monkeypatch.setattr(eval_github_e2e, "_wait_for_bot_authors", fake_wait_for_bot_authors)
+    monkeypatch.setattr(eval_github_e2e, "_evaluate_issue_assignment", fake_assignment)
+
+    result = eval_github_e2e._run_issue_handoff_presence(
+        owner="VibeTechnologies",
+        repo="vibeteam-eval-hello-world",
+        token="token",
+        issue_number=92,
+        timeout=60,
+        post_trigger_comment=True,
+    )
+
+    assert result["assignment_passed"] is True
+    assert result["passed"] is True
+
+
+def test_run_issue_handoff_existing_skips_trigger_comment_by_default(monkeypatch):
+    def fail_create_issue_comment(*args, **kwargs):
+        raise AssertionError("trigger comment should not be posted for existing issue by default")
+
+    def fake_fetch_issue_comments(owner, repo, number, token, since=None):
+        return [
+            {
+                "created_at": datetime.now(timezone.utc).isoformat().replace("+00:00", "Z"),
+                "user": {"login": "vibeteam-support-bot-260301[bot]", "type": "Bot"},
+            },
+            {
+                "created_at": datetime.now(timezone.utc).isoformat().replace("+00:00", "Z"),
+                "user": {"login": "vibeteam-swe-bot-260301[bot]", "type": "Bot"},
+            },
+        ]
+
+    def fake_assignment(*args, **kwargs):
+        return {
+            "target_assignee": "vibeteam-swe-bot-260301[bot]",
+            "issue_assignees": ["vibeteam-swe-bot-260301[bot]"],
+            "assignment_passed": True,
+            "assignment_error": "",
+        }
+
+    monkeypatch.setattr(eval_github_e2e, "_create_issue_comment", fail_create_issue_comment)
+    monkeypatch.setattr(eval_github_e2e, "_fetch_issue_comments", fake_fetch_issue_comments)
+    monkeypatch.setattr(eval_github_e2e, "_evaluate_issue_assignment", fake_assignment)
+
+    result = eval_github_e2e._run_issue_handoff_existing(
+        owner="VibeTechnologies",
+        repo="vibeteam-eval-hello-world",
+        token="token",
+        issue_number=92,
+        timeout=60,
+    )
+
+    assert result["passed"] is True
+    assert result["assignment_passed"] is True
+
+
+def test_run_issue_pr_handoff_uses_existing_issue_and_passes_assignee(monkeypatch):
+    issue_called = {"presence": False, "assignee": None}
+
+    def fake_issue_presence(
+        owner, repo, token, issue_number, timeout, issue_assignee, post_trigger_comment
+    ):
+        issue_called["presence"] = True
+        issue_called["assignee"] = issue_assignee
+        assert post_trigger_comment is False
+        return {
+            "thread": "https://github.com/VibeTechnologies/vibeteam-eval-hello-world/issues/92",
+            "bot_logins": ["vibeteam-swe-bot-260301[bot]"],
+            "recent_bot_logins": ["vibeteam-swe-bot-260301[bot]"],
+            "target_assignee": issue_assignee,
+            "issue_assignees": [issue_assignee],
+            "assignment_passed": True,
+            "assignment_error": "",
             "passed": True,
         }
 
     def fake_pr_presence(owner, repo, token, pr_number, timeout):
         return {
             "thread": "https://github.com/VibeTechnologies/vibeteam-eval-hello-world/pull/1",
-            "bot_logins": ["vibeteam-support-engineer-bot[bot]"],
+            "bot_logins": ["vibeteam-support-bot-260301[bot]"],
+            "recent_bot_logins": ["vibeteam-support-bot-260301[bot]"],
             "passed": True,
         }
 
     monkeypatch.setattr(eval_github_e2e, "_run_issue_handoff_presence", fake_issue_presence)
     monkeypatch.setattr(eval_github_e2e, "_run_pr_handoff_presence", fake_pr_presence)
 
+    assignee = "vibeteam-swe-bot-260301[bot]"
     result = eval_github_e2e._run_issue_pr_handoff(
         "VibeTechnologies",
         "vibeteam-eval-hello-world",
         "token",
-        3,
+        92,
         1,
         60,
+        assignee,
     )
 
     assert issue_called["presence"] is True
+    assert issue_called["assignee"] == assignee
     assert result["passed"] is True
-    assert result["threads"]["issue"]["passed"] is True
+    assert result["threads"]["issue"]["assignment_passed"] is True
     assert result["threads"]["pr"]["passed"] is True
     assert result["bot_logins"] == [
-        "vibeteam-software-engineer-bot[bot]",
-        "vibeteam-support-engineer-bot[bot]",
+        "vibeteam-support-bot-260301[bot]",
+        "vibeteam-swe-bot-260301[bot]",
     ]
 
 
-def test_write_report_with_thread_details(tmp_path, monkeypatch):
+def test_write_report_with_thread_details_and_assignment(tmp_path, monkeypatch):
     monkeypatch.chdir(tmp_path)
-    issue_url = "https://github.com/VibeTechnologies/vibeteam-eval-hello-world/issues/3"
+    issue_url = "https://github.com/VibeTechnologies/vibeteam-eval-hello-world/issues/92"
     pr_url = "https://github.com/VibeTechnologies/vibeteam-eval-hello-world/pull/1"
+    assignee = "vibeteam-swe-bot-260301[bot]"
     results = {
         "thread": f"{issue_url} | {pr_url}",
         "passed": True,
-        "bot_logins": ["vibeteam-software-engineer-bot[bot]"],
+        "bot_logins": ["vibeteam-swe-bot-260301[bot]"],
         "threads": {
             "issue": {
                 "thread": issue_url,
                 "passed": True,
                 "bot_logins": ["bot-a"],
                 "recent_bot_logins": ["bot-a"],
+                "target_assignee": assignee,
+                "issue_assignees": [assignee],
+                "assignment_passed": True,
+                "assignment_error": "",
             },
             "pr": {
                 "thread": pr_url,
@@ -80,3 +296,5 @@ def test_write_report_with_thread_details(tmp_path, monkeypatch):
     assert f"- Thread: {issue_url}" in report
     assert f"- Thread: {pr_url}" in report
     assert "- Recent bot authors after trigger: bot-a" in report
+    assert "- Issue assigned: ✅" in report
+    assert f"- Target assignee: {assignee}" in report


### PR DESCRIPTION
## Summary
- make issue eval trigger text explicit about assignment validation and role mentions
- require issue scenarios to pass based on assignment + recent bot activity (instead of relying on multi-bot mention patterns)
- add tests to assert trigger text contains only role mentions (no bot-handle patterns) and that assignment drives pass criteria

## Why
The requirement is: GitHub issue evaluation should validate assignment behavior and must not rely on `@githubapphandle` mentions.

## Validation
- `uv run python -m pytest tests/test_eval_github_e2e.py -v`
- live eval:
  - `uv run python scripts/eval_github_e2e.py --scenario github_issue_handoff --repo VibeTechnologies/vibeteam-eval-hello-world --issue 92 --post-trigger-comment --timeout 180`
  - `uv run python scripts/eval_github_e2e.py --scenario github_issue_pr_handoff_github --repo VibeTechnologies/vibeteam-eval-hello-world --issue 92 --pr 1 --post-trigger-comment --timeout 240`
- both scenarios passed