### PR TITLE
Enforce real GitHub/Slack app auth in gateway webhook paths

### DIFF
--- a/docs/github.md
+++ b/docs/github.md
@@ -61,15 +61,14 @@ Supported role suffixes:
 
 ### Development (.env)
 
-Shared app:
+Shared app (gateway webhook path):
 ```bash
 GITHUB_APP_ID=123456
 GITHUB_APP_INSTALLATION_ID=12345678
 GITHUB_APP_PRIVATE_KEY="-----BEGIN RSA PRIVATE KEY-----\n...\n-----END RSA PRIVATE KEY-----"
-
-# Optional PAT fallback
-GITHUB_TOKEN=ghp_your_pat_token
 ```
+
+Gateway webhook handlers use GitHub App installation tokens only. PAT fallback is intentionally disabled for webhook-triggered GitHub writes.
 
 Per‑agent apps (recommended):
 ```bash

--- a/docs/requirements.md
+++ b/docs/requirements.md
@@ -88,7 +88,7 @@ LITELLM_MASTER_KEY=
 ### GitHub + Sentry
 
 ```bash
-GITHUB_TOKEN=  # fallback PAT
+GITHUB_TOKEN=  # optional: local eval post-checks only (gateway webhook path uses GitHub App tokens)
 GITHUB_APP_ID_SOFTWARE_ENGINEER=
 GITHUB_APP_INSTALLATION_ID_SOFTWARE_ENGINEER=
 GITHUB_APP_PRIVATE_KEY_SOFTWARE_ENGINEER=

--- a/docs/slack.md
+++ b/docs/slack.md
@@ -110,7 +110,7 @@ The gateway requires these environment variables for Slack integration:
 | `SLACK_ASSISTANT_TOKEN` | Optional token with `assistant:write` for thread status | Same as bot token, or a separate token if you split scopes |
 | `SLACK_ASSISTANT_STATUS_TEXT` | Optional status text (default: `is thinking...`) | Local configuration |
 | `SLACK_SIGNING_SECRET` | Used to verify incoming Slack requests | **Basic Information** > **App Credentials** |
-| `SLACK_TRIGGER_SECRET` | Bearer token for the `/slack/trigger` endpoint (used by eval tests and manual triggering) | Self-generated; set in both `.env` and K8s secrets |
+| `SLACK_TRIGGER_SECRET` | Required bearer token for the `/slack/trigger` endpoint (used by eval tests and manual triggering) | Self-generated; set in both `.env` and K8s secrets |
 
 For Kubernetes deployments, these are stored in the `vibeteam-secrets` secret:
 

--- a/docs/webhook-routing.md
+++ b/docs/webhook-routing.md
@@ -19,9 +19,9 @@ This guide summarizes how external events reach agents. For the canonical routin
 
 ## Authentication
 
-- GitHub: HMAC signature verification.
+- GitHub: HMAC signature verification (required; unsigned webhooks are rejected).
 - Sentry: HMAC signature verification.
-- Slack: request signature + timestamp validation.
+- Slack: request signature + timestamp validation (required).
 
 ## Required Environment Variables
 

--- a/k8s/base/vibeteam-gateway.yaml
+++ b/k8s/base/vibeteam-gateway.yaml
@@ -123,12 +123,6 @@ spec:
                   name: github-app-secret
                   key: installation-id
                   optional: true
-            - name: GITHUB_TOKEN
-              valueFrom:
-                secretKeyRef:
-                  name: vibeteam-secrets
-                  key: GITHUB_TOKEN
-                  optional: true
             # Slack configuration
             - name: SLACK_SIGNING_SECRET
               valueFrom:

--- a/k8s/overlays/dev/gateway-patch.yaml
+++ b/k8s/overlays/dev/gateway-patch.yaml
@@ -32,10 +32,6 @@ spec:
           env:
             - name: PYTHONPATH
               value: "/code/current"
-            - name: GITHUB_ALLOW_UNSIGNED_EVAL_WEBHOOKS
-              value: "true"
-            - name: GITHUB_UNSIGNED_WEBHOOK_REPOS
-              value: "VibeTechnologies/vibeteam-eval-hello-world"
           volumeMounts:
             - name: code
               mountPath: /code

