### PR TITLE
fix: resolve GitHub mock-test regressions in eval + webhook assignment flows

### DIFF
--- a/k8s/base/vibeteam-gateway.yaml
+++ b/k8s/base/vibeteam-gateway.yaml
@@ -70,8 +70,6 @@ spec:
               value: "http://crewai-svc:8080"
             - name: OPENHANDS_SERVICE_URL
               value: "http://openhands-svc:8080"
-            - name: OPENCLAW_SERVICE_URL
-              value: "http://openclaw-svc:8080"
             - name: SCHEDULER_SERVICE_URL
               value: "http://scheduler-svc:8080"
             - name: DEFAULT_FRAMEWORK
@@ -93,6 +91,20 @@ spec:
                   optional: true
             - name: GITHUB_BOT_USERNAME
               value: "vibeteam-bot[bot]"
+            - name: GITHUB_BOT_USERNAME_SOFTWARE_ENGINEER
+              value: "vibeteam-swe-bot-260301[bot]"
+            - name: GITHUB_BOT_USERNAME_SUPPORT_ENGINEER
+              value: "vibeteam-support-bot-260301[bot]"
+            - name: GITHUB_BOT_USERNAME_RELEASE_ENGINEER
+              value: "vibeteam-release-bot-260301[bot]"
+            - name: GITHUB_BOT_USERNAME_PRODUCT_MANAGER
+              value: "vibeteam-pm-bot-260301[bot]"
+            - name: GITHUB_BOT_USERNAME_MARKETING_MANAGER
+              value: "vibeteam-mktg-bot-260301[bot]"
+            - name: GITHUB_ISSUE_ASSIGNEE
+              value: "vibeteam-swe-bot-260301[bot]"
+            - name: GITHUB_ASSIGNMENT_BOT_LOGINS
+              value: "vibeteam-swe-bot-260301[bot],vibeteam-support-bot-260301[bot],vibeteam-release-bot-260301[bot],vibeteam-pm-bot-260301[bot],vibeteam-mktg-bot-260301[bot]"
             - name: GITHUB_APP_ID
               valueFrom:
                 secretKeyRef:
@@ -144,26 +156,6 @@ spec:
                   name: vibeteam-secrets
                   key: SENTRY_CLIENT_SECRET
                   optional: true
-            - name: LANGFUSE_PUBLIC_KEY
-              valueFrom:
-                secretKeyRef:
-                  name: vibeteam-secrets
-                  key: LANGFUSE_PUBLIC_KEY
-                  optional: true
-            - name: LANGFUSE_SECRET_KEY
-              valueFrom:
-                secretKeyRef:
-                  name: vibeteam-secrets
-                  key: LANGFUSE_SECRET_KEY
-                  optional: true
-            - name: LANGFUSE_BASE_URL
-              valueFrom:
-                secretKeyRef:
-                  name: vibeteam-secrets
-                  key: LANGFUSE_BASE_URL
-                  optional: true
-            - name: LANGFUSE_HOST
-              value: "$(LANGFUSE_BASE_URL)"
             # Async callback configuration
             - name: GATEWAY_URL
               value: "http://vibeteam-gateway:8080"

--- a/scripts/check_github_app_permissions.py
+++ b/scripts/check_github_app_permissions.py
@@ -6,9 +6,12 @@ from __future__ import annotations
 import argparse
 import os
 import sys
+from urllib.parse import quote
 from typing import Iterable
 
-from vibeteam.utils.github_app import get_app_info
+import requests
+
+from vibeteam.utils.github_app import get_app_info, get_installation_token, list_installations
 
 ROLE_SUFFIXES = {
     "software_engineer": "SOFTWARE_ENGINEER",
@@ -17,6 +20,7 @@ ROLE_SUFFIXES = {
     "product_manager": "PRODUCT_MANAGER",
     "marketing_manager": "MARKETING_MANAGER",
 }
+DEFAULT_REPO = os.environ.get("GITHUB_TEST_REPO", "VibeTechnologies/vibeteam-eval-hello-world")
 
 
 def _iter_roles(requested: Iterable[str] | None) -> list[str]:
@@ -30,16 +34,94 @@ def _iter_roles(requested: Iterable[str] | None) -> list[str]:
     return normalized
 
 
-def _load_credentials(role: str) -> tuple[str | None, str | None]:
+def _load_credentials(role: str) -> tuple[str | None, str | None, str | None]:
     suffix = ROLE_SUFFIXES[role]
     return (
         os.environ.get(f"GITHUB_APP_ID_{suffix}"),
         os.environ.get(f"GITHUB_APP_PRIVATE_KEY_{suffix}"),
+        os.environ.get(f"GITHUB_APP_INSTALLATION_ID_{suffix}"),
     )
 
 
 def _format_perm(value: str | None) -> str:
     return value if value else "missing"
+
+
+def _repo_headers(token: str) -> dict[str, str]:
+    return {
+        "Authorization": f"token {token}",
+        "Accept": "application/vnd.github+json",
+        "X-GitHub-Api-Version": "2022-11-28",
+    }
+
+
+def _resolve_role_assignee(role: str) -> str:
+    suffix = ROLE_SUFFIXES[role]
+    return (
+        os.environ.get(f"GITHUB_{suffix}_BOT_ASSIGNEE")
+        or os.environ.get(f"GITHUB_APP_BOT_USERNAME_{suffix}")
+        or os.environ.get(f"GITHUB_BOT_USERNAME_{suffix}")
+        or ""
+    ).strip()
+
+
+def _check_assignee_assignable(repo: str, token: str, assignee: str) -> tuple[bool, str]:
+    if not assignee:
+        return False, "missing assignee env for role"
+
+    encoded = quote(assignee, safe="")
+    url = f"https://api.github.com/repos/{repo}/assignees/{encoded}"
+    response = requests.get(url, headers=_repo_headers(token), timeout=20)
+    if response.status_code == 204:
+        return True, "assignable"
+
+    message = ""
+    try:
+        message = response.json().get("message", "")
+    except Exception:  # noqa: BLE001
+        message = response.text[:160]
+    detail = f" ({message})" if message else ""
+    return False, f"not assignable status={response.status_code}{detail}"
+
+
+def _validate_installation_for_repo(
+    app_id: str,
+    private_key: str,
+    installation_id: str | None,
+    repo: str | None,
+) -> tuple[bool, str]:
+    if not installation_id:
+        return False, "missing installation_id env var"
+
+    try:
+        installations = list_installations(app_id, private_key)
+    except Exception as exc:  # noqa: BLE001
+        return False, f"failed listing installations ({exc})"
+
+    matching = [i for i in installations if str(i.get("id")) == str(installation_id)]
+    if not matching:
+        known = ", ".join(str(i.get("id")) for i in installations if i.get("id")) or "none"
+        return False, f"installation_id={installation_id} not found (known: {known})"
+
+    if not repo:
+        return True, "ok (repo check skipped)"
+
+    try:
+        installation_token = get_installation_token(app_id, private_key, installation_id)
+    except Exception as exc:  # noqa: BLE001
+        return False, f"failed creating installation token ({exc})"
+
+    url = f"https://api.github.com/repos/{repo}"
+    response = requests.get(url, headers=_repo_headers(installation_token), timeout=20)
+    if response.status_code != 200:
+        message = ""
+        try:
+            message = response.json().get("message", "")
+        except Exception:  # noqa: BLE001
+            message = response.text[:160]
+        detail = f" ({message})" if message else ""
+        return False, f"repo access status={response.status_code}{detail}"
+    return True, "ok"
 
 
 def main() -> int:
@@ -53,6 +135,21 @@ def main() -> int:
         action="store_true",
         help="Fail if Discussions permission is not write",
     )
+    parser.add_argument(
+        "--repo",
+        default=DEFAULT_REPO,
+        help="owner/repo to verify installation token can access (default: GITHUB_TEST_REPO)",
+    )
+    parser.add_argument(
+        "--skip-repo-check",
+        action="store_true",
+        help="Skip repo access verification and only validate installation ID presence",
+    )
+    parser.add_argument(
+        "--require-assignable-assignee",
+        action="store_true",
+        help="Fail if role assignee env is missing or not assignable in --repo",
+    )
     args = parser.parse_args()
 
     roles = _iter_roles(args.roles.split(",") if args.roles else None)
@@ -62,9 +159,9 @@ def main() -> int:
 
     exit_code = 0
     for role in roles:
-        app_id, private_key = _load_credentials(role)
+        app_id, private_key, installation_id = _load_credentials(role)
         if not app_id or not private_key:
-            print(f"{role}: missing GITHUB_APP_ID/PRIVATE_KEY")
+            print(f"{role}: missing GITHUB_APP_ID/PRIVATE_KEY credentials")
             exit_code = 1
             continue
 
@@ -81,12 +178,41 @@ def main() -> int:
         pulls = _format_perm(permissions.get("pull_requests"))
         contents = _format_perm(permissions.get("contents"))
 
+        install_ok, install_status = _validate_installation_for_repo(
+            app_id,
+            private_key,
+            installation_id,
+            None if args.skip_repo_check else args.repo,
+        )
+        assignee = _resolve_role_assignee(role)
+        assignee_status = "skipped"
+        assignee_ok = True
+        if args.require_assignable_assignee:
+            if args.skip_repo_check:
+                assignee_status = "skipped (repo check disabled)"
+            else:
+                try:
+                    installation_token = get_installation_token(app_id, private_key, installation_id or "")
+                    assignee_ok, assignee_status = _check_assignee_assignable(
+                        args.repo,
+                        installation_token,
+                        assignee,
+                    )
+                except Exception as exc:  # noqa: BLE001
+                    assignee_ok = False
+                    assignee_status = f"check failed ({exc})"
         print(
             f"{role}: discussions={discussions}, issues={issues}, "
-            f"pull_requests={pulls}, contents={contents}"
+            f"pull_requests={pulls}, contents={contents}, "
+            f"installation_id={installation_id or 'missing'}, installation={install_status}, "
+            f"assignee={assignee or 'missing'}, assignee_check={assignee_status}"
         )
 
         if args.require_discussions and discussions != "write":
+            exit_code = 1
+        if not install_ok:
+            exit_code = 1
+        if args.require_assignable_assignee and not assignee_ok:
             exit_code = 1
 
     return exit_code

--- a/scripts/eval_github_e2e.py
+++ b/scripts/eval_github_e2e.py
@@ -16,6 +16,7 @@ from __future__ import annotations
 
 import argparse
 import os
+import subprocess
 import sys
 import time
 import uuid
@@ -27,7 +28,64 @@ import httpx
 DEFAULT_REPO = os.environ.get("GITHUB_TEST_REPO", "VibeTechnologies/vibeteam-eval-hello-world")
 DEFAULT_PR = int(os.environ.get("GITHUB_TEST_PR", "1"))
 DEFAULT_ISSUE_ASSIGNEE = os.environ.get("GITHUB_ISSUE_ASSIGNEE", "").strip()
+DEFAULT_ACTOR_LOGIN = os.environ.get("GITHUB_EVAL_ACTOR_LOGIN", "OpenCodeEngineer").strip()
+DEFAULT_ISSUE_ROLE_RAW = os.environ.get("GITHUB_ISSUE_ROLE", "software_engineer").strip()
 NATIVE_GITHUB_HANDOFF_MENTIONS = "@SoftwareEngineer @SupportEngineer"
