### PR TITLE
Normalize role handles for Slack token lookup

### DIFF
--- a/tests/test_slack_role_tokens.py
+++ b/tests/test_slack_role_tokens.py
@@ -22,6 +22,22 @@ class TestRoleScopedTokenResolution:
             mock_config.SLACK_BOT_TOKEN = "xoxb-default"
             assert _resolve_slack_bot_token("support_engineer") == "xoxb-support"
 
+    def test_resolve_slack_bot_token_supports_camel_case_and_prefixed_handles(self):
+        from vibeteam.gateway.routes.slack import _resolve_slack_bot_token
+
+        with (
+            patch.dict(
+                "os.environ",
+                {"SLACK_BOT_TOKEN_SOFTWARE_ENGINEER": "xoxb-swe"},
+                clear=False,
+            ),
+            patch("vibeteam.gateway.routes.slack.config") as mock_config,
+        ):
+            mock_config.SLACK_BOT_TOKEN = "xoxb-default"
+            assert _resolve_slack_bot_token("SoftwareEngineer") == "xoxb-swe"
+            assert _resolve_slack_bot_token("@SoftwareEngineer") == "xoxb-swe"
+            assert _resolve_slack_bot_token("software-engineer") == "xoxb-swe"
+
     def test_resolve_slack_bot_token_falls_back_to_default(self):
         from vibeteam.gateway.routes.slack import _resolve_slack_bot_token
 

--- a/vibeteam/gateway/routes/slack.py
+++ b/vibeteam/gateway/routes/slack.py
@@ -355,9 +355,13 @@ def _role_env_suffix(role: str | None) -> str | None:
     """Convert a role key like support_engineer to env suffix SUPPORT_ENGINEER."""
     if not role:
         return None
-    normalized = re.sub(r"[^A-Z0-9]+", "_", role.upper()).strip("_")
+    role_text = role.strip()
+    if role_text.startswith("@") or role_text.startswith("/"):
+        role_text = role_text[1:]
+    # Support CamelCase handles (e.g. SoftwareEngineer) and snake/kebab/space variants.
+    role_text = re.sub(r"([a-z0-9])([A-Z])", r"\1_\2", role_text)
+    normalized = re.sub(r"[^A-Z0-9]+", "_", role_text.upper()).strip("_")
     return normalized or None
-
 
 def _get_role_scoped_env(prefix: str, role: str | None) -> str:
     """Get role-scoped env var value (e.g., SLACK_BOT_TOKEN_SUPPORT_ENGINEER)."""


### PR DESCRIPTION
## Summary
- normalize role strings used for Slack env lookup to support CamelCase handle forms (e.g. `SoftwareEngineer`), prefixed forms (`@SoftwareEngineer`, `/SoftwareEngineer`), and snake/kebab variants
- add tests proving role-scoped token resolution still works for these forms

## Testing
- `uv run python -m pytest tests/test_slack_role_tokens.py tests/test_async_callback.py tests/test_gateway_trigger.py -v -p no:rerunfailures`

Follow-up to #350