--- a/scripts/eval_slack_e2e.py
+++ b/scripts/eval_slack_e2e.py
@@ -2585,10 +2585,11 @@ async def run_evaluation(
             print(f"    WARNING: Using default PRODUCTION gateway ({default_prod_url})")
             print("    Set GATEWAY_URL env var or --gateway-url to target a different environment")
 
-        trigger_secret = os.environ.get("SLACK_TRIGGER_SECRET", "")
-        headers: dict[str, str] = {}
-        if trigger_secret:
-            headers["Authorization"] = f"Bearer {trigger_secret}"
+        trigger_secret = os.environ.get("SLACK_TRIGGER_SECRET", "").strip()
+        if not trigger_secret:
+            raise RuntimeError("SLACK_TRIGGER_SECRET is required for /slack/trigger eval flow")
+
+        headers: dict[str, str] = {"Authorization": f"Bearer {trigger_secret}"}
 
         try:
             async with httpx.AsyncClient(timeout=30.0) as client:

--- a/tests/test_async_callback.py
+++ b/tests/test_async_callback.py
@@ -962,7 +962,7 @@ class TestSlackTriggerSyncPath:
             ) as mock_run,
             patch("vibeteam.gateway.routes.slack.config") as mock_config,
         ):
-            mock_config.SLACK_TRIGGER_SECRET = ""  # No auth for test
+            mock_config.SLACK_TRIGGER_SECRET = "test-secret"
 
             response = test_client.post(
                 "/slack/trigger",
@@ -972,6 +972,7 @@ class TestSlackTriggerSyncPath:
                     "text": "@SupportEngineer investigate the issue",
                     "user_id": "eval_script",
                 },
+                headers={"Authorization": "Bearer test-secret"},
             )
 
             assert response.status_code == 200

--- a/tests/test_gateway_trigger.py
+++ b/tests/test_gateway_trigger.py
@@ -3,7 +3,7 @@ Tests for /slack/trigger endpoint authentication and input validation.
 
 Tests cover:
 - Bearer token auth when SLACK_TRIGGER_SECRET is set
