### PR TITLE
Mark GitHub issue assignment as satisfied in fallback mode reports

### DIFF
--- a/scripts/eval_github_e2e.py
+++ b/scripts/eval_github_e2e.py
@@ -1414,6 +1414,11 @@ def _collect_thread_links(results: dict) -> list[str]:
     return links
 
 
+def _assignment_requirement_passed(result: dict) -> bool:
+    """Return True when assignment requirement is satisfied directly or via fallback."""
+    return bool(result.get("assignment_passed") or result.get("assignment_fallback_mode"))
+
+
 def _write_report(scenario: str, results: dict) -> str:
     timestamp = datetime.now(timezone.utc).strftime("%Y%m%d_%H%M%S")
     filename = f"results/eval_reports/eval_github_{scenario}_{timestamp}.md"
@@ -1427,7 +1432,15 @@ def _write_report(scenario: str, results: dict) -> str:
         f"**Bot authors:** {', '.join(results.get('bot_logins', [])) or 'n/a'}",
     ]
     if "assignment_passed" in results:
-        lines.append(f"**Issue assigned:** {'✅' if results.get('assignment_passed') else '❌'}")
+        assignment_effective = _assignment_requirement_passed(results)
+        assignment_suffix = (
+            " (fallback satisfied)"
+            if (not results.get("assignment_passed") and results.get("assignment_fallback_mode"))
+            else ""
+        )
+        lines.append(
+            f"**Issue assigned:** {'✅' if assignment_effective else '❌'}{assignment_suffix}"
+        )
         lines.append(f"**Target assignee:** {results.get('target_assignee', 'n/a')}")
         lines.append(
             f"**Current assignees:** {', '.join(results.get('issue_assignees', [])) or 'n/a'}"
@@ -1512,7 +1525,19 @@ def _write_report(scenario: str, results: dict) -> str:
                 ]
             )
             if "assignment_passed" in thread_result:
-                lines.append(f"- Issue assigned: {'✅' if thread_result.get('assignment_passed') else '❌'}")
+                thread_assignment_effective = _assignment_requirement_passed(thread_result)
+                thread_assignment_suffix = (
+                    " (fallback satisfied)"
+                    if (
+                        not thread_result.get("assignment_passed")
+                        and thread_result.get("assignment_fallback_mode")
+                    )
+                    else ""
+                )
+                lines.append(
+                    f"- Issue assigned: {'✅' if thread_assignment_effective else '❌'}"
+                    f"{thread_assignment_suffix}"
+                )
                 lines.append(f"- Target assignee: {thread_result.get('target_assignee', 'n/a')}")
                 lines.append(
                     "- Current assignees: "
@@ -1689,7 +1714,7 @@ def main() -> int:
             + (
                 " | "
                 f"assigned: {results.get('target_assignee', 'n/a')} "
-                f"({'ok' if results.get('assignment_passed') else 'missing'})"
+                f"({'ok' if results.get('assignment_passed') else ('ok-via-fallback' if results.get('assignment_fallback_mode') else 'missing')})"
                 if "assignment_passed" in results
                 else ""
             )

--- a/tests/test_eval_github_e2e.py
+++ b/tests/test_eval_github_e2e.py
@@ -1219,3 +1219,58 @@ def test_write_report_with_thread_details_and_assignment(tmp_path, monkeypatch):
     assert "- Issue creator check: ✅" in report
     assert "- Expected actor: OpenCodeEngineer" in report
     assert "- Issue creator: OpenCodeEngineer" in report
+
+
+def test_write_report_marks_assignment_passed_in_fallback_mode(tmp_path, monkeypatch):
+    monkeypatch.chdir(tmp_path)
+    issue_url = "https://github.com/org/repo/issues/99"
+    assignee = "vibeteam-swe-bot-260301[bot]"
+    results = {
+        "thread": issue_url,
+        "passed": True,
+        "bot_logins": ["vibesoftwareengineer[bot]", "vibesupportengineer[bot]"],
+        "recent_bot_logins": ["vibesoftwareengineer[bot]", "vibesupportengineer[bot]"],
+        "assignment_passed": False,
+        "assignment_fallback_mode": True,
+        "assignment_fallback_reason": "Target role bot is not assignable.",
+        "target_assignee": assignee,
+        "issue_assignees": [],
+        "assignment_event_seen": False,
+        "assignment_event_count": 0,
+        "assignment_event_error": "",
+        "assignment_event_actors": [],
+        "assignment_actor_passed": False,
+        "assignment_actor_error": "",
+        "actor_login": "OpenCodeEngineer",
+        "issue_creator": "OpenCodeEngineer",
+        "creator_passed": True,
+        "creator_error": "",
+        "threads": {
+            "issue": {
+                "thread": issue_url,
+                "passed": True,
+                "bot_logins": ["vibesoftwareengineer[bot]", "vibesupportengineer[bot]"],
+                "recent_bot_logins": ["vibesoftwareengineer[bot]", "vibesupportengineer[bot]"],
+                "assignment_passed": False,
+                "assignment_fallback_mode": True,
+                "assignment_fallback_reason": "Target role bot is not assignable.",
+                "target_assignee": assignee,
+                "issue_assignees": [],
+                "assignment_event_seen": False,
+                "assignment_event_count": 0,
+                "assignment_event_error": "",
+                "assignment_event_actors": [],
+                "assignment_actor_passed": False,
+                "assignment_actor_error": "",
+                "actor_login": "OpenCodeEngineer",
+                "issue_creator": "OpenCodeEngineer",
+                "creator_passed": True,
+                "creator_error": "",
+            }
+        },
+    }
+
+    report_path = eval_github_e2e._write_report("github_issue_handoff", results)
+    report = Path(report_path).read_text(encoding="utf-8")
+    assert "**Issue assigned:** ✅ (fallback satisfied)" in report
+    assert "- Issue assigned: ✅ (fallback satisfied)" in report


### PR DESCRIPTION
## Summary
- make GitHub eval reports show `Issue assigned: ✅ (fallback satisfied)` when role-bot assignee is non-assignable and fallback mode is active
- preserve raw assignment/event/fallback details in report for auditability
- update CLI status output to show `ok-via-fallback`
- add unit test coverage for fallback assignment reporting

## Validation
- `/Users/engineer/workspace/vibebrowser/VibeTeam/.venv/bin/python -m pytest tests/test_eval_github_e2e.py -p no:rerunfailures` (40 passed)
- `/Users/engineer/workspace/vibebrowser/VibeTeam/.venv/bin/python scripts/eval_github_e2e.py --scenario github_issue_handoff --repo VibeTechnologies/vibeteam-eval-hello-world --actor-login OpenCodeEngineer --issue-role software_engineer --issue-assignee 'vibeteam-swe-bot-260301[bot]' --timeout 900`

Refs: #339