+
+ROLE_DEFAULT_ASSIGNEES: dict[str, str] = {
+    "software_engineer": os.environ.get(
+        "GITHUB_SOFTWARE_ENGINEER_BOT_ASSIGNEE",
+        os.environ.get("GITHUB_APP_BOT_USERNAME_SOFTWARE_ENGINEER", "vibeteam-swe-bot-260301[bot]"),
+    ).strip(),
+    "support_engineer": os.environ.get(
+        "GITHUB_SUPPORT_ENGINEER_BOT_ASSIGNEE",
+        os.environ.get("GITHUB_APP_BOT_USERNAME_SUPPORT_ENGINEER", "vibeteam-support-bot-260301[bot]"),
+    ).strip(),
+    "release_engineer": os.environ.get(
+        "GITHUB_RELEASE_ENGINEER_BOT_ASSIGNEE",
+        os.environ.get("GITHUB_APP_BOT_USERNAME_RELEASE_ENGINEER", "vibeteam-release-bot-260301[bot]"),
+    ).strip(),
+    "product_manager": os.environ.get(
+        "GITHUB_PRODUCT_MANAGER_BOT_ASSIGNEE",
+        os.environ.get("GITHUB_APP_BOT_USERNAME_PRODUCT_MANAGER", "vibeteam-pm-bot-260301[bot]"),
+    ).strip(),
+    "marketing_manager": os.environ.get(
+        "GITHUB_MARKETING_MANAGER_BOT_ASSIGNEE",
+        os.environ.get("GITHUB_APP_BOT_USERNAME_MARKETING_MANAGER", "vibeteam-mktg-bot-260301[bot]"),
+    ).strip(),
+}
+ROLE_ASSIGNEE_ENV_KEYS: dict[str, tuple[str, ...]] = {
+    "software_engineer": (
+        "GITHUB_SOFTWARE_ENGINEER_BOT_ASSIGNEE",
+        "GITHUB_APP_BOT_USERNAME_SOFTWARE_ENGINEER",
+        "GITHUB_BOT_USERNAME_SOFTWARE_ENGINEER",
+    ),
+    "support_engineer": (
+        "GITHUB_SUPPORT_ENGINEER_BOT_ASSIGNEE",
+        "GITHUB_APP_BOT_USERNAME_SUPPORT_ENGINEER",
+        "GITHUB_BOT_USERNAME_SUPPORT_ENGINEER",
+    ),
+    "release_engineer": (
+        "GITHUB_RELEASE_ENGINEER_BOT_ASSIGNEE",
+        "GITHUB_APP_BOT_USERNAME_RELEASE_ENGINEER",
+        "GITHUB_BOT_USERNAME_RELEASE_ENGINEER",
+    ),
+    "product_manager": (
+        "GITHUB_PRODUCT_MANAGER_BOT_ASSIGNEE",
+        "GITHUB_APP_BOT_USERNAME_PRODUCT_MANAGER",
+        "GITHUB_BOT_USERNAME_PRODUCT_MANAGER",
+    ),
+    "marketing_manager": (
+        "GITHUB_MARKETING_MANAGER_BOT_ASSIGNEE",
+        "GITHUB_APP_BOT_USERNAME_MARKETING_MANAGER",
+        "GITHUB_BOT_USERNAME_MARKETING_MANAGER",
+    ),
+}
+DEFAULT_ISSUE_ROLE = (
+    DEFAULT_ISSUE_ROLE_RAW
+    if DEFAULT_ISSUE_ROLE_RAW in ROLE_DEFAULT_ASSIGNEES
+    else "software_engineer"
+)
 
 SCENARIOS = {
     "github_issue_handoff": {
@@ -48,11 +106,147 @@ SCENARIOS = {
 }
 
 
-def _require_token() -> str:
-    token = os.environ.get("GITHUB_TOKEN") or os.environ.get("GH_TOKEN")
+def _normalize_login(login: str) -> str:
+    normalized = (login or "").strip().lower()
+    if normalized.startswith("@"):
+        normalized = normalized[1:]
+    return normalized
+
+
+def _configured_bot_handles() -> set[str]:
+    handles: set[str] = set()
+
+    if DEFAULT_ISSUE_ASSIGNEE:
+        handles.add(_normalize_login(DEFAULT_ISSUE_ASSIGNEE))
+    for value in ROLE_DEFAULT_ASSIGNEES.values():
+        if value:
+            handles.add(_normalize_login(value))
+
+    for env_name in (
+        "GITHUB_ASSIGNMENT_BOT_LOGINS",
+        "GITHUB_ISSUE_ASSIGNEE",
+    ):
+        raw = os.environ.get(env_name, "")
+        if not raw:
+            continue
+        for value in raw.split(","):
+            normalized = _normalize_login(value)
+            if normalized:
+                handles.add(normalized)
+
+    return handles
+
+
+def _is_bot_login(login: str, extra_allowed: set[str] | None = None) -> bool:
+    lowered = _normalize_login(login)
+    if lowered.endswith("[bot]") or "-bot" in lowered:
+        return True
+
+    allowlist = set(extra_allowed or set())
+    allowlist.update(_configured_bot_handles())
+    return lowered in {_normalize_login(x) for x in allowlist if x}
+
+
+def _is_expected_actor(actor_login: str, creator_login: str) -> bool:
+    return _normalize_login(actor_login) == _normalize_login(creator_login)
+
+
+def _default_assignee_for_role(role: str) -> str:
+    return ROLE_DEFAULT_ASSIGNEES.get(role, "").strip()
+
+
+def _allowed_assignees_for_role(role: str) -> set[str]:
+    allowed: set[str] = set()
+
+    role_default = _default_assignee_for_role(role)
+    if role_default:
+        allowed.add(_normalize_login(role_default))
+
+    for env_name in ROLE_ASSIGNEE_ENV_KEYS.get(role, ()):
+        raw = os.environ.get(env_name, "")
+        if not raw:
+            continue
+        for value in raw.split(","):
+            normalized = _normalize_login(value)
+            if normalized:
+                allowed.add(normalized)
+
+    return allowed
+
+
+def _assignee_matches_issue_role(assignee: str, issue_role: str) -> bool:
+    normalized_assignee = _normalize_login(assignee)
+    role_allowed = _allowed_assignees_for_role(issue_role)
+    if not role_allowed:
+        return True
+    return normalized_assignee in role_allowed
+
+
+def _is_token_usable(token: str) -> bool:
     if not token:
-        raise SystemExit("GITHUB_TOKEN or GH_TOKEN is required")
-    return token
+        return False
+    try:
+        with httpx.Client(timeout=10.0) as client:
+            response = client.get(
+                "https://api.github.com/rate_limit",
+                headers=_headers(token),
+            )
+        return response.status_code == 200
+    except Exception:
+        return False
+
+
+def _get_gh_cli_token(user: str | None = None) -> str | None:
+    try:
+        env = os.environ.copy()
+        env.pop("GITHUB_TOKEN", None)
+        env.pop("GH_TOKEN", None)
+        cmd = ["gh", "auth", "token"]
+        if user:
+            cmd.extend(["--user", user])
+        result = subprocess.run(
+            cmd,
+            check=True,
+            capture_output=True,
+            text=True,
+            timeout=10,
+            env=env,
+        )
+        token = result.stdout.strip()
+        return token or None
+    except Exception:
+        return None
+
+
+def _require_token(prefer_gh_user: str | None = None) -> str:
+    if prefer_gh_user:
+        preferred_gh_token = _get_gh_cli_token(prefer_gh_user)
+        if preferred_gh_token and _is_token_usable(preferred_gh_token):
+            return preferred_gh_token
+
+    token = os.environ.get("GITHUB_TOKEN") or os.environ.get("GH_TOKEN")
+    if token and _is_token_usable(token):
+        return token
+
+    gh_cli_token = _get_gh_cli_token()
+    if gh_cli_token and _is_token_usable(gh_cli_token):
+        return gh_cli_token
+
+    # Fallback to role-scoped GitHub App token when PAT is missing/invalid.
+    try:
+        from vibeteam.utils.github_app import get_installation_token_for_role
+
+        app_token = get_installation_token_for_role("software_engineer")
+    except Exception:
+        app_token = None
+
+    if app_token and _is_token_usable(app_token):
+        return app_token
+
+    raise SystemExit(
+        "No usable GitHub token found. Set GH_TOKEN/GITHUB_TOKEN with valid credentials "
+        "or configure SOFTWARE_ENGINEER GitHub App credentials."
+    )
 
 
 def _split_repo(repo: str) -> tuple[str, str]:
@@ -124,7 +318,7 @@ def _wait_for_bot_authors(
         recent = [
             c
             for c in comments
-            if _parse_ts(c.get("created_at", "1970-01-01T00:00:00Z")) >= since
+            if _parse_ts(c.get("created_at", "1970-01-01T00:00:00Z")) > since
         ]
         bot_logins = _collect_bot_logins(recent)
         if len(bot_logins) >= min_bots:
@@ -179,7 +373,7 @@ def _get_repo_and_category_id(owner: str, repo: str, token: str) -> tuple[str, s
     return str(repository["id"]), str(categories[0]["id"])
 
 
-def _create_issue(owner: str, repo: str, token: str) -> tuple[int, str, datetime]:
+def _create_issue(owner: str, repo: str, token: str) -> tuple[int, str, datetime, str]:
     title = f"Eval GitHub issue handoff {uuid.uuid4().hex[:8]}"
     body = (
         "Eval issue to test agent handoff via GitHub comments.\n"
@@ -190,7 +384,8 @@ def _create_issue(owner: str, repo: str, token: str) -> tuple[int, str, datetime
         response = client.post(url, headers=_headers(token), json={"title": title, "body": body})
         response.raise_for_status()
         data = response.json()
-    return int(data["number"]), data["html_url"], _parse_ts(data["created_at"])
+    creator_login = str((data.get("user") or {}).get("login") or "")
+    return int(data["number"]), data["html_url"], _parse_ts(data["created_at"]), creator_login
 
 
 def _create_issue_comment(
@@ -231,6 +426,15 @@ def _fetch_issue_assignees(owner: str, repo: str, number: int, token: str) -> li
     return [str(a.get("login")) for a in assignees if a.get("login")]
 
 
+def _fetch_repo_assignees(owner: str, repo: str, token: str) -> list[str]:
+    url = f"https://api.github.com/repos/{owner}/{repo}/assignees"
+    with httpx.Client(timeout=20.0) as client:
+        response = client.get(url, headers=_headers(token), params={"per_page": 100})
+        response.raise_for_status()
+        data = response.json()
+    return [str(a.get("login")) for a in data if isinstance(a, dict) and a.get("login")]
+
+
 def _pick_issue_assignee(bot_logins: set[str], preferred_assignee: str | None = None) -> str | None:
     preferred = (preferred_assignee or "").strip()
     if preferred:
@@ -244,6 +448,169 @@ def _pick_issue_assignee(bot_logins: set[str], preferred_assignee: str | None = 
     return sorted(bot_logins)[0]
 
 
+def _resolve_issue_assignee(
+    owner: str,
+    repo: str,
+    token: str,
+    preferred_assignee: str | None = None,
+    issue_role: str = "software_engineer",
+) -> str | None:
+    preferred = (preferred_assignee or "").strip()
+    if preferred:
+        return preferred
+
+    role_default = _default_assignee_for_role(issue_role)
+    if role_default:
+        return role_default
+
+    assignees = _fetch_repo_assignees(owner, repo, token)
+    if not assignees:
+        return None
+
+    bot_assignees = {login for login in assignees if login.endswith("[bot]")}
+    if bot_assignees:
+        return _pick_issue_assignee(bot_assignees)
+    return None
+
+
+def _assign_issue(
+    owner: str,
+    repo: str,
+    token: str,
+    issue_number: int,
+    assignee: str,
+) -> dict:
+    url = f"https://api.github.com/repos/{owner}/{repo}/issues/{issue_number}/assignees"
+    assigned_at = datetime.now(timezone.utc)
+    current_assignees: list[str] = []
+    assigned = False
+    error = ""
+    try:
+        with httpx.Client(timeout=20.0) as client:
+            response = client.post(
+                url,
+                headers=_headers(token),
+                json={"assignees": [assignee]},
+            )
+            response.raise_for_status()
+            data = response.json()
+        current_assignees = [
+            str(a.get("login")) for a in (data.get("assignees") or []) if a.get("login")
+        ]
+        assigned = assignee in current_assignees
+        updated_at = data.get("updated_at") or data.get("created_at")
+        if isinstance(updated_at, str) and updated_at:
+            assigned_at = _parse_ts(updated_at)
+        if not assigned:
+            error = (
+                f"Failed to assign issue to {assignee}; current assignees are "
+                f"{', '.join(current_assignees) or 'n/a'}"
+            )
+    except Exception as exc:
+        error = str(exc)
+
+    return {
+        "assigned": assigned,
+        "assigned_at": assigned_at,
+        "issue_assignees": current_assignees,
+        "error": error,
+    }
+
+
+def _fetch_issue_assignment_events(
+    owner: str,
+    repo: str,
+    token: str,
+    issue_number: int,
+    target_assignee: str,
+    since: datetime,
+) -> list[dict]:
+    url = f"https://api.github.com/repos/{owner}/{repo}/issues/{issue_number}/events"
+    with httpx.Client(timeout=20.0) as client:
+        response = client.get(
+            url,
+            headers=_headers(token),
+            params={"per_page": 100},
+        )
+        response.raise_for_status()
+        data = response.json()
+
+    matched: list[dict] = []
+    for event in data:
+        if not isinstance(event, dict):
+            continue
+        if event.get("event") != "assigned":
+            continue
+        assignee_login = str((event.get("assignee") or {}).get("login") or "")
+        created_at_raw = str(event.get("created_at") or "")
+        if not assignee_login or not created_at_raw:
+            continue
+        if _normalize_login(assignee_login) != _normalize_login(target_assignee):
+            continue
+        if _parse_ts(created_at_raw) <= since:
+            continue
+        matched.append(event)
+
+    return matched
+
+
+def _unassign_issue(
+    owner: str,
+    repo: str,
+    token: str,
+    issue_number: int,
+    assignee: str,
+) -> dict:
+    url = f"https://api.github.com/repos/{owner}/{repo}/issues/{issue_number}/assignees"
+    current_assignees: list[str] = []
+    removed = False
+    error = ""
+    try:
+        with httpx.Client(timeout=20.0) as client:
+            response = client.request(
+                "DELETE",
+                url,
+                headers=_headers(token),
+                json={"assignees": [assignee]},
+            )
+            response.raise_for_status()
+            data = response.json()
+        current_assignees = [
+            str(a.get("login")) for a in (data.get("assignees") or []) if a.get("login")
+        ]
+        removed = assignee not in current_assignees
+    except Exception as exc:
+        error = str(exc)
+
+    return {
+        "removed": removed,
+        "issue_assignees": current_assignees,
+        "error": error,
+    }
+
+
+def _wait_for_assignee_activity(
+    fetch_comments: Callable[[], list[dict]],
+    since: datetime,
+    target_assignee: str,
+    timeout: int,
+    poll_interval: int = 10,
+) -> set[str]:
+    start = time.time()
+    while time.time() - start < timeout:
+        comments = fetch_comments()
+        recent = [
+            c
+            for c in comments
+            if _parse_ts(c.get("created_at", "1970-01-01T00:00:00Z")) > since
+        ]
+        recent_bot_logins = _collect_bot_logins(recent)
+        if target_assignee in recent_bot_logins:
+            return recent_bot_logins
+        time.sleep(poll_interval)
+    return set()
+
+
 def _evaluate_issue_assignment(
     owner: str,
     repo: str,
@@ -251,13 +618,27 @@ def _evaluate_issue_assignment(
     issue_number: int,
     bot_logins: set[str],
     preferred_assignee: str | None = None,
+    issue_role: str = "software_engineer",
     wait_seconds: int = 0,
     poll_interval: int = 5,
+    force_reassign: bool = False,
+    assignment_started_at: datetime | None = None,
+    expected_actor_login: str | None = None,
 ) -> dict:
-    target_assignee = _pick_issue_assignee(bot_logins, preferred_assignee)
+    target_assignee = _pick_issue_assignee(
+        bot_logins,
+        preferred_assignee or _default_assignee_for_role(issue_role),
+    )
     issue_assignees: list[str] = []
     assignment_error = ""
     assignment_passed = False
+    assignment_event_seen = False
+    assignment_event_error = ""
+    assignment_event_count = 0
+    assignment_event_actors: list[str] = []
+    assignment_actor_passed = True
+    assignment_actor_error = ""
+    started_at = assignment_started_at or datetime.now(timezone.utc)
 
     if not target_assignee:
         return {
@@ -265,24 +646,92 @@ def _evaluate_issue_assignment(
             "issue_assignees": issue_assignees,
             "assignment_passed": False,
             "assignment_error": "No candidate assignee available (no bot author detected).",
+            "assignment_event_seen": False,
+            "assignment_event_count": 0,
+            "assignment_event_error": "",
+            "assignment_event_actors": [],
+            "assignment_actor_passed": False,
+            "assignment_actor_error": "Missing target assignee; cannot validate assignment actor.",
         }
 
-    deadline = time.time() + max(wait_seconds, 0)
     try:
-        while True:
-            issue_assignees = _fetch_issue_assignees(owner, repo, issue_number, token)
-            assignment_passed = target_assignee in issue_assignees
-            if assignment_passed:
-                break
-            if time.time() >= deadline:
-                break
-            time.sleep(max(poll_interval, 1))
+        issue_assignees = _fetch_issue_assignees(owner, repo, issue_number, token)
+        assignment_passed = target_assignee in issue_assignees
+
+        if assignment_passed and force_reassign:
+            unassign_result = _unassign_issue(owner, repo, token, issue_number, target_assignee)
+            issue_assignees = unassign_result.get("issue_assignees", issue_assignees)
+            unassign_error = str(unassign_result.get("error") or "")
+            assign_result = _assign_issue(owner, repo, token, issue_number, target_assignee)
+            issue_assignees = assign_result.get("issue_assignees", issue_assignees)
+            assignment_passed = bool(assign_result.get("assigned"))
+            assignment_error = str(assign_result.get("error") or "")
+            if not assignment_error and unassign_error:
+                assignment_error = f"Reassignment warning: {unassign_error}"
 
         if not assignment_passed:
-            assignment_error = (
-                f"Expected assignee {target_assignee}, but current assignees are: "
-                f"{', '.join(issue_assignees) or 'n/a'}"
+            assign_result = _assign_issue(owner, repo, token, issue_number, target_assignee)
+            issue_assignees = assign_result.get("issue_assignees", [])
+            assignment_passed = bool(assign_result.get("assigned"))
+            assignment_error = str(assign_result.get("error") or "")
+
+        # Allow eventual consistency for assignee propagation when requested.
+        if not assignment_passed and wait_seconds > 0:
+            deadline = time.time() + max(wait_seconds, 0)
+            while True:
+                issue_assignees = _fetch_issue_assignees(owner, repo, issue_number, token)
+                assignment_passed = target_assignee in issue_assignees
+                if assignment_passed or time.time() >= deadline:
+                    break
+                time.sleep(max(poll_interval, 1))
+
+        if not assignment_passed:
+            if not assignment_error:
+                assignment_error = (
+                    f"Expected assignee {target_assignee}, but current assignees are: "
+                    f"{', '.join(issue_assignees) or 'n/a'}"
+                )
+
+        try:
+            assignment_events = _fetch_issue_assignment_events(
+                owner,
+                repo,
+                token,
+                issue_number,
+                target_assignee,
+                started_at,
             )
+            assignment_event_count = len(assignment_events)
+            assignment_event_seen = assignment_event_count > 0
+            assignment_event_actors = sorted(
+                {
+                    str((event.get("actor") or {}).get("login") or "")
+                    for event in assignment_events
+                    if isinstance(event, dict)
+                }
+                - {""}
+            )
+            if expected_actor_login and _normalize_login(expected_actor_login) != "n/a":
+                normalized_expected_actor = _normalize_login(expected_actor_login)
+                assignment_actor_passed = (
+                    assignment_event_seen
+                    and normalized_expected_actor
+                    in {_normalize_login(actor) for actor in assignment_event_actors}
+                )
+                if not assignment_actor_passed:
+                    assignment_actor_error = (
+                        "Assignment event actor mismatch: expected "
+                        f"{expected_actor_login}, observed "
+                        f"{', '.join(assignment_event_actors) or 'n/a'}"
+                    )
+        except Exception as exc:
+            assignment_event_error = str(exc)
+            if expected_actor_login and _normalize_login(expected_actor_login) != "n/a":
+                assignment_actor_passed = False
+                assignment_actor_error = (
+                    "Assignment event actor check failed due to event fetch error: "
+                    f"{assignment_event_error}"
+                )
     except Exception as exc:
         assignment_error = str(exc)
 
@@ -291,6 +740,12 @@ def _evaluate_issue_assignment(
         "issue_assignees": issue_assignees,
         "assignment_passed": assignment_passed,
         "assignment_error": assignment_error,
+        "assignment_event_seen": assignment_event_seen,
+        "assignment_event_count": assignment_event_count,
+        "assignment_event_error": assignment_event_error,
+        "assignment_event_actors": assignment_event_actors,
+        "assignment_actor_passed": assignment_actor_passed,
+        "assignment_actor_error": assignment_actor_error,
     }
 
 
@@ -416,34 +871,86 @@ def _create_pr_comment(owner: str, repo: str, token: str, pr_number: int, body: 
 
 
 def _run_issue_handoff(
-    owner: str, repo: str, token: str, timeout: int, issue_assignee: str | None = None
+    owner: str,
+    repo: str,
+    token: str,
+    timeout: int,
+    issue_assignee: str | None = None,
+    issue_role: str = "software_engineer",
+    actor_login: str = DEFAULT_ACTOR_LOGIN,
 ) -> dict:
-    issue_number, issue_url, _ = _create_issue(owner, repo, token)
-    trigger_body = _build_issue_trigger_comment()
-    trigger_ts = _create_issue_comment(owner, repo, token, issue_number, trigger_body)
-
-    def fetch() -> list[dict]:
-        return _fetch_issue_comments(owner, repo, issue_number, token, since=trigger_ts)
-
-    bot_logins = _wait_for_bot_authors(fetch, trigger_ts, 2, timeout)
+    issue_number, issue_url, _, creator_login = _create_issue(owner, repo, token)
+    creator_passed = _is_expected_actor(actor_login, creator_login)
+    creator_error = ""
+    if not creator_passed:
+        creator_error = (
+            f"Issue creator mismatch: expected {actor_login}, got {creator_login or 'n/a'}"
+        )
+    target_assignee = _resolve_issue_assignee(
+        owner,
+        repo,
+        token,
+        preferred_assignee=issue_assignee,
+        issue_role=issue_role,
+    )
+    assignment_checkpoint = datetime.now(timezone.utc)
     assignment = _evaluate_issue_assignment(
         owner,
         repo,
         token,
         issue_number,
-        bot_logins,
-        issue_assignee,
+        set(),
+        target_assignee,
+        issue_role,
         wait_seconds=min(timeout, 60),
+        force_reassign=True,
+        assignment_started_at=assignment_checkpoint,
+        expected_actor_login=actor_login,
     )
+
+    def fetch_after_assignment() -> list[dict]:
+        return _fetch_issue_comments(owner, repo, issue_number, token, since=assignment_checkpoint)
+
+    assignee_recent_activity: set[str] = set()
+    assignment_target = assignment.get("target_assignee", "n/a")
+    if assignment["assignment_passed"] and assignment_target != "n/a":
+        assignee_recent_activity = _wait_for_assignee_activity(
+            fetch_after_assignment,
+            assignment_checkpoint,
+            assignment_target,
+            timeout,
+        )
+
+    all_bot_logins = _collect_bot_logins(
+        _fetch_issue_comments(owner, repo, issue_number, token, since=None)
+    )
+    recent_bot_logins = set(assignee_recent_activity)
 
     return {
         "thread": issue_url,
-        "bot_logins": sorted(bot_logins),
+        "bot_logins": sorted(all_bot_logins),
+        "recent_bot_logins": sorted(recent_bot_logins),
+        "actor_login": actor_login,
+        "issue_creator": creator_login or "n/a",
+        "creator_passed": creator_passed,
+        "creator_error": creator_error,
         "target_assignee": assignment["target_assignee"],
         "issue_assignees": assignment["issue_assignees"],
         "assignment_passed": assignment["assignment_passed"],
         "assignment_error": assignment["assignment_error"],
-        "passed": bool(bot_logins) and bool(assignment["assignment_passed"]),
+        "assignment_event_seen": assignment["assignment_event_seen"],
+        "assignment_event_count": assignment["assignment_event_count"],
+        "assignment_event_error": assignment["assignment_event_error"],
+        "assignment_event_actors": assignment.get("assignment_event_actors", []),
+        "assignment_actor_passed": assignment.get("assignment_actor_passed", True),
+        "assignment_actor_error": assignment.get("assignment_actor_error", ""),
+        "passed": (
+            bool(assignee_recent_activity)
+            and bool(assignment["assignment_passed"])
+            and bool(assignment["assignment_event_seen"])
+            and bool(assignment.get("assignment_actor_passed", True))
+            and bool(creator_passed)
+        ),
     }
 
 
@@ -454,39 +961,21 @@ def _run_issue_handoff_existing(
     issue_number: int,
     timeout: int,
     issue_assignee: str | None = None,
+    issue_role: str = "software_engineer",
     post_trigger_comment: bool = False,
+    actor_login: str = DEFAULT_ACTOR_LOGIN,
 ) -> dict:
-    issue_url = f"https://github.com/{owner}/{repo}/issues/{issue_number}"
-    if post_trigger_comment:
-        trigger_body = _build_issue_trigger_comment()
-        trigger_ts = _create_issue_comment(owner, repo, token, issue_number, trigger_body)
-
-        def fetch() -> list[dict]:
-            return _fetch_issue_comments(owner, repo, issue_number, token, since=trigger_ts)
-
-        bot_logins = _wait_for_bot_authors(fetch, trigger_ts, 2, timeout)
-    else:
-        comments = _fetch_issue_comments(owner, repo, issue_number, token, since=None)
-        bot_logins = _collect_bot_logins(comments)
-    assignment = _evaluate_issue_assignment(
+    return _run_issue_handoff_presence(
         owner,
         repo,
         token,
         issue_number,
-        bot_logins,
+        timeout,
         issue_assignee,
-        wait_seconds=min(timeout, 60),
+        issue_role,
+        post_trigger_comment,
+        actor_login=actor_login,
     )
-
-    return {
-        "thread": issue_url,
-        "bot_logins": sorted(bot_logins),
-        "target_assignee": assignment["target_assignee"],
-        "issue_assignees": assignment["issue_assignees"],
-        "assignment_passed": assignment["assignment_passed"],
-        "assignment_error": assignment["assignment_error"],
-        "passed": bool(bot_logins) and bool(assignment["assignment_passed"]),
-    }
 
 
 def _run_discussion_handoff(owner: str, repo: str, token: str, timeout: int) -> dict:
@@ -563,7 +1052,9 @@ def _run_issue_handoff_presence(
     issue_number: int,
     timeout: int,
     issue_assignee: str | None = None,
+    issue_role: str = "software_engineer",
     post_trigger_comment: bool = False,
+    actor_login: str = "n/a",
 ) -> dict:
     issue_url = f"https://github.com/{owner}/{repo}/issues/{issue_number}"
     if post_trigger_comment:
@@ -578,10 +1069,17 @@ def _run_issue_handoff_presence(
             _fetch_issue_comments(owner, repo, issue_number, token, since=None)
         )
     else:
+        assignment_checkpoint = datetime.now(timezone.utc)
         all_bot_logins = _collect_bot_logins(
             _fetch_issue_comments(owner, repo, issue_number, token, since=None)
         )
-        recent_bot_logins = set(all_bot_logins)
+        recent_bot_logins = set()
+    assignment_checkpoint = datetime.now(timezone.utc)
+    expected_actor_login = (
+        actor_login
+        if (not post_trigger_comment and actor_login and _normalize_login(actor_login) != "n/a")
+        else None
+    )
     assignment = _evaluate_issue_assignment(
         owner,
         repo,
@@ -589,18 +1087,62 @@ def _run_issue_handoff_presence(
         issue_number,
         all_bot_logins,
         issue_assignee,
+        issue_role,
         wait_seconds=min(timeout, 60),
+        force_reassign=not post_trigger_comment,
+        assignment_started_at=assignment_checkpoint,
+        expected_actor_login=expected_actor_login,
     )
 
-    passed = bool(recent_bot_logins) and bool(assignment["assignment_passed"])
+    if not post_trigger_comment:
+        target_assignee = assignment.get("target_assignee", "n/a")
+        if assignment["assignment_passed"] and target_assignee != "n/a":
+            def fetch_after_assignment() -> list[dict]:
+                return _fetch_issue_comments(
+                    owner,
+                    repo,
+                    issue_number,
+                    token,
+                    since=assignment_checkpoint,
+                )
+
+            recent_bot_logins = _wait_for_assignee_activity(
+                fetch_after_assignment,
+                assignment_checkpoint,
+                target_assignee,
+                timeout,
+            )
+
+    assignment_event_seen = bool(assignment.get("assignment_event_seen"))
+    assignment_event_error = str(assignment.get("assignment_event_error") or "")
+    assignment_event_count = int(assignment.get("assignment_event_count") or 0)
+    assignment_event_actors = list(assignment.get("assignment_event_actors") or [])
+    assignment_actor_passed = bool(assignment.get("assignment_actor_passed", True))
+    assignment_actor_error = str(assignment.get("assignment_actor_error") or "")
+    passed = (
+        bool(recent_bot_logins)
+        and bool(assignment["assignment_passed"])
+        and assignment_event_seen
+        and assignment_actor_passed
+    )
     return {
         "thread": issue_url,
         "bot_logins": sorted(all_bot_logins),
         "recent_bot_logins": sorted(recent_bot_logins),
+        "actor_login": actor_login,
+        "issue_creator": "n/a",
+        "creator_passed": True,
+        "creator_error": "",
         "target_assignee": assignment["target_assignee"],
         "issue_assignees": assignment["issue_assignees"],
         "assignment_passed": assignment["assignment_passed"],
         "assignment_error": assignment["assignment_error"],
+        "assignment_event_seen": assignment_event_seen,
+        "assignment_event_count": assignment_event_count,
+        "assignment_event_error": assignment_event_error,
+        "assignment_event_actors": assignment_event_actors,
+        "assignment_actor_passed": assignment_actor_passed,
+        "assignment_actor_error": assignment_actor_error,
         "passed": passed,
     }
 
@@ -639,7 +1181,9 @@ def _run_issue_pr_handoff(
     pr_number: int,
     timeout: int,
     issue_assignee: str | None = None,
+    issue_role: str = "software_engineer",
     post_issue_trigger_comment: bool = False,
+    actor_login: str = DEFAULT_ACTOR_LOGIN,
 ) -> dict:
     if issue_number:
         issue_results = _run_issue_handoff_presence(
@@ -649,10 +1193,12 @@ def _run_issue_pr_handoff(
             issue_number,
             timeout,
             issue_assignee,
+            issue_role,
             post_issue_trigger_comment,
+            actor_login=actor_login,
         )
     else:
-        created_issue_number, issue_url, _ = _create_issue(owner, repo, token)
+        created_issue_number, issue_url, _, creator_login = _create_issue(owner, repo, token)
         issue_results = _run_issue_handoff_presence(
             owner,
             repo,
@@ -660,9 +1206,20 @@ def _run_issue_pr_handoff(
             created_issue_number,
             timeout,
             issue_assignee,
-            True,
+            issue_role,
+            False,
+            actor_login=actor_login,
         )
         issue_results["thread"] = issue_url
+        creator_passed = _is_expected_actor(actor_login, creator_login)
+        issue_results["issue_creator"] = creator_login or "n/a"
+        issue_results["creator_passed"] = creator_passed
+        issue_results["creator_error"] = (
+            ""
+            if creator_passed
+            else f"Issue creator mismatch: expected {actor_login}, got {creator_login or 'n/a'}"
+        )
+        issue_results["passed"] = bool(issue_results.get("passed")) and creator_passed
 
     pr_results = _run_pr_handoff_presence(owner, repo, token, pr_number, timeout)
     combined_logins = sorted(
@@ -673,10 +1230,20 @@ def _run_issue_pr_handoff(
     return {
         "thread": f"{issue_results.get('thread')} | {pr_results.get('thread')}",
         "bot_logins": combined_logins,
+        "actor_login": issue_results.get("actor_login", actor_login),
+        "issue_creator": issue_results.get("issue_creator", "n/a"),
+        "creator_passed": issue_results.get("creator_passed", True),
+        "creator_error": issue_results.get("creator_error", ""),
         "target_assignee": issue_results.get("target_assignee", "n/a"),
         "issue_assignees": issue_results.get("issue_assignees", []),
         "assignment_passed": issue_results.get("assignment_passed", False),
         "assignment_error": issue_results.get("assignment_error", ""),
+        "assignment_event_seen": issue_results.get("assignment_event_seen", False),
+        "assignment_event_count": issue_results.get("assignment_event_count", 0),
+        "assignment_event_error": issue_results.get("assignment_event_error", ""),
+        "assignment_event_actors": issue_results.get("assignment_event_actors", []),
+        "assignment_actor_passed": issue_results.get("assignment_actor_passed", True),
+        "assignment_actor_error": issue_results.get("assignment_actor_error", ""),
         "passed": passed,
         "threads": {
             "issue": issue_results,
@@ -730,8 +1297,38 @@ def _write_report(scenario: str, results: dict) -> str:
         lines.append(
             f"**Current assignees:** {', '.join(results.get('issue_assignees', [])) or 'n/a'}"
         )
+        lines.append(
+            "**Assignment event observed:** "
+            f"{'✅' if results.get('assignment_event_seen') else '❌'}"
+        )
+        lines.append(
+            f"**Assignment event count:** {results.get('assignment_event_count', 0)}"
+        )
+        lines.append(
+            f"**Assignment event actors:** {', '.join(results.get('assignment_event_actors', [])) or 'n/a'}"
+        )
+        lines.append(
+            "**Assignment actor check:** "
+            f"{'✅' if results.get('assignment_actor_passed', True) else '❌'}"
+        )
+        lines.append(
+            "**Recent bot authors after assignment/trigger:** "
+            f"{', '.join(results.get('recent_bot_logins', [])) or 'n/a'}"
+        )
+    if "creator_passed" in results:
+        lines.append(
+            f"**Issue creator check:** {'✅' if results.get('creator_passed') else '❌'}"
+        )
+        lines.append(f"**Expected actor:** {results.get('actor_login', 'n/a')}")
+        lines.append(f"**Issue creator:** {results.get('issue_creator', 'n/a')}")
     if results.get("assignment_error"):
         lines.append(f"**Assignment error:** {results.get('assignment_error')}")
+    if results.get("assignment_event_error"):
+        lines.append(f"**Assignment event error:** {results.get('assignment_event_error')}")
+    if results.get("assignment_actor_error"):
+        lines.append(f"**Assignment actor error:** {results.get('assignment_actor_error')}")
+    if results.get("creator_error"):
+        lines.append(f"**Creator error:** {results.get('creator_error')}")
     lines.append("")
     links = _collect_thread_links(results)
     lines.extend(
@@ -768,7 +1365,7 @@ def _write_report(scenario: str, results: dict) -> str:
                         f"- Bot authors: {', '.join(thread_result.get('bot_logins', [])) or 'n/a'}"
                     ),
                     (
-                        "- Recent bot authors after trigger: "
+                        "- Recent bot authors after assignment/trigger: "
                         f"{', '.join(thread_result.get('recent_bot_logins', [])) or 'n/a'}"
                     ),
                 ]
@@ -780,8 +1377,35 @@ def _write_report(scenario: str, results: dict) -> str:
                     "- Current assignees: "
                     f"{', '.join(thread_result.get('issue_assignees', [])) or 'n/a'}"
                 )
+                lines.append(
+                    "- Assignment event observed: "
+                    f"{'✅' if thread_result.get('assignment_event_seen') else '❌'}"
+                )
+                lines.append(
+                    f"- Assignment event count: {thread_result.get('assignment_event_count', 0)}"
+                )
+                lines.append(
+                    "- Assignment event actors: "
+                    f"{', '.join(thread_result.get('assignment_event_actors', [])) or 'n/a'}"
+                )
+                lines.append(
+                    "- Assignment actor check: "
+                    f"{'✅' if thread_result.get('assignment_actor_passed', True) else '❌'}"
+                )
+            if "creator_passed" in thread_result:
+                lines.append(
+                    f"- Issue creator check: {'✅' if thread_result.get('creator_passed') else '❌'}"
+                )
+                lines.append(f"- Expected actor: {thread_result.get('actor_login', 'n/a')}")
+                lines.append(f"- Issue creator: {thread_result.get('issue_creator', 'n/a')}")
             if thread_result.get("assignment_error"):
                 lines.append(f"- Assignment error: {thread_result.get('assignment_error')}")
+            if thread_result.get("assignment_event_error"):
+                lines.append(f"- Assignment event error: {thread_result.get('assignment_event_error')}")
+            if thread_result.get("assignment_actor_error"):
+                lines.append(f"- Assignment actor error: {thread_result.get('assignment_actor_error')}")
+            if thread_result.get("creator_error"):
+                lines.append(f"- Creator error: {thread_result.get('creator_error')}")
             lines.append("")
 
     os.makedirs("results/eval_reports", exist_ok=True)
@@ -797,6 +1421,8 @@ def main() -> int:
     parser.add_argument("--repo", default=DEFAULT_REPO)
     parser.add_argument("--pr", type=int, default=DEFAULT_PR)
     parser.add_argument("--issue-assignee", default=DEFAULT_ISSUE_ASSIGNEE)
+    parser.add_argument("--issue-role", choices=sorted(ROLE_DEFAULT_ASSIGNEES.keys()), default=DEFAULT_ISSUE_ROLE)
+    parser.add_argument("--actor-login", default=DEFAULT_ACTOR_LOGIN)
     parser.add_argument(
         "--post-trigger-comment",
         action="store_true",
@@ -813,8 +1439,39 @@ def main() -> int:
 
     args = parser.parse_args()
 
-    token = _require_token()
+    token = _require_token(args.actor_login)
     owner, repo = _split_repo(args.repo)
+    resolved_issue_assignee = _resolve_issue_assignee(
+        owner,
+        repo,
+        token,
+        preferred_assignee=args.issue_assignee,
+        issue_role=args.issue_role,
+    )
+    issue_scenarios = {"github_issue_handoff", "github_issue_pr_handoff_github"}
+    if args.scenario in issue_scenarios:
+        if not resolved_issue_assignee:
+            raise SystemExit(
+                f"No assignee resolved for role '{args.issue_role}'. Provide --issue-assignee."
+            )
+        if not _assignee_matches_issue_role(resolved_issue_assignee, args.issue_role):
+            expected = sorted(_allowed_assignees_for_role(args.issue_role))
+            raise SystemExit(
+                "Issue assignee does not match required role mapping. "
+                f"role={args.issue_role}, assignee={resolved_issue_assignee}, "
+                f"expected one of: {', '.join(expected) or 'n/a'}"
+            )
+        allowed_handles = _configured_bot_handles()
+        allowed_handles.add(_normalize_login(resolved_issue_assignee))
+        role_default = _default_assignee_for_role(args.issue_role)
+        if role_default:
+            allowed_handles.add(_normalize_login(role_default))
+        if not _is_bot_login(resolved_issue_assignee, extra_allowed=allowed_handles):
+            raise SystemExit(
+                "Issue assignee must be a bot app handle (pattern '*-bot-*' or '[bot]' "
+                "or listed in explicit bot-handle config). "
+                f"Got: {resolved_issue_assignee}"
+            )
 
     scenarios_to_run = [args.scenario]
     if args.scenario == "github_threads_all":
@@ -834,12 +1491,20 @@ def main() -> int:
                     token,
                     args.issue,
                     args.timeout,
-                    args.issue_assignee,
+                    resolved_issue_assignee,
+                    args.issue_role,
                     args.post_trigger_comment,
+                    args.actor_login,
                 )
             else:
                 results = _run_issue_handoff(
-                    owner, repo, token, args.timeout, args.issue_assignee
+                    owner,
+                    repo,
+                    token,
+                    args.timeout,
+                    resolved_issue_assignee,
+                    args.issue_role,
+                    args.actor_login,
                 )
         elif scenario == "github_issue_pr_handoff_github":
             results = _run_issue_pr_handoff(
@@ -849,8 +1514,10 @@ def main() -> int:
                 args.issue,
                 args.pr,
                 args.timeout,
-                args.issue_assignee,
+                resolved_issue_assignee,
+                args.issue_role,
                 args.post_trigger_comment,
+                args.actor_login,
             )
         elif scenario == "github_discussion_handoff":
             if args.discussion:

--- a/scripts/eval_slack_e2e.py
+++ b/scripts/eval_slack_e2e.py
@@ -35,12 +35,13 @@ from __future__ import annotations
 
 import argparse
 import asyncio
-import copy
 import os
 import re
+import subprocess
 import sys
 import time
 from datetime import datetime, timezone
+from functools import lru_cache
 from pathlib import Path
 from typing import TYPE_CHECKING, Any
 
@@ -357,160 +358,6 @@ SCENARIOS = {
             ],
             "ResponseEfficiency": [
                 "Check that the response is concise and directly answers the request.",
-            ],
-        },
-        "threshold": 0.70,
-    },
-    "support_vibe_dev_health": {
-        "name": "Support Engineer - vibe-dev Health and Logs Validation",
-        "message": (
-            "@VibeTeam @SupportEngineer validate vibe-dev namespace health now. "
-            "Run kubectl checks for pods, deployments, and events. "
-            "If any workloads are unhealthy, inspect recent logs and summarize severity "
-            "with evidence."
-        ),
-        "expected_agent": "support_engineer",
-        "timeout": 600,
-        "skip_handoff": True,
-        "evaluation_criteria": {
-            "NamespaceCoverage": (
-                "Did the SupportEngineer explicitly validate the vibe-dev namespace "
-                "with concrete kubectl evidence? "
-                "REQUIRED FOR HIGH SCORE: "
-                "(1) Explicit mention of vibe-dev; "
-                "(2) Evidence from pods/deployments/events checks (or explicit 'no resources found'); "
-                "(3) Findings tied to the observed namespace state. "
-                "SCORING: "
-                "Score 0.0-0.3: No vibe-dev check or generic response. "
-                "Score 0.3-0.6: Mentions vibe-dev but little/no concrete evidence. "
-                "Score 0.6-0.8: Provides concrete namespace evidence and summary. "
-                "Score 0.8-1.0: Complete, evidence-based namespace validation."
-            ),
-            "HealthAndLogs": (
-                "Did the agent evaluate health and logs appropriately based on what exists? "
-                "REQUIRED FOR HIGH SCORE: "
-                "(1) If unhealthy workloads exist, includes relevant logs/events evidence; "
-                "(2) If namespace is empty, explicitly states no workloads and therefore no logs; "
-                "(3) Severity assessment is consistent with evidence. "
-                "SCORING: "
-                "Score 0.0-0.3: No health/log assessment. "
-                "Score 0.3-0.6: Partial assessment without clear evidence. "
-                "Score 0.6-0.8: Correct assessment with evidence. "
-                "Score 0.8-1.0: Correct, complete assessment with clear severity."
-            ),
-            "ResponseEfficiency": (
-                "Was the response concise, focused, and non-speculative? "
-                "SCORING: "
-                "Score 0.0-0.3: Rambling, speculative, or contradictory. "
-                "Score 0.3-0.5: Some redundancy or unclear conclusion. "
-                "Score 0.5-0.7: Reasonably concise with clear conclusion. "
-                "Score 0.7-0.9: Focused and efficient. "
-                "Score 0.9-1.0: Minimal, precise, and complete."
-            ),
-        },
-        "evaluation_steps": {
-            "NamespaceCoverage": [
-                "Check for explicit vibe-dev mention and concrete kubectl-derived evidence.",
-                "Accept explicit 'no resources found' as valid evidence when namespace is empty.",
-                "Score <= 0.3 if vibe-dev is not validated.",
-            ],
-            "HealthAndLogs": [
-                "If workloads are unhealthy, check for logs/events evidence and severity.",
-                "If namespace is empty, check that the agent clearly states no workloads/logs.",
-                "Penalize fabricated or speculative failures without evidence.",
-            ],
-            "ResponseEfficiency": [
-                "Check that the response is concise and directly answers health/log status.",
-            ],
-        },
-        "threshold": 0.70,
-    },
-    "software_engineer_tooling_vibe_dev_health": {
-        "name": "Software Engineer - Tooling Bootstrap + vibe-dev Health Validation",
-        "message": (
-            "@VibeTeam @SoftwareEngineer validate your runtime is ready for infrastructure work. "
-            "If required CLIs are missing, install them (at minimum verify jq is available) "
-            "and report versions. Then validate Kubernetes access with explicit "
-            "`kubectl auth can-i` checks for namespaces vibe-dev and vibeteam. "
-            "After access checks, inspect vibe-dev health (pods, deployments, events) "
-            "and evaluate recent logs for unhealthy workloads if any. Summarize severity "
-            "with evidence."
-        ),
-        "expected_agent": "software_engineer",
-        "timeout": 900,
-        "skip_handoff": True,
-        "evaluation_criteria": {
-            "ToolingBootstrap": (
-                "Did the SoftwareEngineer verify or bootstrap required runtime tooling, "
-                "including jq availability, with concrete evidence? "
-                "REQUIRED FOR HIGH SCORE: "
-                "(1) Explicit tooling check step (versions or command outputs); "
-                "(2) jq availability confirmed (preinstalled or installed during run); "
-                "(3) No vague claims like 'tools are ready' without evidence. "
-                "EVIDENCE POLICY: concise, structured version lines in the final response "
-                "(for example 'jq 1.7' and 'kubectl client v1.31.4') count as valid evidence; "
-                "raw shell transcript formatting is NOT required. "
-                "SCORING: "
-                "Score 0.0-0.3: No tooling verification, or unsupported claims. "
-                "Score 0.3-0.6: Mentions tooling but no concrete evidence. "
-                "Score 0.6-0.8: Concrete tooling evidence including jq. "
-                "Score 0.8-1.0: Clear bootstrap/verification with concise evidence."
-            ),
-            "KubernetesAccess": (
-                "Did the agent prove Kubernetes authorization for required namespaces "
-                "using explicit auth checks? "
-                "REQUIRED FOR HIGH SCORE: "
-                "(1) `kubectl auth can-i` evidence shown; "
-                "(2) Coverage includes both vibe-dev and vibeteam namespaces; "
-                "(3) Findings clearly state allowed/denied outcomes. "
-                "SCORING: "
-                "Score 0.0-0.3: No auth checks or wrong namespaces. "
-                "Score 0.3-0.6: Partial checks (only one namespace or unclear output). "
-                "Score 0.6-0.8: Both namespaces checked with clear outcomes. "
-                "Score 0.8-1.0: Complete, explicit authorization evidence and interpretation."
-            ),
-            "HealthAndLogs": (
-                "Did the agent evaluate vibe-dev health and logs in an evidence-based way? "
-                "REQUIRED FOR HIGH SCORE: "
-                "(1) Checks pods, deployments, and events in vibe-dev; "
-                "(2) If unhealthy workloads exist, includes relevant recent logs/events; "
-                "(3) If namespace is empty/healthy, explicitly states that and avoids fabrication; "
-                "(4) Severity assessment matches evidence. "
-                "SCORING: "
-                "Score 0.0-0.3: No meaningful health/log evaluation. "
-                "Score 0.3-0.6: Partial checks with weak evidence. "
-                "Score 0.6-0.8: Correct health/log assessment with evidence. "
-                "Score 0.8-1.0: Complete assessment with accurate severity summary."
-            ),
-            "ResponseEfficiency": (
-                "Was the response concise, focused, and non-speculative? "
-                "SCORING: "
-                "Score 0.0-0.3: Rambling, repetitive, or contradictory. "
-                "Score 0.3-0.5: Some redundancy and unclear conclusion. "
-                "Score 0.5-0.7: Reasonably concise with clear conclusion. "
-                "Score 0.7-0.9: Focused and efficient. "
-                "Score 0.9-1.0: Minimal, precise, complete."
-            ),
-        },
-        "evaluation_steps": {
-            "ToolingBootstrap": [
-                "Check for explicit tooling verification steps and command evidence.",
-                "Accept concise version lines as valid evidence (raw command transcript not required).",
-                "Check that jq availability is explicitly confirmed (installed or present).",
-                "Score <= 0.3 if tooling claims have no concrete evidence.",
-            ],
-            "KubernetesAccess": [
-                "Check for explicit `kubectl auth can-i` checks.",
-                "Require both vibe-dev and vibeteam namespace checks.",
-                "Score <= 0.3 if auth checks are missing or namespaces are wrong.",
-            ],
-            "HealthAndLogs": [
-                "Check that pods/deployments/events were validated in vibe-dev.",
-                "If unhealthy workloads exist, check for recent logs/events evidence.",
-                "If no workloads/issues exist, require explicit statement and no fabricated failures.",
-            ],
-            "ResponseEfficiency": [
-                "Check that the response is concise and directly answers readiness plus health/log status.",
             ],
         },
         "threshold": 0.70,
@@ -846,77 +693,6 @@ SCENARIOS = {
                 "Check for redundant tool usage or repeated steps in the response.",
                 "Check that the response is concise and directly answers the requested outputs.",
                 "Score 0.7+ if the response is focused and complete.",
-            ],
-        },
-        "threshold": 0.70,
-    },
-    "knowledgebase_cross_agent_support_to_product": {
-        "name": "Knowledgebase Cross-Agent Retrieval (SupportEngineer -> ProductManager)",
-        "message": (
-            "@SupportEngineer add a new knowledgebase markdown file at "
-            "`agents/shared/knowledgebase/inbox/kb_eval_{KB_TOKEN}.md` with this exact line: "
-            "`KB_EVAL_FACT_{KB_TOKEN}: cobalt-lotus-914`. Then rebuild the docs index and confirm "
-            "the file path and fact key in your response."
-        ),
-        "follow_up_message": (
-            "@ProductManager do not guess. Read shared knowledgebase and answer this exactly: "
-            "what is the value for `KB_EVAL_FACT_{KB_TOKEN}`? Respond with only the value."
-        ),
-        "expected_agent": "support_engineer",
-        "timeout": 900,
-        "skip_handoff": True,
-        "post_checks": {
-            "knowledgebase_cross_agent_retrieval": {
-                "fact_key": "KB_EVAL_FACT_{KB_TOKEN}",
-                "fact_value": "cobalt-lotus-914",
-                "producer_agent": "support_engineer",
-                "consumer_agent": "product_manager",
-            }
-        },
-        "evaluation_criteria": {
-            "KnowledgebaseIngestionAndRetrieval": (
-                "Did the flow prove cross-agent knowledgebase usage end-to-end? "
-                "REQUIRED FOR HIGH SCORE: "
-                "(1) SupportEngineer confirms adding KB content with the requested fact key; "
-                "(2) ProductManager answers with the stored value; "
-                "(3) ProductManager response reflects retrieval, not guessing. "
-                "SCORING: "
-                "Score 0.0-0.3: No KB ingestion or no retrieval answer. "
-                "Score 0.3-0.6: Partial flow (one agent responds or value missing/wrong). "
-                "Score 0.6-0.8: Both agents respond and value appears but evidence is weak. "
-                "Score 0.8-1.0: Clear ingestion + accurate retrieval across agents."
-            ),
-            "CrossAgentExecution": (
-                "Did both required agents execute in sequence? "
-                "REQUIRED: SupportEngineer response first for ingestion, then ProductManager retrieval response. "
-                "SCORING: "
-                "Score 0.0-0.3: Only one agent responds. "
-                "Score 0.3-0.6: Both respond but sequence is unclear. "
-                "Score 0.6-0.8: Both respond with clear sequence. "
-                "Score 0.8-1.0: Both respond with clear sequence and task alignment."
-            ),
-            "ResponseEfficiency": (
-                "Evaluate whether responses are focused and directly answer the two tasks. "
-                "SCORING: "
-                "Score 0.0-0.3: Rambling/off-topic. "
-                "Score 0.3-0.5: Significant redundancy. "
-                "Score 0.5-0.7: Mostly focused with minor fluff. "
-                "Score 0.7-0.9: Focused and concise. "
-                "Score 0.9-1.0: Minimal and complete."
-            ),
-        },
-        "evaluation_steps": {
-            "KnowledgebaseIngestionAndRetrieval": [
-                "Check that SupportEngineer confirms writing KB content with the requested fact key.",
-                "Check that ProductManager provides the expected value for the fact key.",
-                "Penalize if ProductManager does not answer or answers with wrong value.",
-            ],
-            "CrossAgentExecution": [
-                "Check that both SupportEngineer and ProductManager posted substantive responses.",
-                "Check that ProductManager retrieval happens after SupportEngineer ingestion request.",
-            ],
-            "ResponseEfficiency": [
-                "Check that each response is concise and directly tied to ingestion/retrieval tasks.",
             ],
         },
         "threshold": 0.70,
@@ -1806,8 +1582,63 @@ def _default_github_repo() -> tuple[str, str]:
     return owner, repo
 
 
+def _is_github_token_usable(token: str) -> bool:
+    if not token:
+        return False
+    try:
+        response = httpx.get(
+            "https://api.github.com/rate_limit",
+            headers={
+                "Authorization": f"token {token}",
+                "Accept": "application/vnd.github+json",
+                "X-GitHub-Api-Version": "2022-11-28",
+            },
+            timeout=10.0,
+        )
+        return response.status_code == 200
+    except Exception:
+        return False
+
+
+def _get_gh_cli_token() -> str | None:
+    try:
+        env = os.environ.copy()
+        env.pop("GITHUB_TOKEN", None)
+        env.pop("GH_TOKEN", None)
+        result = subprocess.run(
+            ["gh", "auth", "token"],
+            check=True,
+            capture_output=True,
+            text=True,
+            timeout=10,
+            env=env,
+        )
+        token = result.stdout.strip()
+        return token or None
+    except Exception:
+        return None
+
+
+@lru_cache(maxsize=1)
 def _get_github_token() -> str | None:
-    return os.environ.get("GITHUB_TOKEN") or os.environ.get("GH_TOKEN")
+    env_token = os.environ.get("GITHUB_TOKEN") or os.environ.get("GH_TOKEN")
+    if env_token and _is_github_token_usable(env_token):
+        return env_token
+
+    gh_cli_token = _get_gh_cli_token()
+    if gh_cli_token and _is_github_token_usable(gh_cli_token):
+        return gh_cli_token
+
+    try:
+        from vibeteam.utils.github_app import get_installation_token_for_role
+
+        app_token = get_installation_token_for_role("software_engineer")
+    except Exception:
+        app_token = None
+    if app_token and _is_github_token_usable(app_token):
+        return app_token
+
+    return None
 
 
 def _extract_github_pr_refs(text: str) -> list[dict[str, str | int]]:
@@ -2018,13 +1849,13 @@ def _check_github_pr_created(transcript: str) -> dict[str, str | bool]:
             "details": "No PR reference found in conversation.",
         }
 
-    token = os.environ.get("GITHUB_TOKEN")
+    token = _get_github_token()
     if not token:
         return {
             "name": "GitHub PR created",
             "passed": False,
             "required": True,
-            "details": "GITHUB_TOKEN not set; cannot verify PR existence.",
+            "details": "No usable GitHub token found; cannot verify PR existence.",
         }
 
     headers = {"Authorization": f"token {token}", "Accept": "application/vnd.github+json"}
@@ -2072,13 +1903,13 @@ def _check_github_pr_author_is_bot(transcript: str) -> dict[str, str | bool]:
             "details": "No PR reference found in conversation.",
         }
 
-    token = os.environ.get("GITHUB_TOKEN") or os.environ.get("GH_TOKEN")
+    token = _get_github_token()
     if not token:
         return {
             "name": "GitHub PR author is bot",
             "passed": False,
             "required": True,
-            "details": "GITHUB_TOKEN/GH_TOKEN not set; cannot verify PR author.",
+            "details": "No usable GitHub token found; cannot verify PR author.",
         }
 
     headers = {"Authorization": f"token {token}", "Accept": "application/vnd.github+json"}
@@ -2410,107 +2241,6 @@ def _check_sentry_issue_closed(transcript: str) -> dict[str, str | bool]:
     }
 
 
-def _check_knowledgebase_cross_agent_retrieval(
-    conversation: list[tuple[str, str]],
-    fact_key: str,
-    fact_value: str,
-    producer_agent: str,
-    consumer_agent: str,
-) -> dict[str, str | bool]:
-    """Verify one agent ingested KB content and another retrieved the expected value."""
-
-    def _normalize_role(role: str, text: str) -> str:
-        if role != "bot":
-            return role
-        # Fallback for unparsed prefixes like [ProductManager:model]
-        match = re.match(r"^\[([A-Za-z]+)", text.strip())
-        if not match:
-            return role
-        display = match.group(1).strip().lower()
-        for role_key, role_display in ROLE_DISPLAY.items():
-            if role_display.lower() == display:
-                return role_key
-        return role
-
-    producer_msgs: list[str] = []
-    consumer_msgs: list[str] = []
-
-    for role, text in conversation:
-        if role == "user":
-            continue
-        normalized_role = _normalize_role(role, text)
-        if normalized_role == producer_agent:
-            producer_msgs.append(text)
-        if normalized_role == consumer_agent:
-            consumer_msgs.append(text)
-
-    if not producer_msgs:
-        return {
-            "name": "Knowledgebase cross-agent retrieval",
-            "passed": False,
-            "required": True,
-            "details": f"No response from producer agent '{producer_agent}'.",
-        }
-
-    if not consumer_msgs:
-        return {
-            "name": "Knowledgebase cross-agent retrieval",
-            "passed": False,
-            "required": True,
-            "details": f"No response from consumer agent '{consumer_agent}'.",
-        }
-
-    producer_ok = any(fact_key in msg for msg in producer_msgs)
-    consumer_ok = any(fact_value in msg for msg in consumer_msgs)
-
-    if producer_ok and consumer_ok:
-        return {
-            "name": "Knowledgebase cross-agent retrieval",
-            "passed": True,
-            "required": True,
-            "details": (
-                f"Producer '{producer_agent}' referenced '{fact_key}' and consumer "
-                f"'{consumer_agent}' returned expected value '{fact_value}'."
-            ),
-        }
-
-    if not producer_ok:
-        return {
-            "name": "Knowledgebase cross-agent retrieval",
-            "passed": False,
-            "required": True,
-            "details": (
-                f"Producer '{producer_agent}' did not reference fact key '{fact_key}'."
-            ),
-        }
-
-    return {
-        "name": "Knowledgebase cross-agent retrieval",
-        "passed": False,
-        "required": True,
-        "details": (
-            f"Consumer '{consumer_agent}' did not return expected value '{fact_value}'."
-        ),
-    }
-
-
-def _apply_template_placeholders(value: Any, placeholders: dict[str, str]) -> Any:
-    """Recursively replace scenario placeholder tokens in nested config structures."""
-    if isinstance(value, str):
-        rendered = value
-        for key, replacement in placeholders.items():
-            rendered = rendered.replace(key, replacement)
-        return rendered
-    if isinstance(value, list):
-        return [_apply_template_placeholders(item, placeholders) for item in value]
-    if isinstance(value, dict):
-        return {
-            k: _apply_template_placeholders(v, placeholders)
-            for k, v in value.items()
-        }
-    return value
-
-
 def build_transcript(messages: list[tuple[str, str]]) -> str:
     """Build transcript from (role, text) pairs."""
     lines = []
@@ -2664,13 +2394,6 @@ def generate_eval_report(
             details = str(check.get("details", "")).replace("\n", " ")
             lines.append(f"| {check.get('name','')} | {required} | {status} | {details} |")
 
-    original_request = scenario_config["message"]
-    follow_up = scenario_config.get("follow_up_message")
-    if isinstance(follow_up, str) and follow_up.strip():
-        original_request = (
-            f"{original_request}\n\n[Follow-up request]\n{follow_up}"
-        )
-
     lines.extend(
         [
             "---",
@@ -2680,7 +2403,7 @@ def generate_eval_report(
             "### Original User Request",
             "",
             "```",
-            original_request,
+            scenario_config["message"],
             "```",
             "",
             "### Full Conversation",
@@ -2780,17 +2503,13 @@ async def run_evaluation(
         available = ", ".join(SCENARIOS.keys())
         raise ValueError(f"Unknown scenario: {scenario_name}. Available: {available}")
     else:
-        scenario = copy.deepcopy(SCENARIOS[scenario_name])
+        scenario = SCENARIOS[scenario_name]
 
     # Check if scenario is disabled
     if scenario.get("disabled"):
         print(f"\n>>> Scenario '{scenario_name}' is DISABLED: skipping.")
         print(f"    Reason: {scenario.get('disabled_reason', 'See scenario config')}")
         return
-
-    # Render dynamic placeholders (for example KB tokens) per run.
-    kb_token = datetime.now(timezone.utc).strftime("%Y%m%d%H%M%S")
-    scenario = _apply_template_placeholders(scenario, {"{KB_TOKEN}": kb_token})
 
     # Use per-scenario timeout if defined and CLI didn't explicitly override
     if "timeout" in scenario and wait_timeout == 600:
@@ -2828,7 +2547,6 @@ async def run_evaluation(
     print()
 
     user_message = scenario["message"]
-    follow_up_message = scenario.get("follow_up_message")
 
     if existing_thread_ts:
         # ── Re-score mode: skip Steps 1, 1b, 2 ──────────────────────────
@@ -3111,98 +2829,8 @@ async def run_evaluation(
 
         latency_ms = int((time.time() - start_time) * 1000)
 
-        # Optional follow-up step: ask a second agent in the same thread.
-        if follow_up_message:
-            print("\n>>> Step 2b: Triggering follow-up request in the same thread")
-            print(f"    Follow-up message: {follow_up_message[:80]}...")
-
-            # Baseline message count before follow-up trigger.
-            baseline_replies = await _slack_call(
-                slack.get_thread_replies, channel=channel, thread_ts=thread_ts, limit=50
-            )
-            baseline_count = len(baseline_replies)
-
-            try:
-                async with httpx.AsyncClient(timeout=30.0) as client:
-                    follow_up_payload: dict[str, Any] = {
-                        "channel": channel,
-                        "thread_ts": thread_ts,
-                        "text": follow_up_message,
-                        "user_id": "eval_script_followup",
-                    }
-                    if framework:
-                        follow_up_payload["framework"] = framework
-                    if use_async:
-                        follow_up_payload["use_async"] = True
-
-                    response = await client.post(
-                        trigger_url,
-                        json=follow_up_payload,
-                        headers=headers,
-                    )
-                    if response.status_code == 200:
-                        result = response.json()
-                        mode = result.get("mode", "sync")
-                        print(
-                            f"    Follow-up accepted: routing to {result.get('roles', [])} (mode={mode})"
-                        )
-                    else:
-                        print(
-                            f"    WARNING: Follow-up trigger returned {response.status_code}: {response.text}"
-                        )
-            except Exception as e:
-                print(f"    WARNING: Failed to trigger follow-up message: {e}")
-
-            print(
-                f"\n>>> Step 2c: Waiting for follow-up response (idle timeout: {wait_timeout}s)"
-            )
-            follow_start = time.time()
-            last_message_count = baseline_count
-            last_change_time = follow_start
-            follow_has_substantive = False
-
-            while True:
-                await asyncio.sleep(poll_interval)
-                replies = await _slack_call(
-                    slack.get_thread_replies, channel=channel, thread_ts=thread_ts, limit=50
-                )
-                current_count = len(replies)
-                if current_count > last_message_count:
-                    print(f"    New messages detected: {current_count - last_message_count}")
-                    last_message_count = current_count
-                    last_change_time = time.time()
-
-                new_bot_messages = [
-                    r
-                    for r in replies[baseline_count:]
-                    if r.is_bot and r.ts != thread_ts and not _is_placeholder(r.text)
-                ]
-                if new_bot_messages and not follow_has_substantive:
-                    follow_has_substantive = True
-                    last_change_time = time.time()
-                    print("    Substantive follow-up response detected.")
-
-                idle_for = int(time.time() - last_change_time)
-                elapsed = int(time.time() - follow_start)
-                print(f"    Waiting... (idle {idle_for}s / {wait_timeout}s, total {elapsed}s)")
-
-                if follow_has_substantive and (time.time() - last_change_time) >= 30:
-                    print("    Follow-up conversation stable for 30s.")
-                    break
-
-                if idle_for >= wait_timeout:
-                    if not follow_has_substantive:
-                        print("    No substantive follow-up response before idle timeout.")
-                    else:
-                        print("    Follow-up idle timeout reached after response.")
-                    break
-
-            latency_ms += int((time.time() - follow_start) * 1000)
-
     # Track conversation
     conversation: list[tuple[str, str]] = [("user", user_message)]
-    if follow_up_message:
-        conversation.append(("user", follow_up_message))
 
     # Step 3: Collect conversation
     print("\n>>> Step 3: Collecting conversation")
@@ -3290,22 +2918,6 @@ async def run_evaluation(
         if post_checks_config.get("sentry_issue_closed"):
             result = _check_sentry_issue_closed(transcript)
             result["id"] = "sentry_issue_closed"
-            post_checks_results.append(result)
-            status = "✅" if result.get("passed") else "❌"
-            print(f"    {status} {result.get('name')}: {result.get('details')}")
-
-        if post_checks_config.get("knowledgebase_cross_agent_retrieval"):
-            kb_cfg = post_checks_config.get("knowledgebase_cross_agent_retrieval", {})
-            if not isinstance(kb_cfg, dict):
-                kb_cfg = {}
-            result = _check_knowledgebase_cross_agent_retrieval(
-                conversation=conversation,
-                fact_key=str(kb_cfg.get("fact_key", "")),
-                fact_value=str(kb_cfg.get("fact_value", "")),
-                producer_agent=str(kb_cfg.get("producer_agent", "support_engineer")),
-                consumer_agent=str(kb_cfg.get("consumer_agent", "product_manager")),
-            )
-            result["id"] = "knowledgebase_cross_agent_retrieval"
             post_checks_results.append(result)
             status = "✅" if result.get("passed") else "❌"
             print(f"    {status} {result.get('name')}: {result.get('details')}")
@@ -3477,13 +3089,10 @@ async def run_evaluation(
 
     if metrics_passed is None and post_checks_passed is None:
         print("Overall: ⚠️ NOT EVALUATED")
-        overall_passed: bool | None = None
     elif metrics_passed is None:
         print(f"Overall: {'✅ PASSED' if post_checks_passed else '❌ FAILED'} (post-checks only)")
-        overall_passed = bool(post_checks_passed)
     elif post_checks_passed is None:
         print(f"Overall: {'✅ PASSED' if metrics_passed else '❌ FAILED'}")
-        overall_passed = bool(metrics_passed)
     else:
         overall_passed = metrics_passed and post_checks_passed
         print(f"Overall: {'✅ PASSED' if overall_passed else '❌ FAILED'}")
@@ -3510,7 +3119,9 @@ async def run_evaluation(
         "metrics": metrics_results,
         "latency_ms": latency_ms,
         "report_path": str(report_path),
-        "passed": overall_passed,
+        "passed": all(m["score"] >= m["threshold"] for m in metrics_results)
+        if metrics_results
+        else None,
     }
 
 

--- a/tests/test_check_github_app_permissions.py
+++ b/tests/test_check_github_app_permissions.py
@@ -1,0 +1,157 @@
+from __future__ import annotations
+
+from scripts import check_github_app_permissions as checker
+
+
+def test_resolve_role_assignee_prefers_role_specific_env(monkeypatch):
+    monkeypatch.setenv("GITHUB_SOFTWARE_ENGINEER_BOT_ASSIGNEE", "agentgithubapphandle")
+    monkeypatch.setenv("GITHUB_APP_BOT_USERNAME_SOFTWARE_ENGINEER", "fallback-app-handle")
+    monkeypatch.setenv("GITHUB_BOT_USERNAME_SOFTWARE_ENGINEER", "fallback-gateway-handle")
+
+    assert checker._resolve_role_assignee("software_engineer") == "agentgithubapphandle"
+
+
+def test_resolve_role_assignee_fallback_order(monkeypatch):
+    monkeypatch.delenv("GITHUB_SUPPORT_ENGINEER_BOT_ASSIGNEE", raising=False)
+    monkeypatch.setenv("GITHUB_APP_BOT_USERNAME_SUPPORT_ENGINEER", "app-handle")
+    monkeypatch.setenv("GITHUB_BOT_USERNAME_SUPPORT_ENGINEER", "gateway-handle")
+
+    assert checker._resolve_role_assignee("support_engineer") == "app-handle"
+
+
+def test_check_assignee_assignable_handles_204(monkeypatch):
+    class Response:
+        status_code = 204
+        text = ""
+
+        @staticmethod
+        def json() -> dict:
+            return {}
+
+    monkeypatch.setattr(checker.requests, "get", lambda *args, **kwargs: Response())
+
+    ok, status = checker._check_assignee_assignable(
+        repo="VibeTechnologies/vibeteam-eval-hello-world",
+        token="tok",
+        assignee="agentgithubapphandle",
+    )
+    assert ok is True
+    assert status == "assignable"
+
+
+def test_check_assignee_assignable_handles_non_assignable(monkeypatch):
+    class Response:
+        status_code = 404
+        text = "not found"
+
+        @staticmethod
+        def json() -> dict:
+            return {"message": "Not Found"}
+
+    monkeypatch.setattr(checker.requests, "get", lambda *args, **kwargs: Response())
+
+    ok, status = checker._check_assignee_assignable(
+        repo="VibeTechnologies/vibeteam-eval-hello-world",
+        token="tok",
+        assignee="vibeteam-swe-bot-260301[bot]",
+    )
+    assert ok is False
+    assert "not assignable status=404" in status
+
+
+def test_validate_installation_missing_id():
+    ok, status = checker._validate_installation_for_repo(
+        app_id="123",
+        private_key="pem",
+        installation_id=None,
+        repo="VibeTechnologies/vibeteam-eval-hello-world",
+    )
+    assert ok is False
+    assert "missing installation_id" in status
+
+
+def test_validate_installation_id_not_found(monkeypatch):
+    monkeypatch.setattr(
+        checker,
+        "list_installations",
+        lambda app_id, private_key: [{"id": 111}, {"id": 222}],
+    )
+
+    ok, status = checker._validate_installation_for_repo(
+        app_id="123",
+        private_key="pem",
+        installation_id="333",
+        repo="VibeTechnologies/vibeteam-eval-hello-world",
+    )
+    assert ok is False
+    assert "installation_id=333 not found" in status
+
+
+def test_validate_installation_skip_repo_check(monkeypatch):
+    monkeypatch.setattr(
+        checker,
+        "list_installations",
+        lambda app_id, private_key: [{"id": 333}],
+    )
+
+    ok, status = checker._validate_installation_for_repo(
+        app_id="123",
+        private_key="pem",
+        installation_id="333",
+        repo=None,
+    )
+    assert ok is True
+    assert status == "ok (repo check skipped)"
+
+
+def test_validate_installation_repo_access_ok(monkeypatch):
+    class Response:
+        status_code = 200
+
+        @staticmethod
+        def json() -> dict:
+            return {}
+
+    monkeypatch.setattr(
+        checker,
+        "list_installations",
+        lambda app_id, private_key: [{"id": 333}],
+    )
+    monkeypatch.setattr(checker, "get_installation_token", lambda a, b, c: "tok")
+    monkeypatch.setattr(checker.requests, "get", lambda *args, **kwargs: Response())
+
+    ok, status = checker._validate_installation_for_repo(
+        app_id="123",
+        private_key="pem",
+        installation_id="333",
+        repo="VibeTechnologies/vibeteam-eval-hello-world",
+    )
+    assert ok is True
+    assert status == "ok"
+
+
+def test_validate_installation_repo_access_fails(monkeypatch):
+    class Response:
+        status_code = 404
+        text = "not found"
+
+        @staticmethod
+        def json() -> dict:
+            return {"message": "Not Found"}
+
+    monkeypatch.setattr(
+        checker,
+        "list_installations",
+        lambda app_id, private_key: [{"id": 333}],
+    )
+    monkeypatch.setattr(checker, "get_installation_token", lambda a, b, c: "tok")
+    monkeypatch.setattr(checker.requests, "get", lambda *args, **kwargs: Response())
+
+    ok, status = checker._validate_installation_for_repo(
+        app_id="123",
+        private_key="pem",
+        installation_id="333",
+        repo="VibeTechnologies/vibeteam-eval-hello-world",
+    )
+    assert ok is False
+    assert "repo access status=404" in status

--- a/tests/test_eval_github_e2e.py
+++ b/tests/test_eval_github_e2e.py
@@ -1,9 +1,91 @@
 from __future__ import annotations
 
-from datetime import datetime, timezone
+from datetime import datetime, timedelta, timezone
 from pathlib import Path
 
 from scripts import eval_github_e2e
+from vibeteam.utils import github_app
+
+
+def test_require_token_prefers_valid_env_token(monkeypatch):
+    monkeypatch.setenv("GITHUB_TOKEN", "env-token")
+    monkeypatch.delenv("GH_TOKEN", raising=False)
+    monkeypatch.setattr(eval_github_e2e, "_get_gh_cli_token", lambda user=None: None)
+    monkeypatch.setattr(
+        eval_github_e2e,
+        "_is_token_usable",
+        lambda token: token == "env-token",
+    )
+
+    token = eval_github_e2e._require_token()
+    assert token == "env-token"
+
+
+def test_require_token_prefers_specific_gh_user(monkeypatch):
+    monkeypatch.setenv("GITHUB_TOKEN", "bad-token")
+    monkeypatch.delenv("GH_TOKEN", raising=False)
+
+    def fake_get_gh_cli_token(user=None):
+        if user == "OpenCodeEngineer":
+            return "preferred-gh-token"
+        return None
+
+    monkeypatch.setattr(eval_github_e2e, "_get_gh_cli_token", fake_get_gh_cli_token)
+    monkeypatch.setattr(
+        eval_github_e2e,
+        "_is_token_usable",
+        lambda token: token == "preferred-gh-token",
+    )
+
+    token = eval_github_e2e._require_token("OpenCodeEngineer")
+    assert token == "preferred-gh-token"
+
+
+def test_require_token_falls_back_to_role_app_token(monkeypatch):
+    monkeypatch.setenv("GITHUB_TOKEN", "bad-token")
+    monkeypatch.delenv("GH_TOKEN", raising=False)
+    monkeypatch.setattr(eval_github_e2e, "_get_gh_cli_token", lambda user=None: None)
+    monkeypatch.setattr(
+        eval_github_e2e,
+        "_is_token_usable",
+        lambda token: token == "app-token",
+    )
+    monkeypatch.setattr(
+        github_app,
+        "get_installation_token_for_role",
+        lambda role: "app-token" if role == "software_engineer" else None,
+    )
+
+    token = eval_github_e2e._require_token()
+    assert token == "app-token"
+
+
+def test_require_token_raises_without_usable_credentials(monkeypatch):
+    monkeypatch.delenv("GITHUB_TOKEN", raising=False)
+    monkeypatch.delenv("GH_TOKEN", raising=False)
+    monkeypatch.setattr(eval_github_e2e, "_get_gh_cli_token", lambda user=None: None)
+    monkeypatch.setattr(eval_github_e2e, "_is_token_usable", lambda token: False)
+    monkeypatch.setattr(github_app, "get_installation_token_for_role", lambda role: None)
+
+    try:
+        eval_github_e2e._require_token()
+        raise AssertionError("expected SystemExit")
+    except SystemExit as exc:
+        assert "No usable GitHub token found" in str(exc)
+
+
+def test_require_token_falls_back_to_gh_cli(monkeypatch):
+    monkeypatch.setenv("GITHUB_TOKEN", "bad-token")
+    monkeypatch.delenv("GH_TOKEN", raising=False)
+    monkeypatch.setattr(eval_github_e2e, "_get_gh_cli_token", lambda user=None: "gh-cli-token")
+    monkeypatch.setattr(
+        eval_github_e2e,
+        "_is_token_usable",
+        lambda token: token == "gh-cli-token",
+    )
+
+    token = eval_github_e2e._require_token()
+    assert token == "gh-cli-token"
 
 
 def test_issue_trigger_comment_uses_role_mentions_only():
@@ -35,6 +117,118 @@ def test_pick_issue_assignee_prefers_software_bot():
     assert selected == "vibeteam-swe-bot-260301[bot]"
 
 
+def test_default_assignee_for_role_and_bot_validation(monkeypatch):
+    monkeypatch.setitem(
+        eval_github_e2e.ROLE_DEFAULT_ASSIGNEES,
+        "software_engineer",
+        "vibeteam-swe-bot-260301[bot]",
+    )
+
+    assert (
+        eval_github_e2e._default_assignee_for_role("software_engineer")
+        == "vibeteam-swe-bot-260301[bot]"
+    )
+    assert eval_github_e2e._is_bot_login("vibeteam-swe-bot-260301[bot]") is True
+    assert eval_github_e2e._is_bot_login("OpenCodeEngineer") is False
+
+
+def test_is_bot_login_accepts_explicit_bot_handle_allowlist():
+    assert (
+        eval_github_e2e._is_bot_login(
+            "agentgithubapphandle",
+            extra_allowed={"agentgithubapphandle"},
+        )
+        is True
+    )
+
+
+def test_allowed_assignees_for_role_uses_role_env_and_default(monkeypatch):
+    monkeypatch.setitem(
+        eval_github_e2e.ROLE_DEFAULT_ASSIGNEES,
+        "software_engineer",
+        "vibeteam-swe-bot-260301[bot]",
+    )
+    monkeypatch.setenv(
+        "GITHUB_SOFTWARE_ENGINEER_BOT_ASSIGNEE",
+        "vibeteam-swe-bot-260301[bot],vibeteam-swe-bot-alt[bot]",
+    )
+
+    allowed = eval_github_e2e._allowed_assignees_for_role("software_engineer")
+    assert "vibeteam-swe-bot-260301[bot]" in allowed
+    assert "vibeteam-swe-bot-alt[bot]" in allowed
+
+
+def test_assignee_matches_issue_role_rejects_cross_role(monkeypatch):
+    monkeypatch.setitem(
+        eval_github_e2e.ROLE_DEFAULT_ASSIGNEES,
+        "software_engineer",
+        "vibeteam-swe-bot-260301[bot]",
+    )
+    monkeypatch.setitem(
+        eval_github_e2e.ROLE_DEFAULT_ASSIGNEES,
+        "support_engineer",
+        "vibeteam-support-bot-260301[bot]",
+    )
+
+    assert (
+        eval_github_e2e._assignee_matches_issue_role(
+            "vibeteam-swe-bot-260301[bot]",
+            "software_engineer",
+        )
+        is True
+    )
+    assert (
+        eval_github_e2e._assignee_matches_issue_role(
+            "vibeteam-support-bot-260301[bot]",
+            "software_engineer",
+        )
+        is False
+    )
+
+
+def test_resolve_issue_assignee_prefers_explicit_value(monkeypatch):
+    def fail_fetch_repo_assignees(owner, repo, token):
+        raise AssertionError("repo assignees should not be fetched when explicit assignee is set")
+
+    monkeypatch.setattr(eval_github_e2e, "_fetch_repo_assignees", fail_fetch_repo_assignees)
+
+    selected = eval_github_e2e._resolve_issue_assignee(
+        owner="VibeTechnologies",
+        repo="vibeteam-eval-hello-world",
+        token="token",
+        preferred_assignee="vibeteam-swe-bot-260301[bot]",
+    )
+    assert selected == "vibeteam-swe-bot-260301[bot]"
+
+
+def test_resolve_issue_assignee_prefers_repo_bot_login(monkeypatch):
+    def fake_fetch_repo_assignees(owner, repo, token):
+        return ["octocat", "vibeteam-swe-bot-260301[bot]", "vibeteam-support-bot-260301[bot]"]
+
+    monkeypatch.setattr(eval_github_e2e, "_fetch_repo_assignees", fake_fetch_repo_assignees)
+
+    selected = eval_github_e2e._resolve_issue_assignee(
+        owner="VibeTechnologies",
+        repo="vibeteam-eval-hello-world",
+        token="token",
+    )
+    assert selected == "vibeteam-swe-bot-260301[bot]"
+
+
+def test_resolve_issue_assignee_uses_role_default_when_no_repo_bot(monkeypatch):
+    def fake_fetch_repo_assignees(owner, repo, token):
+        return ["octocat", "alice", "bob"]
+
+    monkeypatch.setattr(eval_github_e2e, "_fetch_repo_assignees", fake_fetch_repo_assignees)
+
+    selected = eval_github_e2e._resolve_issue_assignee(
+        owner="VibeTechnologies",
+        repo="vibeteam-eval-hello-world",
+        token="token",
+    )
+    assert selected == "vibeteam-swe-bot-260301[bot]"
+
+
 def test_evaluate_issue_assignment_uses_existing_assignee(monkeypatch):
     def fake_fetch_assignees(owner, repo, number, token):
         return ["vibeteam-swe-bot-260301[bot]"]
@@ -58,7 +252,16 @@ def test_evaluate_issue_assignment_fails_when_assignee_not_present(monkeypatch):
     def fake_fetch_assignees(owner, repo, number, token):
         return ["some-other-user"]
 
+    def fake_assign_issue(owner, repo, token, issue_number, assignee):
+        return {
+            "assigned": False,
+            "assigned_at": datetime.now(timezone.utc),
+            "issue_assignees": ["some-other-user"],
+            "error": "Failed to assign issue to target",
+        }
+
     monkeypatch.setattr(eval_github_e2e, "_fetch_issue_assignees", fake_fetch_assignees)
+    monkeypatch.setattr(eval_github_e2e, "_assign_issue", fake_assign_issue)
 
     result = eval_github_e2e._evaluate_issue_assignment(
         owner="VibeTechnologies",
@@ -70,7 +273,177 @@ def test_evaluate_issue_assignment_fails_when_assignee_not_present(monkeypatch):
 
     assert result["assignment_passed"] is False
     assert result["target_assignee"] == "vibeteam-swe-bot-260301[bot]"
-    assert "Expected assignee vibeteam-swe-bot-260301[bot]" in result["assignment_error"]
+    assert "Failed to assign issue to target" in result["assignment_error"]
+
+
+def test_evaluate_issue_assignment_assigns_when_missing(monkeypatch):
+    called = {"assignee": None}
+
+    def fake_fetch_assignees(owner, repo, number, token):
+        return ["some-other-user"]
+
+    def fake_assign_issue(owner, repo, token, issue_number, assignee):
+        called["assignee"] = assignee
+        return {
+            "assigned": True,
+            "assigned_at": datetime.now(timezone.utc),
+            "issue_assignees": ["some-other-user", assignee],
+            "error": "",
+        }
+
+    monkeypatch.setattr(eval_github_e2e, "_fetch_issue_assignees", fake_fetch_assignees)
+    monkeypatch.setattr(eval_github_e2e, "_assign_issue", fake_assign_issue)
+
+    result = eval_github_e2e._evaluate_issue_assignment(
+        owner="VibeTechnologies",
+        repo="vibeteam-eval-hello-world",
+        token="token",
+        issue_number=92,
+        bot_logins={"vibeteam-swe-bot-260301[bot]"},
+    )
+
+    assert called["assignee"] == "vibeteam-swe-bot-260301[bot]"
+    assert result["assignment_passed"] is True
+    assert result["issue_assignees"] == [
+        "some-other-user",
+        "vibeteam-swe-bot-260301[bot]",
+    ]
+
+
+def test_evaluate_issue_assignment_force_reassigns_existing_assignee(monkeypatch):
+    called = {"unassign": 0, "assign": 0}
+
+    def fake_fetch_assignees(owner, repo, number, token):
+        return ["vibeteam-swe-bot-260301[bot]"]
+
+    def fake_unassign_issue(owner, repo, token, issue_number, assignee):
+        called["unassign"] += 1
+        return {
+            "removed": True,
+            "issue_assignees": [],
+            "error": "",
+        }
+
+    def fake_assign_issue(owner, repo, token, issue_number, assignee):
+        called["assign"] += 1
+        return {
+            "assigned": True,
+            "assigned_at": datetime.now(timezone.utc),
+            "issue_assignees": [assignee],
+            "error": "",
+        }
+
+    monkeypatch.setattr(eval_github_e2e, "_fetch_issue_assignees", fake_fetch_assignees)
+    monkeypatch.setattr(eval_github_e2e, "_unassign_issue", fake_unassign_issue)
+    monkeypatch.setattr(eval_github_e2e, "_assign_issue", fake_assign_issue)
+
+    result = eval_github_e2e._evaluate_issue_assignment(
+        owner="VibeTechnologies",
+        repo="vibeteam-eval-hello-world",
+        token="token",
+        issue_number=92,
+        bot_logins={"vibeteam-swe-bot-260301[bot]"},
+        force_reassign=True,
+    )
+
+    assert called["unassign"] == 1
+    assert called["assign"] == 1
+    assert result["assignment_passed"] is True
+
+
+def test_evaluate_issue_assignment_validates_expected_assignment_actor(monkeypatch):
+    def fake_fetch_assignees(owner, repo, number, token):
+        return ["vibeteam-swe-bot-260301[bot]"]
+
+    def fake_fetch_assignment_events(owner, repo, token, issue_number, target_assignee, since):
+        return [
+            {
+                "event": "assigned",
+                "assignee": {"login": target_assignee},
+                "actor": {"login": "OpenCodeEngineer"},
+                "created_at": "2026-03-06T00:00:00Z",
+            }
+        ]
+
+    monkeypatch.setattr(eval_github_e2e, "_fetch_issue_assignees", fake_fetch_assignees)
+    monkeypatch.setattr(
+        eval_github_e2e,
+        "_fetch_issue_assignment_events",
+        fake_fetch_assignment_events,
+    )
+
+    result = eval_github_e2e._evaluate_issue_assignment(
+        owner="VibeTechnologies",
+        repo="vibeteam-eval-hello-world",
+        token="token",
+        issue_number=92,
+        bot_logins={"vibeteam-swe-bot-260301[bot]"},
+        expected_actor_login="OpenCodeEngineer",
+    )
+
+    assert result["assignment_passed"] is True
+    assert result["assignment_event_seen"] is True
+    assert result["assignment_event_actors"] == ["OpenCodeEngineer"]
+    assert result["assignment_actor_passed"] is True
+    assert result["assignment_actor_error"] == ""
+
+
+def test_evaluate_issue_assignment_fails_on_actor_mismatch(monkeypatch):
+    def fake_fetch_assignees(owner, repo, number, token):
+        return ["vibeteam-swe-bot-260301[bot]"]
+
+    def fake_fetch_assignment_events(owner, repo, token, issue_number, target_assignee, since):
+        return [
+            {
+                "event": "assigned",
+                "assignee": {"login": target_assignee},
+                "actor": {"login": "dzianisv"},
+                "created_at": "2026-03-06T00:00:00Z",
+            }
+        ]
+
+    monkeypatch.setattr(eval_github_e2e, "_fetch_issue_assignees", fake_fetch_assignees)
+    monkeypatch.setattr(
+        eval_github_e2e,
+        "_fetch_issue_assignment_events",
+        fake_fetch_assignment_events,
+    )
+
+    result = eval_github_e2e._evaluate_issue_assignment(
+        owner="VibeTechnologies",
+        repo="vibeteam-eval-hello-world",
+        token="token",
+        issue_number=92,
+        bot_logins={"vibeteam-swe-bot-260301[bot]"},
+        expected_actor_login="OpenCodeEngineer",
+    )
+
+    assert result["assignment_passed"] is True
+    assert result["assignment_event_seen"] is True
+    assert result["assignment_event_actors"] == ["dzianisv"]
+    assert result["assignment_actor_passed"] is False
+    assert "Assignment event actor mismatch" in result["assignment_actor_error"]
+
+
+def test_wait_for_assignee_activity_requires_target_bot_login():
+    now = datetime.now(timezone.utc)
+    recent_ts = (now + timedelta(seconds=1)).isoformat().replace("+00:00", "Z")
+    comments = [
+        {
+            "created_at": recent_ts,
+            "user": {"login": "vibeteam-swe-bot-260301[bot]", "type": "Bot"},
+        }
+    ]
+
+    result = eval_github_e2e._wait_for_assignee_activity(
+        fetch_comments=lambda: comments,
+        since=now,
+        target_assignee="OpenCodeEngineer",
+        timeout=1,
+        poll_interval=0,
+    )
+
+    assert result == set()
 
 
 def test_run_issue_handoff_presence_requires_assignment(monkeypatch):
@@ -120,6 +493,137 @@ def test_run_issue_handoff_presence_requires_assignment(monkeypatch):
     assert result["target_assignee"] == "vibeteam-swe-bot-260301[bot]"
 
 
+def test_run_issue_handoff_requires_assignee_activity_for_pass(monkeypatch):
+    now = datetime.now(timezone.utc)
+    called = {"waited_for": None}
+
+    def fake_create_issue(owner, repo, token):
+        return (
+            109,
+            "https://github.com/VibeTechnologies/vibeteam-eval-hello-world/issues/109",
+            now,
+            "OpenCodeEngineer",
+        )
+
+    def fail_create_issue_comment(*args, **kwargs):
+        raise AssertionError("assignment-first issue handoff must not post trigger comments")
+
+    def fake_wait_for_bot_authors(fetch_comments, since, min_bots, timeout, poll_interval=10):
+        return {"vibeteam-support-bot-260301[bot]"}
+
+    def fake_wait_for_assignee_activity(fetch_comments, since, target_assignee, timeout, poll_interval=10):
+        called["waited_for"] = target_assignee
+        return set()
+
+    def fake_fetch_issue_comments(owner, repo, number, token, since=None):
+        return [
+            {
+                "created_at": now.isoformat().replace("+00:00", "Z"),
+                "user": {"login": "vibeteam-support-bot-260301[bot]", "type": "Bot"},
+            },
+            {
+                "created_at": now.isoformat().replace("+00:00", "Z"),
+                "user": {"login": "vibeteam-swe-bot-260301[bot]", "type": "Bot"},
+            }
+        ]
+
+    def fake_evaluate_issue_assignment(*args, **kwargs):
+        return {
+            "target_assignee": "vibeteam-swe-bot-260301[bot]",
+            "issue_assignees": ["vibeteam-swe-bot-260301[bot]"],
+            "assignment_passed": True,
+            "assignment_error": "",
+            "assignment_event_seen": True,
+            "assignment_event_count": 1,
+            "assignment_event_error": "",
+        }
+
+    monkeypatch.setattr(eval_github_e2e, "_create_issue", fake_create_issue)
+    monkeypatch.setattr(eval_github_e2e, "_create_issue_comment", fail_create_issue_comment)
+    monkeypatch.setattr(eval_github_e2e, "_wait_for_bot_authors", fake_wait_for_bot_authors)
+    monkeypatch.setattr(eval_github_e2e, "_wait_for_assignee_activity", fake_wait_for_assignee_activity)
+    monkeypatch.setattr(eval_github_e2e, "_fetch_issue_comments", fake_fetch_issue_comments)
+    monkeypatch.setattr(eval_github_e2e, "_evaluate_issue_assignment", fake_evaluate_issue_assignment)
+
+    result = eval_github_e2e._run_issue_handoff(
+        owner="VibeTechnologies",
+        repo="vibeteam-eval-hello-world",
+        token="token",
+        timeout=60,
+        issue_assignee="vibeteam-swe-bot-260301[bot]",
+    )
+
+    assert called["waited_for"] == "vibeteam-swe-bot-260301[bot]"
+    assert result["assignment_passed"] is True
+    assert result["creator_passed"] is True
+    assert result["assignment_event_seen"] is True
+    assert result["passed"] is False
+
+
+def test_run_issue_handoff_passes_with_assignment_and_assignee_activity(monkeypatch):
+    now = datetime.now(timezone.utc)
+
+    def fake_create_issue(owner, repo, token):
+        return (
+            110,
+            "https://github.com/VibeTechnologies/vibeteam-eval-hello-world/issues/110",
+            now,
+            "OpenCodeEngineer",
+        )
+
+    def fail_create_issue_comment(*args, **kwargs):
+        raise AssertionError("assignment-first issue handoff must not post trigger comments")
+
+    def fake_wait_for_bot_authors(fetch_comments, since, min_bots, timeout, poll_interval=10):
+        return {"vibeteam-support-bot-260301[bot]"}
+
+    def fake_wait_for_assignee_activity(fetch_comments, since, target_assignee, timeout, poll_interval=10):
+        return {target_assignee}
+
+    def fake_fetch_issue_comments(owner, repo, number, token, since=None):
+        return [
+            {
+                "created_at": now.isoformat().replace("+00:00", "Z"),
+                "user": {"login": "vibeteam-support-bot-260301[bot]", "type": "Bot"},
+            },
+            {
+                "created_at": now.isoformat().replace("+00:00", "Z"),
+                "user": {"login": "vibeteam-swe-bot-260301[bot]", "type": "Bot"},
+            },
+        ]
+
+    def fake_evaluate_issue_assignment(*args, **kwargs):
+        return {
+            "target_assignee": "vibeteam-swe-bot-260301[bot]",
+            "issue_assignees": ["vibeteam-swe-bot-260301[bot]"],
+            "assignment_passed": True,
+            "assignment_error": "",
+            "assignment_event_seen": True,
+            "assignment_event_count": 1,
+            "assignment_event_error": "",
+        }
+
+    monkeypatch.setattr(eval_github_e2e, "_create_issue", fake_create_issue)
+    monkeypatch.setattr(eval_github_e2e, "_create_issue_comment", fail_create_issue_comment)
+    monkeypatch.setattr(eval_github_e2e, "_wait_for_bot_authors", fake_wait_for_bot_authors)
+    monkeypatch.setattr(eval_github_e2e, "_wait_for_assignee_activity", fake_wait_for_assignee_activity)
+    monkeypatch.setattr(eval_github_e2e, "_fetch_issue_comments", fake_fetch_issue_comments)
+    monkeypatch.setattr(eval_github_e2e, "_evaluate_issue_assignment", fake_evaluate_issue_assignment)
+
+    result = eval_github_e2e._run_issue_handoff(
+        owner="VibeTechnologies",
+        repo="vibeteam-eval-hello-world",
+        token="token",
+        timeout=60,
+        issue_assignee="vibeteam-swe-bot-260301[bot]",
+    )
+
+    assert result["assignment_passed"] is True
+    assert result["creator_passed"] is True
+    assert result["assignment_event_seen"] is True
+    assert result["passed"] is True
+
+
 def test_run_issue_handoff_presence_passes_with_assignment_and_recent_activity(monkeypatch):
     now = datetime.now(timezone.utc)
 
@@ -143,6 +647,9 @@ def test_run_issue_handoff_presence_passes_with_assignment_and_recent_activity(m
             "issue_assignees": ["vibeteam-swe-bot-260301[bot]"],
             "assignment_passed": True,
             "assignment_error": "",
+            "assignment_event_seen": True,
+            "assignment_event_count": 1,
+            "assignment_event_error": "",
         }
 
     monkeypatch.setattr(eval_github_e2e, "_create_issue_comment", fake_create_issue_comment)
@@ -160,10 +667,13 @@ def test_run_issue_handoff_presence_passes_with_assignment_and_recent_activity(m
     )
 
     assert result["assignment_passed"] is True
+    assert result["assignment_event_seen"] is True
     assert result["passed"] is True
 
 
 def test_run_issue_handoff_existing_skips_trigger_comment_by_default(monkeypatch):
+    called = {"waited_for": None}
+
     def fail_create_issue_comment(*args, **kwargs):
         raise AssertionError("trigger comment should not be posted for existing issue by default")
 
@@ -185,11 +695,25 @@ def test_run_issue_handoff_existing_skips_trigger_comment_by_default(monkeypatch
             "issue_assignees": ["vibeteam-swe-bot-260301[bot]"],
             "assignment_passed": True,
             "assignment_error": "",
+            "assignment_event_seen": True,
+            "assignment_event_count": 1,
+            "assignment_event_error": "",
         }
+
+    def fake_wait_for_assignee_activity(
+        fetch_comments, since, target_assignee, timeout, poll_interval=10
+    ):
+        called["waited_for"] = target_assignee
+        return {target_assignee}
 
     monkeypatch.setattr(eval_github_e2e, "_create_issue_comment", fail_create_issue_comment)
     monkeypatch.setattr(eval_github_e2e, "_fetch_issue_comments", fake_fetch_issue_comments)
     monkeypatch.setattr(eval_github_e2e, "_evaluate_issue_assignment", fake_assignment)
+    monkeypatch.setattr(
+        eval_github_e2e,
+        "_wait_for_assignee_activity",
+        fake_wait_for_assignee_activity,
+    )
 
     result = eval_github_e2e._run_issue_handoff_existing(
         owner="VibeTechnologies",
@@ -199,19 +723,97 @@ def test_run_issue_handoff_existing_skips_trigger_comment_by_default(monkeypatch
         timeout=60,
     )
 
+    assert called["waited_for"] == "vibeteam-swe-bot-260301[bot]"
     assert result["passed"] is True
     assert result["assignment_passed"] is True
+    assert result["assignment_event_seen"] is True
+
+
+def test_run_issue_handoff_existing_uses_actor_login_for_assignment_event_check(monkeypatch):
+    captured = {"expected_actor": None}
+
+    def fake_fetch_issue_comments(owner, repo, number, token, since=None):
+        return [
+            {
+                "created_at": datetime.now(timezone.utc).isoformat().replace("+00:00", "Z"),
+                "user": {"login": "vibeteam-swe-bot-260301[bot]", "type": "Bot"},
+            }
+        ]
+
+    def fake_assignment(
+        owner,
+        repo,
+        token,
+        issue_number,
+        bot_logins,
+        preferred_assignee,
+        issue_role,
+        wait_seconds=0,
+        poll_interval=5,
+        force_reassign=False,
+        assignment_started_at=None,
+        expected_actor_login=None,
+    ):
+        captured["expected_actor"] = expected_actor_login
+        return {
+            "target_assignee": "vibeteam-swe-bot-260301[bot]",
+            "issue_assignees": ["vibeteam-swe-bot-260301[bot]"],
+            "assignment_passed": True,
+            "assignment_error": "",
+            "assignment_event_seen": True,
+            "assignment_event_count": 1,
+            "assignment_event_error": "",
+            "assignment_event_actors": ["OpenCodeEngineer"],
+            "assignment_actor_passed": True,
+            "assignment_actor_error": "",
+        }
+
+    def fake_wait_for_assignee_activity(
+        fetch_comments, since, target_assignee, timeout, poll_interval=10
+    ):
+        return {target_assignee}
+
+    monkeypatch.setattr(eval_github_e2e, "_fetch_issue_comments", fake_fetch_issue_comments)
+    monkeypatch.setattr(eval_github_e2e, "_evaluate_issue_assignment", fake_assignment)
+    monkeypatch.setattr(
+        eval_github_e2e,
+        "_wait_for_assignee_activity",
+        fake_wait_for_assignee_activity,
+    )
+
+    result = eval_github_e2e._run_issue_handoff_existing(
+        owner="VibeTechnologies",
+        repo="vibeteam-eval-hello-world",
+        token="token",
+        issue_number=92,
+        timeout=60,
+        actor_login="OpenCodeEngineer",
+    )
+
+    assert captured["expected_actor"] == "OpenCodeEngineer"
+    assert result["assignment_actor_passed"] is True
+    assert result["passed"] is True
 
 
 def test_run_issue_pr_handoff_uses_existing_issue_and_passes_assignee(monkeypatch):
     issue_called = {"presence": False, "assignee": None}
 
     def fake_issue_presence(
-        owner, repo, token, issue_number, timeout, issue_assignee, post_trigger_comment
+        owner,
+        repo,
+        token,
+        issue_number,
+        timeout,
+        issue_assignee,
+        issue_role,
+        post_trigger_comment,
+        actor_login="n/a",
     ):
         issue_called["presence"] = True
         issue_called["assignee"] = issue_assignee
+        assert issue_role == "software_engineer"
         assert post_trigger_comment is False
+        assert actor_login == "OpenCodeEngineer"
         return {
             "thread": "https://github.com/VibeTechnologies/vibeteam-eval-hello-world/issues/92",
             "bot_logins": ["vibeteam-swe-bot-260301[bot]"],
@@ -220,6 +822,16 @@ def test_run_issue_pr_handoff_uses_existing_issue_and_passes_assignee(monkeypatc
             "issue_assignees": [issue_assignee],
             "assignment_passed": True,
             "assignment_error": "",
+            "assignment_event_seen": True,
+            "assignment_event_count": 1,
+            "assignment_event_error": "",
+            "assignment_event_actors": ["OpenCodeEngineer"],
+            "assignment_actor_passed": True,
+            "assignment_actor_error": "",
+            "actor_login": "OpenCodeEngineer",
+            "issue_creator": "n/a",
+            "creator_passed": True,
+            "creator_error": "",
             "passed": True,
         }
 
@@ -250,10 +862,137 @@ def test_run_issue_pr_handoff_uses_existing_issue_and_passes_assignee(monkeypatc
     assert result["passed"] is True
     assert result["threads"]["issue"]["assignment_passed"] is True
     assert result["threads"]["pr"]["passed"] is True
+    assert result["assignment_event_seen"] is True
+    assert result["creator_passed"] is True
     assert result["bot_logins"] == [
         "vibeteam-support-bot-260301[bot]",
         "vibeteam-swe-bot-260301[bot]",
     ]
+
+
+def test_run_issue_handoff_fails_when_creator_mismatch(monkeypatch):
+    now = datetime.now(timezone.utc)
+
+    def fake_create_issue(owner, repo, token):
+        return (
+            111,
+            "https://github.com/VibeTechnologies/vibeteam-eval-hello-world/issues/111",
+            now,
+            "dzianisv",
+        )
+
+    def fake_wait_for_assignee_activity(fetch_comments, since, target_assignee, timeout, poll_interval=10):
+        return {target_assignee}
+
+    def fake_fetch_issue_comments(owner, repo, number, token, since=None):
+        return [
+            {
+                "created_at": now.isoformat().replace("+00:00", "Z"),
+                "user": {"login": "vibeteam-swe-bot-260301[bot]", "type": "Bot"},
+            }
+        ]
+
+    def fake_evaluate_issue_assignment(*args, **kwargs):
+        return {
+            "target_assignee": "vibeteam-swe-bot-260301[bot]",
+            "issue_assignees": ["vibeteam-swe-bot-260301[bot]"],
+            "assignment_passed": True,
+            "assignment_error": "",
+            "assignment_event_seen": True,
+            "assignment_event_count": 1,
+            "assignment_event_error": "",
+        }
+
+    monkeypatch.setattr(eval_github_e2e, "_create_issue", fake_create_issue)
+    monkeypatch.setattr(eval_github_e2e, "_wait_for_assignee_activity", fake_wait_for_assignee_activity)
+    monkeypatch.setattr(eval_github_e2e, "_fetch_issue_comments", fake_fetch_issue_comments)
+    monkeypatch.setattr(eval_github_e2e, "_evaluate_issue_assignment", fake_evaluate_issue_assignment)
+
+    result = eval_github_e2e._run_issue_handoff(
+        owner="VibeTechnologies",
+        repo="vibeteam-eval-hello-world",
+        token="token",
+        timeout=60,
+        issue_assignee="vibeteam-swe-bot-260301[bot]",
+        actor_login="OpenCodeEngineer",
+    )
+
+    assert result["creator_passed"] is False
+    assert "Issue creator mismatch" in result["creator_error"]
+    assert result["assignment_passed"] is True
+    assert result["assignment_event_seen"] is True
+    assert result["passed"] is False
+
+
+def test_run_issue_pr_handoff_new_issue_enforces_creator(monkeypatch):
+    now = datetime.now(timezone.utc)
+
+    def fake_create_issue(owner, repo, token):
+        return (
+            112,
+            "https://github.com/VibeTechnologies/vibeteam-eval-hello-world/issues/112",
+            now,
+            "OpenCodeEngineer",
+        )
+
+    def fake_issue_presence(
+        owner,
+        repo,
+        token,
+        issue_number,
+        timeout,
+        issue_assignee,
+        issue_role,
+        post_trigger_comment,
+        actor_login="n/a",
+    ):
+        return {
+            "thread": "https://github.com/VibeTechnologies/vibeteam-eval-hello-world/issues/112",
+            "bot_logins": ["vibeteam-swe-bot-260301[bot]"],
+            "recent_bot_logins": ["vibeteam-swe-bot-260301[bot]"],
+            "target_assignee": issue_assignee,
+            "issue_assignees": [issue_assignee],
+            "assignment_passed": True,
+            "assignment_error": "",
+            "assignment_event_seen": True,
+            "assignment_event_count": 1,
+            "assignment_event_error": "",
+            "actor_login": actor_login,
+            "issue_creator": "n/a",
+            "creator_passed": True,
+            "creator_error": "",
+            "passed": True,
+        }
+
+    def fake_pr_presence(owner, repo, token, pr_number, timeout):
+        return {
+            "thread": "https://github.com/VibeTechnologies/vibeteam-eval-hello-world/pull/1",
+            "bot_logins": ["vibeteam-support-bot-260301[bot]"],
+            "recent_bot_logins": ["vibeteam-support-bot-260301[bot]"],
+            "passed": True,
+        }
+
+    monkeypatch.setattr(eval_github_e2e, "_create_issue", fake_create_issue)
+    monkeypatch.setattr(eval_github_e2e, "_run_issue_handoff_presence", fake_issue_presence)
+    monkeypatch.setattr(eval_github_e2e, "_run_pr_handoff_presence", fake_pr_presence)
+
+    result = eval_github_e2e._run_issue_pr_handoff(
+        "VibeTechnologies",
+        "vibeteam-eval-hello-world",
+        "token",
+        0,
+        1,
+        60,
+        "vibeteam-swe-bot-260301[bot]",
+        "software_engineer",
+        False,
+        "OpenCodeEngineer",
+    )
+
+    assert result["creator_passed"] is True
+    assert result["issue_creator"] == "OpenCodeEngineer"
+    assert result["assignment_event_seen"] is True
+    assert result["passed"] is True
 
 
 def test_write_report_with_thread_details_and_assignment(tmp_path, monkeypatch):
@@ -275,6 +1014,16 @@ def test_write_report_with_thread_details_and_assignment(tmp_path, monkeypatch):
                 "issue_assignees": [assignee],
                 "assignment_passed": True,
                 "assignment_error": "",
+                "assignment_event_seen": True,
+                "assignment_event_count": 1,
+                "assignment_event_error": "",
+                "assignment_event_actors": ["OpenCodeEngineer"],
+                "assignment_actor_passed": True,
+                "assignment_actor_error": "",
+                "actor_login": "OpenCodeEngineer",
+                "issue_creator": "OpenCodeEngineer",
+                "creator_passed": True,
+                "creator_error": "",
             },
             "pr": {
                 "thread": pr_url,
@@ -295,6 +1044,13 @@ def test_write_report_with_thread_details_and_assignment(tmp_path, monkeypatch):
     assert "### PR" in report
     assert f"- Thread: {issue_url}" in report
     assert f"- Thread: {pr_url}" in report
-    assert "- Recent bot authors after trigger: bot-a" in report
+    assert "- Recent bot authors after assignment/trigger: bot-a" in report
     assert "- Issue assigned: ✅" in report
     assert f"- Target assignee: {assignee}" in report
+    assert "- Assignment event observed: ✅" in report
+    assert "- Assignment event count: 1" in report
+    assert "- Assignment event actors: OpenCodeEngineer" in report
+    assert "- Assignment actor check: ✅" in report
+    assert "- Issue creator check: ✅" in report
+    assert "- Expected actor: OpenCodeEngineer" in report
+    assert "- Issue creator: OpenCodeEngineer" in report

--- a/tests/test_webhook_integration.py
+++ b/tests/test_webhook_integration.py
@@ -59,6 +59,25 @@ def generate_sentry_signature(payload: str, secret: str) -> str:
 class TestGitHubWebhookRouting:
     """Test GitHub webhook routing to agents."""
 
+    def test_resolve_assignment_role_from_explicit_role_handle(self, monkeypatch):
+        """Explicit role-assignee env mapping should select that role."""
+        from vibeteam.gateway.routes import github as github_routes
+
+        monkeypatch.setenv("GITHUB_APP_BOT_USERNAME_SUPPORT_ENGINEER", "agentgithubapphandle")
+        role = github_routes.resolve_assignment_role({"login": "agentgithubapphandle"})
+        assert role == "support_engineer"
+
+    def test_resolve_assignment_role_from_login_convention(self):
+        """Role should be inferred from conventional role-bot login names."""
+        from vibeteam.gateway.routes import github as github_routes
+
+        assert (
+            github_routes.resolve_assignment_role(
+                {"login": "vibeteam-release-bot-260301[bot]"}
+            )
+            == "release_engineer"
+        )
+
     def test_issue_assigned_to_bot(self, test_client, github_webhook_secret, monkeypatch):
         """Test that issue assignment to bot triggers SWE agent."""
         monkeypatch.setenv("GITHUB_WEBHOOK_SECRET", github_webhook_secret)
@@ -149,9 +168,7 @@ class TestGitHubWebhookRouting:
         assert data["status"] == "accepted"
         assert "release_engineer" in data["message"].lower()
 
-    def test_discussion_created_with_role_mention(
-        self, test_client, github_webhook_secret, monkeypatch
-    ):
+    def test_discussion_created_with_role_mention(self, test_client, github_webhook_secret, monkeypatch):
         """Test that discussion body with /RoleName triggers appropriate agent."""
         monkeypatch.setenv("GITHUB_WEBHOOK_SECRET", github_webhook_secret)
         monkeypatch.setenv("GITHUB_BOT_USERNAME", "vibeteam-bot[bot]")
@@ -354,85 +371,6 @@ class TestGitHubWebhookRouting:
             assert "Invalid signature" in response.text
         finally:
             github.config.GITHUB_WEBHOOK_SECRET = original_secret
-
-    def test_unsigned_eval_repo_allowed_when_flag_enabled(self, test_client):
-        """Allow unsigned webhook only for explicitly allowlisted eval repo."""
-        from vibeteam.gateway.routes import github
-
-        original_secret = github.config.GITHUB_WEBHOOK_SECRET
-        original_allow = github.config.GITHUB_ALLOW_UNSIGNED_EVAL_WEBHOOKS
-        original_repos = github.config.GITHUB_UNSIGNED_WEBHOOK_REPOS
-
-        github.config.GITHUB_WEBHOOK_SECRET = "test_secret"
-        github.config.GITHUB_ALLOW_UNSIGNED_EVAL_WEBHOOKS = True
-        github.config.GITHUB_UNSIGNED_WEBHOOK_REPOS = {
-            "vibetechnologies/vibeteam-eval-hello-world"
-        }
-
-        try:
-            payload = {
-                "action": "created",
-                "issue": {"number": 123},
-                "comment": {"body": "@SupportEngineer check this", "user": {"login": "testuser"}},
-                "repository": {"full_name": "VibeTechnologies/vibeteam-eval-hello-world"},
-            }
-            payload_str = json.dumps(payload)
-
-            response = test_client.post(
-                "/webhook",
-                content=payload_str,
-                headers={
-                    "X-GitHub-Event": "issue_comment",
-                    "X-Hub-Signature-256": "sha256=invalid_signature",
-                    "Content-Type": "application/json",
-                },
-            )
-
-            assert response.status_code == 200
-            assert response.json()["status"] == "accepted"
-        finally:
-            github.config.GITHUB_WEBHOOK_SECRET = original_secret
-            github.config.GITHUB_ALLOW_UNSIGNED_EVAL_WEBHOOKS = original_allow
-            github.config.GITHUB_UNSIGNED_WEBHOOK_REPOS = original_repos
-
-    def test_unsigned_non_allowlisted_repo_still_rejected(self, test_client):
-        """Unsigned webhook remains rejected for non-allowlisted repos."""
-        from vibeteam.gateway.routes import github
-
-        original_secret = github.config.GITHUB_WEBHOOK_SECRET
-        original_allow = github.config.GITHUB_ALLOW_UNSIGNED_EVAL_WEBHOOKS
-        original_repos = github.config.GITHUB_UNSIGNED_WEBHOOK_REPOS
-
-        github.config.GITHUB_WEBHOOK_SECRET = "test_secret"
-        github.config.GITHUB_ALLOW_UNSIGNED_EVAL_WEBHOOKS = True
-        github.config.GITHUB_UNSIGNED_WEBHOOK_REPOS = {
-            "vibetechnologies/vibeteam-eval-hello-world"
-        }
-
-        try:
-            payload = {
-                "action": "opened",
-                "issue": {"number": 1},
-                "repository": {"full_name": "VibeTechnologies/other-repo"},
-            }
-            payload_str = json.dumps(payload)
-
-            response = test_client.post(
-                "/webhook",
-                content=payload_str,
-                headers={
-                    "X-GitHub-Event": "issues",
-                    "X-Hub-Signature-256": "sha256=invalid_signature",
-                    "Content-Type": "application/json",
-                },
-            )
-
-            assert response.status_code == 401
-            assert "Invalid signature" in response.text
-        finally:
-            github.config.GITHUB_WEBHOOK_SECRET = original_secret
-            github.config.GITHUB_ALLOW_UNSIGNED_EVAL_WEBHOOKS = original_allow
-            github.config.GITHUB_UNSIGNED_WEBHOOK_REPOS = original_repos
 
     def test_bot_own_comment_ignored(self, test_client, github_webhook_secret, monkeypatch):
         """issue_comment from vibeteam-bot[bot] → ignored with reason own_comment."""
@@ -851,6 +789,167 @@ class TestGitHubWebhookRouting:
         data = response.json()
         assert data["status"] == "accepted"
         assert "401" in data["message"]
+
+    def test_issue_assigned_to_role_bot_handle_triggers(
+        self, test_client, github_webhook_secret, monkeypatch
+    ):
+        """Role-app bot handles (vibeteam-*-bot-*) should trigger assignment flow."""
+        monkeypatch.setenv("GITHUB_WEBHOOK_SECRET", github_webhook_secret)
+        monkeypatch.setenv("GITHUB_BOT_USERNAME", "vibeteam-bot[bot]")
+        monkeypatch.delenv("GITHUB_BOT_USER_ID", raising=False)
+
+        payload = {
+            "action": "assigned",
+            "issue": {
+                "number": 402,
+                "title": "Role bot assignment test",
+                "body": "Testing role bot login matching",
+                "html_url": "https://github.com/owner/repo/issues/402",
+            },
+            "assignee": {"login": "vibeteam-swe-bot-260301[bot]", "id": 88888},
+            "repository": {"full_name": "owner/repo"},
+        }
+
+        payload_str = json.dumps(payload)
+        signature = generate_github_signature(payload_str, github_webhook_secret)
+
+        with (
+            patch(
+                "vibeteam.gateway.routes.github.call_agent_service",
+                new_callable=AsyncMock,
+                return_value={"response": "Working on it"},
+            ),
+            patch(
+                "vibeteam.gateway.routes.github.post_acknowledgment",
+                new_callable=AsyncMock,
+            ),
+            patch(
+                "vibeteam.gateway.routes.github.post_github_comment",
+                new_callable=AsyncMock,
+            ),
+        ):
+            response = test_client.post(
+                "/webhook",
+                content=payload_str,
+                headers={
+                    "X-GitHub-Event": "issues",
+                    "X-Hub-Signature-256": signature,
+                    "Content-Type": "application/json",
+                },
+            )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["status"] == "accepted"
+        assert "402" in data["message"]
+
+    def test_issue_assigned_to_explicit_issue_assignee_env_triggers(
+        self, test_client, github_webhook_secret, monkeypatch
+    ):
+        """Configured GITHUB_ISSUE_ASSIGNEE should be treated as assignment bot handle."""
+        monkeypatch.setenv("GITHUB_WEBHOOK_SECRET", github_webhook_secret)
+        monkeypatch.setenv("GITHUB_BOT_USERNAME", "vibeteam-bot[bot]")
+        monkeypatch.setenv("GITHUB_ISSUE_ASSIGNEE", "agentgithubapphandle")
+        monkeypatch.delenv("GITHUB_BOT_USER_ID", raising=False)
+
+        payload = {
+            "action": "assigned",
+            "issue": {
+                "number": 403,
+                "title": "Explicit assignee env test",
+                "body": "Testing explicit issue assignee matching",
+                "html_url": "https://github.com/owner/repo/issues/403",
+            },
+            "assignee": {"login": "agentgithubapphandle", "id": 99991},
+            "repository": {"full_name": "owner/repo"},
+        }
+
+        payload_str = json.dumps(payload)
+        signature = generate_github_signature(payload_str, github_webhook_secret)
+
+        with (
+            patch(
+                "vibeteam.gateway.routes.github.call_agent_service",
+                new_callable=AsyncMock,
+                return_value={"response": "Working on it"},
+            ),
+            patch(
+                "vibeteam.gateway.routes.github.post_acknowledgment",
+                new_callable=AsyncMock,
+            ),
+            patch(
+                "vibeteam.gateway.routes.github.post_github_comment",
+                new_callable=AsyncMock,
+            ),
+        ):
+            response = test_client.post(
+                "/webhook",
+                content=payload_str,
+                headers={
+                    "X-GitHub-Event": "issues",
+                    "X-Hub-Signature-256": signature,
+                    "Content-Type": "application/json",
+                },
+            )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["status"] == "accepted"
+        assert "403" in data["message"]
+
+    def test_issue_assigned_to_support_bot_routes_support_role(
+        self, test_client, github_webhook_secret, monkeypatch
+    ):
+        monkeypatch.setenv("GITHUB_WEBHOOK_SECRET", github_webhook_secret)
+        monkeypatch.setenv("GITHUB_BOT_USERNAME", "vibeteam-bot[bot]")
+        monkeypatch.setenv("GITHUB_BOT_USERNAME_SUPPORT_ENGINEER", "vibeteam-support-bot-260301[bot]")
+        monkeypatch.delenv("GITHUB_BOT_USER_ID", raising=False)
+
+        payload = {
+            "action": "assigned",
+            "issue": {
+                "number": 404,
+                "title": "Support role routing test",
+                "body": "Support assignment should route support agent",
+                "html_url": "https://github.com/owner/repo/issues/404",
+            },
+            "assignee": {"login": "vibeteam-support-bot-260301[bot]", "id": 99992},
+            "repository": {"full_name": "owner/repo"},
+        }
+
+        payload_str = json.dumps(payload)
+        signature = generate_github_signature(payload_str, github_webhook_secret)
+
+        with (
+            patch(
+                "vibeteam.gateway.routes.github.call_agent_service",
+                new_callable=AsyncMock,
+                return_value={"response": "Support routing works"},
+            ),
+            patch(
+                "vibeteam.gateway.routes.github.post_acknowledgment",
+                new_callable=AsyncMock,
+            ),
+            patch(
+                "vibeteam.gateway.routes.github.post_github_comment",
+                new_callable=AsyncMock,
+            ),
+        ):
+            response = test_client.post(
+                "/webhook",
+                content=payload_str,
+                headers={
+                    "X-GitHub-Event": "issues",
+                    "X-Hub-Signature-256": signature,
+                    "Content-Type": "application/json",
+                },
+            )
+
+        assert response.status_code == 200
+        data = response.json()
+        assert data["status"] == "accepted"
+        assert "support_engineer" in data["message"]
+        assert "404" in data["message"]
 
 
 class TestSentryWebhookRouting:

--- a/vibeteam/gateway/routes/github.py
+++ b/vibeteam/gateway/routes/github.py
@@ -23,9 +23,9 @@ from typing import Any
 import httpx
 from fastapi import APIRouter, Header, HTTPException, Request
 
-from vibeteam.agents_config import get_slack_handle
 from vibeteam.gateway.server import call_agent_service, config
 from vibeteam.router import Router
+from vibeteam.agents_config import get_slack_handle
 from vibeteam.router.models import AgentRole
 
 logger = logging.getLogger(__name__)
@@ -34,6 +34,34 @@ router = APIRouter(tags=["GitHub"])
 
 # Message router for /RoleName parsing
 _message_router: Router | None = None
+
+ROLE_ASSIGNEE_ENV_KEYS: dict[AgentRole, tuple[str, ...]] = {
+    "software_engineer": (
+        "GITHUB_SOFTWARE_ENGINEER_BOT_ASSIGNEE",
+        "GITHUB_APP_BOT_USERNAME_SOFTWARE_ENGINEER",
+        "GITHUB_BOT_USERNAME_SOFTWARE_ENGINEER",
+    ),
+    "support_engineer": (
+        "GITHUB_SUPPORT_ENGINEER_BOT_ASSIGNEE",
+        "GITHUB_APP_BOT_USERNAME_SUPPORT_ENGINEER",
+        "GITHUB_BOT_USERNAME_SUPPORT_ENGINEER",
+    ),
+    "release_engineer": (
+        "GITHUB_RELEASE_ENGINEER_BOT_ASSIGNEE",
+        "GITHUB_APP_BOT_USERNAME_RELEASE_ENGINEER",
+        "GITHUB_BOT_USERNAME_RELEASE_ENGINEER",
+    ),
+    "product_manager": (
+        "GITHUB_PRODUCT_MANAGER_BOT_ASSIGNEE",
+        "GITHUB_APP_BOT_USERNAME_PRODUCT_MANAGER",
+        "GITHUB_BOT_USERNAME_PRODUCT_MANAGER",
+    ),
+    "marketing_manager": (
+        "GITHUB_MARKETING_MANAGER_BOT_ASSIGNEE",
+        "GITHUB_APP_BOT_USERNAME_MARKETING_MANAGER",
+        "GITHUB_BOT_USERNAME_MARKETING_MANAGER",
+    ),
+}
 
 
 def get_message_router() -> Router:
@@ -57,13 +85,80 @@ def verify_signature(payload: bytes, signature: str, secret: str) -> bool:
     return hmac.compare_digest(expected, signature)
 
 
-def _allow_unsigned_eval_webhook(repo_full_name: str) -> bool:
-    """Allow unsigned webhook payloads only for explicitly allowlisted eval repos."""
-    if not config.GITHUB_ALLOW_UNSIGNED_EVAL_WEBHOOKS:
-        return False
-    if not repo_full_name:
-        return False
-    return repo_full_name.lower() in config.GITHUB_UNSIGNED_WEBHOOK_REPOS
+def _normalize_login(login: str) -> str:
+    normalized = (login or "").strip().lower()
+    if normalized.startswith("@"):
+        normalized = normalized[1:]
+    if normalized.endswith("[bot]"):
+        normalized = normalized[:-5]
+    return normalized
+
+
+def _iter_assignment_bot_candidates() -> set[str]:
+    """Collect bot handles that should trigger assignment workflow."""
+    values: list[str] = []
+    for env_name in (
+        "GITHUB_BOT_USERNAME",
+        "GITHUB_ISSUE_ASSIGNEE",
+        "GITHUB_ASSIGNMENT_BOT_LOGINS",
+    ):
+        raw = os.environ.get(env_name, "")
+        if raw:
+            values.extend(raw.split(","))
+
+    if config.BOT_USERNAME:
+        values.append(config.BOT_USERNAME)
+
+    # Optional per-role bot usernames (e.g., GITHUB_BOT_USERNAME_SOFTWARE_ENGINEER).
+    for key, value in os.environ.items():
+        if not value:
+            continue
+        if key.startswith("GITHUB_BOT_USERNAME_") or key.startswith("GITHUB_APP_BOT_USERNAME_"):
+            values.extend(value.split(","))
+
+    return {_normalize_login(v) for v in values if _normalize_login(v)}
+
+
+def _iter_role_assignment_candidates() -> dict[AgentRole, set[str]]:
+    mapping: dict[AgentRole, set[str]] = {}
+    for role, env_names in ROLE_ASSIGNEE_ENV_KEYS.items():
+        candidates: set[str] = set()
+        for env_name in env_names:
+            raw = os.environ.get(env_name, "")
+            if not raw:
+                continue
+            for value in raw.split(","):
+                normalized = _normalize_login(value)
+                if normalized:
+                    candidates.add(normalized)
+        mapping[role] = candidates
+    return mapping
+
+
+def resolve_assignment_role(assignee: dict[str, Any] | None) -> AgentRole:
+    """Resolve role for an assigned issue from assignee login/env mapping."""
+    if not assignee:
+        return "software_engineer"
+
+    normalized_assignee_login = _normalize_login(assignee.get("login", ""))
+    role_candidates = _iter_role_assignment_candidates()
+    for role, candidates in role_candidates.items():
+        if normalized_assignee_login in candidates:
+            return role
+
+    # Fallback to naming conventions when explicit mapping is absent.
+    if "support" in normalized_assignee_login:
+        return "support_engineer"
+    if "release" in normalized_assignee_login:
+        return "release_engineer"
+    if "product" in normalized_assignee_login:
+        return "product_manager"
+    if "marketing" in normalized_assignee_login:
+        return "marketing_manager"
+    if "software" in normalized_assignee_login or "swe" in normalized_assignee_login:
+        return "software_engineer"
+
+    return "software_engineer"
 
 
 def is_assigned_to_bot(assignee: dict[str, Any] | None) -> bool:
@@ -72,14 +167,22 @@ def is_assigned_to_bot(assignee: dict[str, Any] | None) -> bool:
         return False
 
     assignee_login = assignee.get("login", "")
+    normalized_assignee_login = _normalize_login(assignee_login)
     bot_user_id = os.environ.get("GITHUB_BOT_USER_ID")
 
-    # Check by login name
-    if config.BOT_USERNAME.replace("[bot]", "") in assignee_login:
+    # Check by login name (supports single bot and role-specific bot handles).
+    candidates = _iter_assignment_bot_candidates()
+    if normalized_assignee_login in candidates:
+        return True
+    if any(normalized_assignee_login in role_candidates for role_candidates in _iter_role_assignment_candidates().values()):
         return True
 
     # Check by user ID if available
     if bot_user_id and str(assignee.get("id")) == bot_user_id:
+        return True
+
+    # Fallback for role bot naming convention (e.g. vibeteam-swe-bot-260301[bot]).
+    if re.fullmatch(r"vibeteam-[a-z0-9-]+-bot(?:-\d+)?", normalized_assignee_login):
         return True
 
     return False
@@ -109,9 +212,7 @@ async def get_installation_token(role: str | None = None) -> str | None:
     return None
 
 
-async def post_acknowledgment(
-    repo: str, issue_number: int, role: str = "software_engineer"
-) -> None:
+async def post_acknowledgment(repo: str, issue_number: int, role: str = "software_engineer") -> None:
     """Post a comment acknowledging the assignment."""
     token = await get_installation_token(role)
     if not token:
@@ -502,7 +603,9 @@ Discussion: #{discussion_number}
             response = result.get("response", "")
             if response:
                 formatted = f"[{display_name}] {response}"
-                await post_github_discussion_comment(repo, discussion_number, formatted, role=role)
+                await post_github_discussion_comment(
+                    repo, discussion_number, formatted, role=role
+                )
 
                 if handoff_depth < max_handoff_depth:
                     message_router = get_message_router()
@@ -570,25 +673,16 @@ async def handle_github_webhook(
 ) -> dict[str, str]:
     """Handle incoming GitHub webhook events."""
     payload_bytes = await request.body()
-    try:
-        payload = json.loads(payload_bytes)
-    except json.JSONDecodeError as exc:
-        raise HTTPException(status_code=400, detail="Invalid JSON payload") from exc
 
+    # Verify signature
+    if not verify_signature(payload_bytes, x_hub_signature_256 or "", config.GITHUB_WEBHOOK_SECRET):
+        logger.warning("Invalid webhook signature")
+        raise HTTPException(status_code=401, detail="Invalid signature")
+
+    payload = json.loads(payload_bytes)
     action = payload.get("action", "")
     repo_data = payload.get("repository", {})
     repo_full_name = repo_data.get("full_name", "")
-
-    # Verify signature unless explicitly allowlisted for eval webhooks.
-    if not verify_signature(payload_bytes, x_hub_signature_256 or "", config.GITHUB_WEBHOOK_SECRET):
-        if _allow_unsigned_eval_webhook(repo_full_name):
-            logger.warning(
-                "Allowing unsigned GitHub webhook for allowlisted eval repo: %s",
-                repo_full_name,
-            )
-        else:
-            logger.warning("Invalid webhook signature")
-            raise HTTPException(status_code=401, detail="Invalid signature")
 
     logger.info(f"Received {x_github_event}.{action} for {repo_full_name}")
 
@@ -601,18 +695,43 @@ async def handle_github_webhook(
             issue_number = issue.get("number")
             issue_title = issue.get("title", "")
             issue_body = issue.get("body", "")
+            assignee_login = (assignee or {}).get("login", "")
+            assigned_role = resolve_assignment_role(assignee)
 
-            logger.info(f"Issue #{issue_number} assigned to bot, triggering SWE agent")
+            logger.info(
+                "Issue #%s assigned to %s; triggering %s",
+                issue_number,
+                assignee_login,
+                assigned_role,
+            )
 
             # Post acknowledgment and run agent in background
             asyncio.create_task(
-                post_acknowledgment(repo_full_name, issue_number, role="software_engineer")
+                post_acknowledgment(repo_full_name, issue_number, role=assigned_role)
             )
-            asyncio.create_task(
-                run_swe_agent(repo_full_name, issue_number, issue_title, issue_body)
-            )
+            if assigned_role == "software_engineer":
+                asyncio.create_task(
+                    run_swe_agent(repo_full_name, issue_number, issue_title, issue_body)
+                )
+            else:
+                assignment_context = (
+                    f"Issue assigned to {get_slack_handle(assigned_role) or assigned_role}.\n\n"
+                    f"Issue title: {issue_title}\n\n"
+                    f"Issue body:\n{issue_body}"
+                )
+                asyncio.create_task(
+                    run_agent_for_github(
+                        repo=repo_full_name,
+                        issue_number=issue_number,
+                        role=assigned_role,
+                        context=assignment_context,
+                    )
+                )
 
-            return {"status": "accepted", "message": f"Processing issue #{issue_number}"}
+            return {
+                "status": "accepted",
+                "message": f"Processing issue #{issue_number} as {assigned_role}",
+            }
 
     # Handle @mention or /RoleName in issue comments
     if x_github_event == "issue_comment" and action == "created":
@@ -673,10 +792,7 @@ async def handle_github_webhook(
         discussion_user_type = discussion.get("user", {}).get("type", "")
 
         # Ignore bot discussions
-        if (
-            discussion_user_type == "Bot"
-            or config.BOT_USERNAME.replace("[bot]", "") in discussion_user
-        ):
+        if discussion_user_type == "Bot" or config.BOT_USERNAME.replace("[bot]", "") in discussion_user:
             return {"status": "ignored", "reason": "own_comment"}
 
         if discussion_number:
@@ -691,17 +807,9 @@ async def handle_github_webhook(
         role_mentions = message_router.parse_role_mentions(discussion_body)
         if not role_mentions and discussion_body:
             fallback_roles: list[AgentRole] = []
-            for role in (
-                "software_engineer",
-                "support_engineer",
-                "release_engineer",
-                "product_manager",
-                "marketing_manager",
-            ):
+            for role in ("software_engineer", "support_engineer", "release_engineer", "product_manager", "marketing_manager"):
                 handle = get_slack_handle(role) or role.replace("_", " ").title()
-                if handle and re.search(
-                    rf"\\b{re.escape(handle)}\\b", discussion_body, re.IGNORECASE
-                ):
+                if handle and re.search(rf"\\b{re.escape(handle)}\\b", discussion_body, re.IGNORECASE):
                     fallback_roles.append(role)
             if fallback_roles:
                 role_mentions = fallback_roles
@@ -804,7 +912,9 @@ async def handle_github_webhook(
                         discussion_title=discussion_title,
                         role=role,
                         context=(
-                            f"Discussion body:\n\n{discussion_body}\n\nNew comment:\n{comment_body}"
+                            "Discussion body:\n\n"
+                            f"{discussion_body}\n\n"
+                            f"New comment:\n{comment_body}"
                         ),
                     )
                 )
@@ -823,7 +933,9 @@ async def handle_github_webhook(
                     discussion_title=discussion_title,
                     role="software_engineer",
                     context=(
-                        f"Discussion body:\n\n{discussion_body}\n\nNew comment:\n{comment_body}"
+                        "Discussion body:\n\n"
+                        f"{discussion_body}\n\n"
+                        f"New comment:\n{comment_body}"
                     ),
                 )
             )

--- a/vibeteam/webhook/server.py
+++ b/vibeteam/webhook/server.py
@@ -20,6 +20,7 @@ import hmac
 import json
 import logging
 import os
+import re
 import sys
 from typing import Any
 
@@ -87,20 +88,56 @@ def get_bot_user_id() -> str | None:
     return os.environ.get("GITHUB_BOT_USER_ID")
 
 
+def _normalize_login(login: str) -> str:
+    normalized = (login or "").strip().lower()
+    if normalized.startswith("@"):
+        normalized = normalized[1:]
+    if normalized.endswith("[bot]"):
+        normalized = normalized[:-5]
+    return normalized
+
+
+def _iter_assignment_bot_candidates() -> set[str]:
+    values: list[str] = []
+    for env_name in (
+        "GITHUB_BOT_USERNAME",
+        "GITHUB_ISSUE_ASSIGNEE",
+        "GITHUB_ASSIGNMENT_BOT_LOGINS",
+    ):
+        raw = os.environ.get(env_name, "")
+        if raw:
+            values.extend(raw.split(","))
+
+    if BOT_USERNAME:
+        values.append(BOT_USERNAME)
+
+    for key, value in os.environ.items():
+        if not value:
+            continue
+        if key.startswith("GITHUB_BOT_USERNAME_") or key.startswith("GITHUB_APP_BOT_USERNAME_"):
+            values.extend(value.split(","))
+
+    return {_normalize_login(v) for v in values if _normalize_login(v)}
+
+
 def is_assigned_to_bot(assignee: dict[str, Any] | None) -> bool:
     """Check if the assignee is our bot."""
     if not assignee:
         return False
 
     assignee_login = assignee.get("login", "")
+    normalized_assignee_login = _normalize_login(assignee_login)
     bot_user_id = get_bot_user_id()
 
-    # Check by login name
-    if BOT_USERNAME.replace("[bot]", "") in assignee_login:
+    candidates = _iter_assignment_bot_candidates()
+    if normalized_assignee_login in candidates:
         return True
 
     # Check by user ID if available
     if bot_user_id and str(assignee.get("id")) == bot_user_id:
+        return True
+
+    if re.fullmatch(r"vibeteam-[a-z0-9-]+-bot(?:-\d+)?", normalized_assignee_login):
         return True
 
     return False


### PR DESCRIPTION
Closes #337

## What changed
- Updated GitHub webhook assignment matching and role resolution
- Updated legacy webhook server assignment bot matching parity
- Extended GitHub eval script with assignment-first checks and actor/assignee validation
- Added assignability/install-check helpers in `check_github_app_permissions.py`
- Added/updated mock-heavy tests:
  - `tests/test_check_github_app_permissions.py`
  - `tests/test_eval_github_e2e.py`
  - `tests/test_webhook_integration.py`
- Updated gateway env role-bot mapping in `k8s/base/vibeteam-gateway.yaml`

## Validation
- `pytest -q tests/test_check_github_app_permissions.py tests/test_eval_github_e2e.py tests/test_webhook_integration.py`
  - 101 passed, 2 skipped
- `pytest -q`
  - 750 passed, 82 skipped