-- Passthrough when SLACK_TRIGGER_SECRET is not set
+- 503 misconfiguration when SLACK_TRIGGER_SECRET is not set
 - Input validation (missing channel, text, role mentions)
 - Rate limiting
 """
@@ -41,20 +41,20 @@ VALID_PAYLOAD = {
     "user_id": "test_user",
 }
 
+AUTH_HEADERS = {"Authorization": "Bearer test-secret"}
+
 
 class TestTriggerAuth:
     """Test /slack/trigger authentication."""
 
-    def test_no_auth_required_when_secret_unset(self, client: TestClient):
-        """When SLACK_TRIGGER_SECRET is empty, requests pass without auth."""
+    def test_503_when_secret_unset(self, client: TestClient):
+        """When SLACK_TRIGGER_SECRET is empty, endpoint rejects as misconfigured."""
         with patch("vibeteam.gateway.routes.slack.config") as mock_config:
             mock_config.SLACK_TRIGGER_SECRET = ""
             mock_config.SLACK_BOT_TOKEN = "xoxb-test"
             response = client.post("/slack/trigger", json=VALID_PAYLOAD)
-        assert response.status_code == 200
-        data = response.json()
-        assert data["status"] == "accepted"
-        assert "support_engineer" in data["roles"]
+        assert response.status_code == 503
+        assert "not configured" in response.json()["detail"].lower()
 
     def test_401_when_secret_set_and_no_header(self, client: TestClient):
         """When SLACK_TRIGGER_SECRET is set, missing Authorization returns 401."""
@@ -109,10 +109,11 @@ class TestTriggerValidation:
     def test_400_missing_channel(self, client: TestClient):
         """Missing channel returns 400."""
         with patch("vibeteam.gateway.routes.slack.config") as mock_config:
-            mock_config.SLACK_TRIGGER_SECRET = ""
+            mock_config.SLACK_TRIGGER_SECRET = "test-secret"
             response = client.post(
                 "/slack/trigger",
                 json={"text": "@SupportEngineer check this"},
+                headers=AUTH_HEADERS,
             )
         assert response.status_code == 400
         assert "channel is required" in response.json()["detail"]
@@ -120,10 +121,11 @@ class TestTriggerValidation:
     def test_400_missing_text(self, client: TestClient):
         """Missing text returns 400."""
         with patch("vibeteam.gateway.routes.slack.config") as mock_config:
-            mock_config.SLACK_TRIGGER_SECRET = ""
+            mock_config.SLACK_TRIGGER_SECRET = "test-secret"
             response = client.post(
                 "/slack/trigger",
                 json={"channel": "C0AATPSADB8"},
+                headers=AUTH_HEADERS,
             )
         assert response.status_code == 400
         assert "text is required" in response.json()["detail"]
@@ -131,13 +133,14 @@ class TestTriggerValidation:
     def test_400_no_role_mention(self, client: TestClient):
         """Text without @RoleName mention returns 400."""
         with patch("vibeteam.gateway.routes.slack.config") as mock_config:
-            mock_config.SLACK_TRIGGER_SECRET = ""
+            mock_config.SLACK_TRIGGER_SECRET = "test-secret"
             response = client.post(
                 "/slack/trigger",
                 json={
                     "channel": "C0AATPSADB8",
                     "text": "just a regular message with no mention",
                 },
+                headers=AUTH_HEADERS,
             )
         assert response.status_code == 400
         assert "@RoleName mention" in response.json()["detail"]
@@ -145,7 +148,7 @@ class TestTriggerValidation:
     def test_short_form_mentions_accepted(self, client: TestClient):
         """Short-form mentions like @SWE and @PM are accepted."""
         with patch("vibeteam.gateway.routes.slack.config") as mock_config:
-            mock_config.SLACK_TRIGGER_SECRET = ""
+            mock_config.SLACK_TRIGGER_SECRET = "test-secret"
             mock_config.SLACK_BOT_TOKEN = "xoxb-test"
             response = client.post(
                 "/slack/trigger",
@@ -153,6 +156,7 @@ class TestTriggerValidation:
                     "channel": "C0AATPSADB8",
                     "text": "@SWE please review this code",
                 },
+                headers=AUTH_HEADERS,
             )
         assert response.status_code == 200
         assert "software_engineer" in response.json()["roles"]
@@ -160,7 +164,7 @@ class TestTriggerValidation:
     def test_multiple_role_mentions(self, client: TestClient):
         """Multiple @RoleName mentions are all returned."""
         with patch("vibeteam.gateway.routes.slack.config") as mock_config:
-            mock_config.SLACK_TRIGGER_SECRET = ""
+            mock_config.SLACK_TRIGGER_SECRET = "test-secret"
             mock_config.SLACK_BOT_TOKEN = "xoxb-test"
             response = client.post(
                 "/slack/trigger",
@@ -168,6 +172,7 @@ class TestTriggerValidation:
                     "channel": "C0AATPSADB8",
                     "text": "@SupportEngineer and @ReleaseEngineer investigate this",
                 },
+                headers=AUTH_HEADERS,
             )
         assert response.status_code == 200
         roles = response.json()["roles"]
@@ -181,7 +186,7 @@ class TestTriggerRateLimit:
     def test_rate_limit_exceeded(self, client: TestClient):
         """Exceeding rate limit returns 429."""
         with patch("vibeteam.gateway.routes.slack.config") as mock_config:
-            mock_config.SLACK_TRIGGER_SECRET = ""
+            mock_config.SLACK_TRIGGER_SECRET = "test-secret"
             mock_config.SLACK_BOT_TOKEN = "xoxb-test"
 
             # Reset both the per-endpoint trigger limiter and global middleware limiter
@@ -195,11 +200,11 @@ class TestTriggerRateLimit:
 
             # Fire requests up to the limit + 1
             for i in range(_trigger_rate_limiter.max_requests):
-                resp = client.post("/slack/trigger", json=VALID_PAYLOAD)
+                resp = client.post("/slack/trigger", json=VALID_PAYLOAD, headers=AUTH_HEADERS)
                 assert resp.status_code == 200, f"Request {i + 1} should succeed"
 
             # Next request should be rate limited
-            response = client.post("/slack/trigger", json=VALID_PAYLOAD)
+            response = client.post("/slack/trigger", json=VALID_PAYLOAD, headers=AUTH_HEADERS)
             assert response.status_code == 429
             assert "Rate limit exceeded" in response.json()["detail"]
 
@@ -222,9 +227,9 @@ class TestTriggerAsyncMode:
     def test_default_mode_is_sync(self, client: TestClient, _patch_run_agent):
         """Without use_async, mode should be 'sync' and run_agent called with use_async=False."""
         with patch("vibeteam.gateway.routes.slack.config") as mock_config:
-            mock_config.SLACK_TRIGGER_SECRET = ""
+            mock_config.SLACK_TRIGGER_SECRET = "test-secret"
             mock_config.SLACK_BOT_TOKEN = "xoxb-test"
-            response = client.post("/slack/trigger", json=VALID_PAYLOAD)
+            response = client.post("/slack/trigger", json=VALID_PAYLOAD, headers=AUTH_HEADERS)
         assert response.status_code == 200
         data = response.json()
         assert data["mode"] == "sync"
@@ -237,9 +242,9 @@ class TestTriggerAsyncMode:
         """With use_async=true, mode should be 'async' and run_agent called with use_async=True."""
         payload = {**VALID_PAYLOAD, "use_async": True}
         with patch("vibeteam.gateway.routes.slack.config") as mock_config:
-            mock_config.SLACK_TRIGGER_SECRET = ""
+            mock_config.SLACK_TRIGGER_SECRET = "test-secret"
             mock_config.SLACK_BOT_TOKEN = "xoxb-test"
-            response = client.post("/slack/trigger", json=payload)
+            response = client.post("/slack/trigger", json=payload, headers=AUTH_HEADERS)
         assert response.status_code == 200
         data = response.json()
         assert data["mode"] == "async"
@@ -252,9 +257,9 @@ class TestTriggerAsyncMode:
         """With use_async=false explicitly, mode should be 'sync'."""
         payload = {**VALID_PAYLOAD, "use_async": False}
         with patch("vibeteam.gateway.routes.slack.config") as mock_config:
-            mock_config.SLACK_TRIGGER_SECRET = ""
+            mock_config.SLACK_TRIGGER_SECRET = "test-secret"
             mock_config.SLACK_BOT_TOKEN = "xoxb-test"
-            response = client.post("/slack/trigger", json=payload)
+            response = client.post("/slack/trigger", json=payload, headers=AUTH_HEADERS)
         assert response.status_code == 200
         data = response.json()
         assert data["mode"] == "sync"

--- a/tests/test_webhook_integration.py
+++ b/tests/test_webhook_integration.py
@@ -355,19 +355,12 @@ class TestGitHubWebhookRouting:
         finally:
             github.config.GITHUB_WEBHOOK_SECRET = original_secret
 
-    def test_unsigned_non_allowlisted_repo_still_rejected(self, test_client):
-        """Unsigned webhook remains rejected for non-allowlisted repos."""
+    def test_unsigned_webhook_rejected(self, test_client):
+        """Unsigned webhook remains rejected when signature is invalid."""
         from vibeteam.gateway.routes import github
 
         original_secret = github.config.GITHUB_WEBHOOK_SECRET
-        original_allow = github.config.GITHUB_ALLOW_UNSIGNED_EVAL_WEBHOOKS
-        original_repos = github.config.GITHUB_UNSIGNED_WEBHOOK_REPOS
-
         github.config.GITHUB_WEBHOOK_SECRET = "test_secret"
-        github.config.GITHUB_ALLOW_UNSIGNED_EVAL_WEBHOOKS = True
-        github.config.GITHUB_UNSIGNED_WEBHOOK_REPOS = {
-            "vibetechnologies/vibeteam-eval-hello-world"
-        }
 
         try:
             payload = {
@@ -391,8 +384,6 @@ class TestGitHubWebhookRouting:
             assert "Invalid signature" in response.text
         finally:
             github.config.GITHUB_WEBHOOK_SECRET = original_secret
-            github.config.GITHUB_ALLOW_UNSIGNED_EVAL_WEBHOOKS = original_allow
-            github.config.GITHUB_UNSIGNED_WEBHOOK_REPOS = original_repos
 
     def test_bot_own_comment_ignored(self, test_client, github_webhook_secret, monkeypatch):
         """issue_comment from vibeteam-bot[bot] → ignored with reason own_comment."""
@@ -726,8 +717,8 @@ class TestGitHubWebhookRouting:
         assert data["status"] == "ignored"
         assert data["event"] == "issue_comment.created"
 
-    def test_no_secret_skips_verification(self, test_client, monkeypatch):
-        """When GITHUB_WEBHOOK_SECRET is empty, verification is skipped and request passes."""
+    def test_missing_secret_rejected(self, test_client, monkeypatch):
+        """When GITHUB_WEBHOOK_SECRET is empty, webhook request is rejected as misconfigured."""
         from vibeteam.gateway.routes import github
 
         original_secret = github.config.GITHUB_WEBHOOK_SECRET
@@ -743,7 +734,6 @@ class TestGitHubWebhookRouting:
             }
             payload_str = json.dumps(payload)
 
-            # No signature header sent — should still pass because secret is empty
             response = test_client.post(
                 "/webhook",
                 content=payload_str,
@@ -753,10 +743,8 @@ class TestGitHubWebhookRouting:
                 },
             )
 
-            # Request should NOT be rejected — it falls through to ignored (unhandled event)
-            assert response.status_code == 200
-            data = response.json()
-            assert data["status"] == "ignored"
+            assert response.status_code == 503
+            assert "not configured" in response.json()["detail"].lower()
         finally:
             github.config.GITHUB_WEBHOOK_SECRET = original_secret
 

--- a/vibeteam/gateway/routes/github.py
+++ b/vibeteam/gateway/routes/github.py
@@ -75,8 +75,8 @@ def get_message_router() -> Router:
 def verify_signature(payload: bytes, signature: str, secret: str) -> bool:
     """Verify GitHub webhook signature (HMAC-SHA256)."""
     if not secret:
-        logger.warning("GITHUB_WEBHOOK_SECRET not set, skipping verification")
-        return True
+        logger.error("GITHUB_WEBHOOK_SECRET is not configured")
+        return False
 
     if not signature or not signature.startswith("sha256="):
         return False
@@ -212,14 +212,26 @@ async def get_installation_token(role: str | None = None) -> str | None:
     return None
 
 
+async def get_required_installation_token(role: str | None, action: str) -> str | None:
+    """Return a GitHub App installation token or log a hard failure for webhook flows."""
+    token = await get_installation_token(role)
+    if token:
+        return token
+    logger.error(
+        "GitHub App token unavailable for action '%s' (role=%s). "
+        "Gateway webhook actions require GitHub App credentials.",
+        action,
+        role or "default",
+    )
+    return None
+
+
 async def post_acknowledgment(repo: str, issue_number: int, role: str = "software_engineer") -> None:
     """Post a comment acknowledging the assignment."""
-    token = await get_installation_token(role)
-    if not token:
-        token = os.environ.get("GITHUB_TOKEN")
+    token = await get_required_installation_token(role, "post_acknowledgment")
 
     if not token:
-        logger.warning("No GitHub token available, skipping acknowledgment")
+        logger.warning("No GitHub App token available, skipping acknowledgment")
         return
 
     try:
@@ -401,11 +413,9 @@ async def post_github_discussion_comment(
 ) -> None:
     """Post a comment on a GitHub discussion."""
     token = await get_installation_token(role)
-    if not token:
-        token = os.environ.get("GITHUB_TOKEN")
 
     if not token:
-        logger.warning("No GitHub token available, skipping discussion comment")
+        logger.warning("No GitHub App token available, skipping discussion comment")
         return
 
     try:
@@ -480,11 +490,9 @@ async def fetch_github_discussion(
 ) -> dict[str, Any] | None:
     """Fetch discussion details from GitHub."""
     token = await get_installation_token(role)
-    if not token:
-        token = os.environ.get("GITHUB_TOKEN")
 
     if not token:
-        logger.warning("No GitHub token available, skipping discussion fetch")
+        logger.warning("No GitHub App token available, skipping discussion fetch")
         return None
 
     try:
@@ -511,11 +519,9 @@ async def fetch_github_discussion_comment(
 ) -> dict[str, Any] | None:
     """Fetch discussion comment details via GraphQL node ID."""
     token = await get_installation_token(role)
-    if not token:
-        token = os.environ.get("GITHUB_TOKEN")
 
     if not token:
-        logger.warning("No GitHub token available, skipping discussion comment fetch")
+        logger.warning("No GitHub App token available, skipping discussion comment fetch")
         return None
 
     query = """
@@ -639,12 +645,10 @@ async def post_github_comment(
     role: str | None = None,
 ) -> None:
     """Post a comment on a GitHub issue."""
-    token = await get_installation_token(role)
-    if not token:
-        token = os.environ.get("GITHUB_TOKEN")
+    token = await get_required_installation_token(role, "post_github_comment")
 
     if not token:
-        logger.warning("No GitHub token available, skipping comment")
+        logger.warning("No GitHub App token available, skipping comment")
         return
 
     try:
@@ -673,9 +677,13 @@ async def handle_github_webhook(
 ) -> dict[str, str]:
     """Handle incoming GitHub webhook events."""
     payload_bytes = await request.body()
+    webhook_secret = config.GITHUB_WEBHOOK_SECRET or os.environ.get("GITHUB_WEBHOOK_SECRET", "")
+    if not webhook_secret:
+        logger.error("GITHUB_WEBHOOK_SECRET is required for GitHub webhook handling")
+        raise HTTPException(status_code=503, detail="GitHub webhook secret not configured")
 
     # Verify signature
-    if not verify_signature(payload_bytes, x_hub_signature_256 or "", config.GITHUB_WEBHOOK_SECRET):
+    if not verify_signature(payload_bytes, x_hub_signature_256 or "", webhook_secret):
         logger.warning("Invalid webhook signature")
         raise HTTPException(status_code=401, detail="Invalid signature")
 

--- a/vibeteam/gateway/routes/slack.py
+++ b/vibeteam/gateway/routes/slack.py
@@ -331,8 +331,8 @@ def verify_slack_signature(
 ) -> bool:
     """Verify Slack request signature."""
     if not secret:
-        logger.warning("SLACK_SIGNING_SECRET not set, skipping verification")
-        return True
+        logger.error("SLACK_SIGNING_SECRET is not configured")
+        return False
 
     if not signature or not timestamp:
         return False
@@ -2007,6 +2007,10 @@ async def handle_slack_events(
         logger.info("Responding to Slack URL verification challenge")
         return {"challenge": payload.get("challenge")}
 
+    if not config.SLACK_SIGNING_SECRET:
+        logger.error("SLACK_SIGNING_SECRET is required for Slack event handling")
+        raise HTTPException(status_code=503, detail="Slack signing secret not configured")
+
     # Verify signature for all other events
     if not verify_slack_signature(
         payload_bytes,
@@ -2067,7 +2071,7 @@ async def trigger_agent_for_slack(
 
     Authentication:
     - If SLACK_TRIGGER_SECRET is set, requires Bearer token in Authorization header.
-    - If SLACK_TRIGGER_SECRET is not set, logs a warning and allows unauthenticated access.
+    - If SLACK_TRIGGER_SECRET is not set, request is rejected (gateway misconfiguration).
 
     Request body:
     {
@@ -2109,10 +2113,8 @@ async def trigger_agent_for_slack(
             logger.warning("Invalid trigger secret in /slack/trigger request")
             raise HTTPException(status_code=403, detail="Invalid trigger secret")
     else:
-        logger.warning(
-            "SLACK_TRIGGER_SECRET not set - /slack/trigger endpoint is unauthenticated. "
-            "Set SLACK_TRIGGER_SECRET env var to secure this endpoint."
-        )
+        logger.error("SLACK_TRIGGER_SECRET is required for /slack/trigger")
+        raise HTTPException(status_code=503, detail="Slack trigger secret not configured")
     try:
         body = await request.json()
     except Exception:

--- a/vibeteam/gateway/server.py
+++ b/vibeteam/gateway/server.py
@@ -44,17 +44,6 @@ class GatewayConfig:
 
     # GitHub configuration
     GITHUB_WEBHOOK_SECRET = os.environ.get("GITHUB_WEBHOOK_SECRET", "")
-    GITHUB_ALLOW_UNSIGNED_EVAL_WEBHOOKS = os.environ.get(
-        "GITHUB_ALLOW_UNSIGNED_EVAL_WEBHOOKS", "false"
-    ).lower() in {"1", "true", "yes", "on"}
-    GITHUB_UNSIGNED_WEBHOOK_REPOS = {
-        repo.strip().lower()
-        for repo in os.environ.get(
-            "GITHUB_UNSIGNED_WEBHOOK_REPOS",
-            "VibeTechnologies/vibeteam-eval-hello-world",
-        ).split(",")
-        if repo.strip()
-    }
     BOT_USERNAME = os.environ.get("GITHUB_BOT_USERNAME", "vibeteam-bot[bot]")
     GITHUB_APP_ID = os.environ.get("GITHUB_APP_ID", "")
     GITHUB_APP_PRIVATE_KEY = os.environ.get("GITHUB_APP_PRIVATE_KEY", "")

--- a/vibeteam/webhook/server.py
+++ b/vibeteam/webhook/server.py
@@ -73,8 +73,8 @@ class WebhookPayload(BaseModel):
 def verify_signature(payload: bytes, signature: str, secret: str) -> bool:
     """Verify GitHub webhook signature (HMAC-SHA256)."""
     if not secret:
-        logger.warning("GITHUB_WEBHOOK_SECRET not set, skipping verification")
-        return True
+        logger.error("GITHUB_WEBHOOK_SECRET is not configured")
+        return False
 
     if not signature or not signature.startswith("sha256="):
         return False
@@ -415,8 +415,8 @@ async def start_openhands_conversation(
 def verify_sentry_signature(payload: bytes, signature: str, secret: str) -> bool:
     """Verify Sentry webhook signature (HMAC-SHA256)."""
     if not secret:
-        logger.warning("SENTRY_CLIENT_SECRET not set, skipping verification")
-        return True
+        logger.error("SENTRY_CLIENT_SECRET is not configured")
+        return False
 
     if not signature:
         return False
@@ -548,8 +548,8 @@ async def handle_sentry_webhook(
 def verify_slack_signature(payload: bytes, timestamp: str, signature: str, secret: str) -> bool:
     """Verify Slack request signature."""
     if not secret:
-        logger.warning("SLACK_SIGNING_SECRET not set, skipping verification")
-        return True
+        logger.error("SLACK_SIGNING_SECRET is not configured")
+        return False
 
     if not signature or not timestamp:
         return False


### PR DESCRIPTION
## Summary
- remove unsigned GitHub webhook bypass config and require signed webhook secrets in gateway paths
- enforce authenticated `/slack/trigger` with required `SLACK_TRIGGER_SECRET`
- require GitHub App installation token for webhook-triggered GitHub writes
- update docs, k8s overlays, and tests to match strict real-app behavior

## Key changes
- `vibeteam/gateway/routes/github.py`
  - `verify_signature` now fails when secret is missing
  - `/webhook` now resolves secret from config/env and returns `503` if missing
  - app-token-required helper used for webhook write actions (no PAT fallback)
- `vibeteam/gateway/routes/slack.py`
  - `/slack/events` and signature verifier require `SLACK_SIGNING_SECRET`
  - `/slack/trigger` requires bearer auth when `SLACK_TRIGGER_SECRET` configured and returns `503` when missing
- `vibeteam/gateway/server.py`
  - removed unsigned webhook bypass config fields
- `k8s/base/vibeteam-gateway.yaml`, `k8s/overlays/dev/gateway-patch.yaml`
  - removed unsigned webhook bypass env vars and gateway PAT env injection
- docs
  - `docs/github.md`, `docs/slack.md`, `docs/webhook-routing.md`, `docs/requirements.md`
  - clarified real app-only webhook/auth requirements
- tests
  - updated trigger and webhook integration expectations for strict auth behavior

## Validation
- `pytest tests/test_gateway_trigger.py tests/test_webhook_integration.py -v -p no:rerunfailures`
  - `70 passed, 2 skipped`
- `pytest tests/ -q -p no:rerunfailures`
  - `711 passed, 82 skipped`
- Slack eval (real app): `software_engineer_github_app_hello_world`
  - thread ts `1772821384.908359`
  - PR created: `https://github.com/VibeTechnologies/vibeteam-eval-hello-world/pull/164`
  - report: `results/eval_reports/eval_software_engineer_github_app_hello_world_20260306_182524.md`
- GitHub eval (real app): `github_pr_comment_handoff`
  - thread: `https://github.com/VibeTechnologies/vibeteam-eval-hello-world/pull/164`
  - report: `results/eval_reports/eval_github_github_pr_comment_handoff_20260306_182721.md`

Closes #341