### PR TITLE
feat: support JSON-backed GitHub/Slack role secrets in deploy workflows

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -85,3 +85,13 @@ DISCORD_WEBHOOK_MARKETING=
 # - SLACK_BOT_TOKEN: Slack bot token for posting messages
 # - SLACK_EVAL_CHANNEL: Slack channel ID for evaluation (e.g., C0AATPSADB8)
 # - GATEWAY_URL: Gateway URL (e.g., https://webhook.team.vibebrowser.app)
+#
+# Preferred for deployment secret management:
+# - GITHUB_APP_ROLE_SECRETS_JSON: JSON payload with role-scoped GitHub App creds
+# - SLACK_ROLE_SECRETS_JSON: JSON payload with role-scoped Slack bot/assistant/signing creds
+#
+# Example GITHUB_APP_ROLE_SECRETS_JSON:
+# {"roles":{"software_engineer":{"app_id":"123","installation_id":"456","private_key":"-----BEGIN RSA PRIVATE KEY-----\\n...\\n-----END RSA PRIVATE KEY-----"}}}
+#
+# Example SLACK_ROLE_SECRETS_JSON:
+# {"default":{"bot_token":"xoxb-...","signing_secret":"...","trigger_secret":"..."},"support_engineer":{"bot_token":"xoxb-...","assistant_token":"xapp-..."}}

--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -122,33 +122,70 @@ jobs:
           echo "${{ secrets.KUBECONFIG }}" > ~/.kube/config
           chmod 600 ~/.kube/config
       
-      - name: Generate secrets file from env
-        working-directory: k8s/overlays/prod
+      - name: Generate secrets files from legacy env and JSON payloads
+        env:
+          AZURE_API_KEY: ${{ secrets.AZURE_API_KEY }}
+          AZURE_API_BASE: ${{ secrets.AZURE_API_BASE }}
+          AZURE_OPENAI_DEPLOYMENT: ${{ secrets.AZURE_OPENAI_DEPLOYMENT }}
+          AZURE_API_VERSION: ${{ secrets.AZURE_API_VERSION }}
+          LITELLM_MASTER_KEY: ${{ secrets.LITELLM_MASTER_KEY }}
+          GITHUB_TOKEN: ${{ secrets.PAT_TOKEN }}
+          GITHUB_WEBHOOK_SECRET: ${{ secrets.GITHUB_WEBHOOK_SECRET }}
+          SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
+          SLACK_ASSISTANT_TOKEN: ${{ secrets.SLACK_ASSISTANT_TOKEN }}
+          SLACK_SIGNING_SECRET: ${{ secrets.SLACK_SIGNING_SECRET }}
+          SLACK_TRIGGER_SECRET: ${{ secrets.SLACK_TRIGGER_SECRET }}
+          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+          SENTRY_CLIENT_SECRET: ${{ secrets.SENTRY_CLIENT_SECRET }}
+          LANGFUSE_PUBLIC_KEY: ${{ secrets.LANGFUSE_PUBLIC_KEY }}
+          LANGFUSE_SECRET_KEY: ${{ secrets.LANGFUSE_SECRET_KEY }}
+          LANGFUSE_BASE_URL: ${{ secrets.LANGFUSE_BASE_URL }}
+          DATABASE_URL: ${{ secrets.DATABASE_URL }}
+          CALLBACK_SECRET: ${{ secrets.CALLBACK_SECRET }}
+          GITHUB_APP_ROLE_SECRETS_JSON: ${{ secrets.GITHUB_APP_ROLE_SECRETS_JSON }}
+          SLACK_ROLE_SECRETS_JSON: ${{ secrets.SLACK_ROLE_SECRETS_JSON }}
+          GITHUB_APP_ID_SOFTWARE_ENGINEER: ${{ secrets.GITHUB_APP_ID_SOFTWARE_ENGINEER }}
+          GITHUB_APP_INSTALLATION_ID_SOFTWARE_ENGINEER: ${{ secrets.GITHUB_APP_INSTALLATION_ID_SOFTWARE_ENGINEER }}
+          GITHUB_APP_PRIVATE_KEY_SOFTWARE_ENGINEER: ${{ secrets.GITHUB_APP_PRIVATE_KEY_SOFTWARE_ENGINEER }}
+          GITHUB_WEBHOOK_SECRET_SOFTWARE_ENGINEER: ${{ secrets.GITHUB_WEBHOOK_SECRET_SOFTWARE_ENGINEER }}
+          GITHUB_APP_ID_SUPPORT_ENGINEER: ${{ secrets.GITHUB_APP_ID_SUPPORT_ENGINEER }}
+          GITHUB_APP_INSTALLATION_ID_SUPPORT_ENGINEER: ${{ secrets.GITHUB_APP_INSTALLATION_ID_SUPPORT_ENGINEER }}
+          GITHUB_APP_PRIVATE_KEY_SUPPORT_ENGINEER: ${{ secrets.GITHUB_APP_PRIVATE_KEY_SUPPORT_ENGINEER }}
+          GITHUB_WEBHOOK_SECRET_SUPPORT_ENGINEER: ${{ secrets.GITHUB_WEBHOOK_SECRET_SUPPORT_ENGINEER }}
+          GITHUB_APP_ID_RELEASE_ENGINEER: ${{ secrets.GITHUB_APP_ID_RELEASE_ENGINEER }}
+          GITHUB_APP_INSTALLATION_ID_RELEASE_ENGINEER: ${{ secrets.GITHUB_APP_INSTALLATION_ID_RELEASE_ENGINEER }}
+          GITHUB_APP_PRIVATE_KEY_RELEASE_ENGINEER: ${{ secrets.GITHUB_APP_PRIVATE_KEY_RELEASE_ENGINEER }}
+          GITHUB_WEBHOOK_SECRET_RELEASE_ENGINEER: ${{ secrets.GITHUB_WEBHOOK_SECRET_RELEASE_ENGINEER }}
+          GITHUB_APP_ID_PRODUCT_MANAGER: ${{ secrets.GITHUB_APP_ID_PRODUCT_MANAGER }}
+          GITHUB_APP_INSTALLATION_ID_PRODUCT_MANAGER: ${{ secrets.GITHUB_APP_INSTALLATION_ID_PRODUCT_MANAGER }}
+          GITHUB_APP_PRIVATE_KEY_PRODUCT_MANAGER: ${{ secrets.GITHUB_APP_PRIVATE_KEY_PRODUCT_MANAGER }}
+          GITHUB_WEBHOOK_SECRET_PRODUCT_MANAGER: ${{ secrets.GITHUB_WEBHOOK_SECRET_PRODUCT_MANAGER }}
+          GITHUB_APP_ID_MARKETING_MANAGER: ${{ secrets.GITHUB_APP_ID_MARKETING_MANAGER }}
+          GITHUB_APP_INSTALLATION_ID_MARKETING_MANAGER: ${{ secrets.GITHUB_APP_INSTALLATION_ID_MARKETING_MANAGER }}
+          GITHUB_APP_PRIVATE_KEY_MARKETING_MANAGER: ${{ secrets.GITHUB_APP_PRIVATE_KEY_MARKETING_MANAGER }}
+          GITHUB_WEBHOOK_SECRET_MARKETING_MANAGER: ${{ secrets.GITHUB_WEBHOOK_SECRET_MARKETING_MANAGER }}
+          SLACK_BOT_TOKEN_SOFTWARE_ENGINEER: ${{ secrets.SLACK_BOT_TOKEN_SOFTWARE_ENGINEER }}
+          SLACK_BOT_TOKEN_SUPPORT_ENGINEER: ${{ secrets.SLACK_BOT_TOKEN_SUPPORT_ENGINEER }}
+          SLACK_BOT_TOKEN_RELEASE_ENGINEER: ${{ secrets.SLACK_BOT_TOKEN_RELEASE_ENGINEER }}
+          SLACK_BOT_TOKEN_PRODUCT_MANAGER: ${{ secrets.SLACK_BOT_TOKEN_PRODUCT_MANAGER }}
+          SLACK_BOT_TOKEN_MARKETING_MANAGER: ${{ secrets.SLACK_BOT_TOKEN_MARKETING_MANAGER }}
+          SLACK_ASSISTANT_TOKEN_SOFTWARE_ENGINEER: ${{ secrets.SLACK_ASSISTANT_TOKEN_SOFTWARE_ENGINEER }}
+          SLACK_ASSISTANT_TOKEN_SUPPORT_ENGINEER: ${{ secrets.SLACK_ASSISTANT_TOKEN_SUPPORT_ENGINEER }}
+          SLACK_ASSISTANT_TOKEN_RELEASE_ENGINEER: ${{ secrets.SLACK_ASSISTANT_TOKEN_RELEASE_ENGINEER }}
+          SLACK_ASSISTANT_TOKEN_PRODUCT_MANAGER: ${{ secrets.SLACK_ASSISTANT_TOKEN_PRODUCT_MANAGER }}
+          SLACK_ASSISTANT_TOKEN_MARKETING_MANAGER: ${{ secrets.SLACK_ASSISTANT_TOKEN_MARKETING_MANAGER }}
+          SLACK_SIGNING_SECRET_SOFTWARE_ENGINEER: ${{ secrets.SLACK_SIGNING_SECRET_SOFTWARE_ENGINEER }}
+          SLACK_SIGNING_SECRET_SUPPORT_ENGINEER: ${{ secrets.SLACK_SIGNING_SECRET_SUPPORT_ENGINEER }}
+          SLACK_SIGNING_SECRET_RELEASE_ENGINEER: ${{ secrets.SLACK_SIGNING_SECRET_RELEASE_ENGINEER }}
+          SLACK_SIGNING_SECRET_PRODUCT_MANAGER: ${{ secrets.SLACK_SIGNING_SECRET_PRODUCT_MANAGER }}
+          SLACK_SIGNING_SECRET_MARKETING_MANAGER: ${{ secrets.SLACK_SIGNING_SECRET_MARKETING_MANAGER }}
         run: |
-          cat > .env.secrets << EOF
-          AZURE_API_KEY=${{ secrets.AZURE_API_KEY }}
-          AZURE_API_BASE=${{ secrets.AZURE_API_BASE }}
-          AZURE_OPENAI_DEPLOYMENT=${{ secrets.AZURE_OPENAI_DEPLOYMENT }}
-          AZURE_API_VERSION=${{ secrets.AZURE_API_VERSION }}
-          LITELLM_MASTER_KEY=${{ secrets.LITELLM_MASTER_KEY }}
-          GITHUB_TOKEN=${{ secrets.PAT_TOKEN }}
-          GITHUB_WEBHOOK_SECRET=${{ secrets.GITHUB_WEBHOOK_SECRET }}
-          SLACK_BOT_TOKEN=${{ secrets.SLACK_BOT_TOKEN }}
-          SLACK_SIGNING_SECRET=${{ secrets.SLACK_SIGNING_SECRET }}
-          SLACK_TRIGGER_SECRET=${{ secrets.SLACK_TRIGGER_SECRET }}
-          SENTRY_AUTH_TOKEN=${{ secrets.SENTRY_AUTH_TOKEN }}
-          SENTRY_CLIENT_SECRET=${{ secrets.SENTRY_CLIENT_SECRET }}
-          LANGFUSE_PUBLIC_KEY=${{ secrets.LANGFUSE_PUBLIC_KEY }}
-          LANGFUSE_SECRET_KEY=${{ secrets.LANGFUSE_SECRET_KEY }}
-          LANGFUSE_BASE_URL=${{ secrets.LANGFUSE_BASE_URL }}
-          DATABASE_URL=${{ secrets.DATABASE_URL }}
-          EOF
-          # Strip leading whitespace from each line
-          sed -i 's/^[[:space:]]*//' .env.secrets
-          # Remove empty lines and comment lines
-          sed -i '/^$/d' .env.secrets
-          sed -i '/^#/d' .env.secrets
-          echo "Generated .env.secrets with $(wc -l < .env.secrets) entries"
+          set -euo pipefail
+          python scripts/render_k8s_role_secrets.py \
+            --namespace "$K8S_NAMESPACE" \
+            --vibeteam-env-output k8s/overlays/prod/.env.secrets \
+            --github-role-yaml-output k8s/overlays/prod/github-app-role-secrets.yaml
+          echo "Generated .env.secrets with $(wc -l < k8s/overlays/prod/.env.secrets) entries"
       
       - name: Generate GitHub App secret YAML
         working-directory: k8s/overlays/prod
@@ -173,46 +210,6 @@ jobs:
           $(cat github-app-private-key.pem | sed 's/^/      /')
           EOF
 
-      - name: Generate GitHub App role secrets YAML
-        working-directory: k8s/overlays/prod
-        run: |
-          cat > github-app-role-secrets.yaml << EOF
-          apiVersion: v1
-          kind: Secret
-          metadata:
-            name: github-app-role-secrets
-            labels:
-              app: vibeteam
-              component: github-app
-          type: Opaque
-          stringData:
-            GITHUB_APP_ID_SOFTWARE_ENGINEER: "${{ secrets.GITHUB_APP_ID_SOFTWARE_ENGINEER }}"
-            GITHUB_APP_INSTALLATION_ID_SOFTWARE_ENGINEER: "${{ secrets.GITHUB_APP_INSTALLATION_ID_SOFTWARE_ENGINEER }}"
-            GITHUB_APP_PRIVATE_KEY_SOFTWARE_ENGINEER: |
-          $(printf '%s' "${{ secrets.GITHUB_APP_PRIVATE_KEY_SOFTWARE_ENGINEER }}" | sed 's/^/      /')
-            GITHUB_WEBHOOK_SECRET_SOFTWARE_ENGINEER: "${{ secrets.GITHUB_WEBHOOK_SECRET_SOFTWARE_ENGINEER }}"
-            GITHUB_APP_ID_SUPPORT_ENGINEER: "${{ secrets.GITHUB_APP_ID_SUPPORT_ENGINEER }}"
-            GITHUB_APP_INSTALLATION_ID_SUPPORT_ENGINEER: "${{ secrets.GITHUB_APP_INSTALLATION_ID_SUPPORT_ENGINEER }}"
-            GITHUB_APP_PRIVATE_KEY_SUPPORT_ENGINEER: |
-          $(printf '%s' "${{ secrets.GITHUB_APP_PRIVATE_KEY_SUPPORT_ENGINEER }}" | sed 's/^/      /')
-            GITHUB_WEBHOOK_SECRET_SUPPORT_ENGINEER: "${{ secrets.GITHUB_WEBHOOK_SECRET_SUPPORT_ENGINEER }}"
-            GITHUB_APP_ID_RELEASE_ENGINEER: "${{ secrets.GITHUB_APP_ID_RELEASE_ENGINEER }}"
-            GITHUB_APP_INSTALLATION_ID_RELEASE_ENGINEER: "${{ secrets.GITHUB_APP_INSTALLATION_ID_RELEASE_ENGINEER }}"
-            GITHUB_APP_PRIVATE_KEY_RELEASE_ENGINEER: |
-          $(printf '%s' "${{ secrets.GITHUB_APP_PRIVATE_KEY_RELEASE_ENGINEER }}" | sed 's/^/      /')
-            GITHUB_WEBHOOK_SECRET_RELEASE_ENGINEER: "${{ secrets.GITHUB_WEBHOOK_SECRET_RELEASE_ENGINEER }}"
-            GITHUB_APP_ID_PRODUCT_MANAGER: "${{ secrets.GITHUB_APP_ID_PRODUCT_MANAGER }}"
-            GITHUB_APP_INSTALLATION_ID_PRODUCT_MANAGER: "${{ secrets.GITHUB_APP_INSTALLATION_ID_PRODUCT_MANAGER }}"
-            GITHUB_APP_PRIVATE_KEY_PRODUCT_MANAGER: |
-          $(printf '%s' "${{ secrets.GITHUB_APP_PRIVATE_KEY_PRODUCT_MANAGER }}" | sed 's/^/      /')
-            GITHUB_WEBHOOK_SECRET_PRODUCT_MANAGER: "${{ secrets.GITHUB_WEBHOOK_SECRET_PRODUCT_MANAGER }}"
-            GITHUB_APP_ID_MARKETING_MANAGER: "${{ secrets.GITHUB_APP_ID_MARKETING_MANAGER }}"
-            GITHUB_APP_INSTALLATION_ID_MARKETING_MANAGER: "${{ secrets.GITHUB_APP_INSTALLATION_ID_MARKETING_MANAGER }}"
-            GITHUB_APP_PRIVATE_KEY_MARKETING_MANAGER: |
-          $(printf '%s' "${{ secrets.GITHUB_APP_PRIVATE_KEY_MARKETING_MANAGER }}" | sed 's/^/      /')
-            GITHUB_WEBHOOK_SECRET_MARKETING_MANAGER: "${{ secrets.GITHUB_WEBHOOK_SECRET_MARKETING_MANAGER }}"
-          EOF
-      
       - name: Deploy with kustomize
         env:
           # Use short SHA (7 chars) to match docker/metadata-action output

--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -109,63 +109,97 @@ jobs:
         run: kubectl create namespace $NAMESPACE --dry-run=client -o yaml | kubectl apply -f -
 
       - name: Create secrets
+        env:
+          AZURE_API_KEY: ${{ secrets.AZURE_API_KEY }}
+          AZURE_API_BASE: ${{ secrets.AZURE_API_BASE }}
+          AZURE_OPENAI_DEPLOYMENT: ${{ secrets.AZURE_OPENAI_DEPLOYMENT }}
+          AZURE_API_VERSION: ${{ secrets.AZURE_API_VERSION }}
+          CALLBACK_SECRET: ${{ secrets.CALLBACK_SECRET }}
+          DATABASE_URL: ${{ secrets.DATABASE_URL }}
+          GITHUB_TOKEN: ${{ secrets.PAT_TOKEN }}
+          GITHUB_WEBHOOK_SECRET: ${{ secrets.GITHUB_WEBHOOK_SECRET }}
+          LANGFUSE_PUBLIC_KEY: ${{ secrets.LANGFUSE_PUBLIC_KEY }}
+          LANGFUSE_SECRET_KEY: ${{ secrets.LANGFUSE_SECRET_KEY }}
+          LANGFUSE_BASE_URL: https://langfuse.vibebrowser.app
+          SENTRY_AUTH_TOKEN: ${{ secrets.SENTRY_AUTH_TOKEN }}
+          SENTRY_CLIENT_SECRET: ${{ secrets.SENTRY_CLIENT_SECRET }}
+          SLACK_BOT_TOKEN: ${{ secrets.SLACK_BOT_TOKEN }}
+          SLACK_ASSISTANT_TOKEN: ${{ secrets.SLACK_ASSISTANT_TOKEN }}
+          SLACK_SIGNING_SECRET: ${{ secrets.SLACK_SIGNING_SECRET }}
+          SLACK_TRIGGER_SECRET: ${{ secrets.SLACK_TRIGGER_SECRET }}
+          GITHUB_APP_ROLE_SECRETS_JSON: ${{ secrets.GITHUB_APP_ROLE_SECRETS_JSON }}
+          SLACK_ROLE_SECRETS_JSON: ${{ secrets.SLACK_ROLE_SECRETS_JSON }}
+          GITHUB_APP_ID_SOFTWARE_ENGINEER: ${{ secrets.GITHUB_APP_ID_SOFTWARE_ENGINEER }}
+          GITHUB_APP_INSTALLATION_ID_SOFTWARE_ENGINEER: ${{ secrets.GITHUB_APP_INSTALLATION_ID_SOFTWARE_ENGINEER }}
+          GITHUB_APP_PRIVATE_KEY_SOFTWARE_ENGINEER: ${{ secrets.GITHUB_APP_PRIVATE_KEY_SOFTWARE_ENGINEER }}
+          GITHUB_WEBHOOK_SECRET_SOFTWARE_ENGINEER: ${{ secrets.GITHUB_WEBHOOK_SECRET_SOFTWARE_ENGINEER }}
+          GITHUB_APP_ID_SUPPORT_ENGINEER: ${{ secrets.GITHUB_APP_ID_SUPPORT_ENGINEER }}
+          GITHUB_APP_INSTALLATION_ID_SUPPORT_ENGINEER: ${{ secrets.GITHUB_APP_INSTALLATION_ID_SUPPORT_ENGINEER }}
+          GITHUB_APP_PRIVATE_KEY_SUPPORT_ENGINEER: ${{ secrets.GITHUB_APP_PRIVATE_KEY_SUPPORT_ENGINEER }}
+          GITHUB_WEBHOOK_SECRET_SUPPORT_ENGINEER: ${{ secrets.GITHUB_WEBHOOK_SECRET_SUPPORT_ENGINEER }}
+          GITHUB_APP_ID_RELEASE_ENGINEER: ${{ secrets.GITHUB_APP_ID_RELEASE_ENGINEER }}
+          GITHUB_APP_INSTALLATION_ID_RELEASE_ENGINEER: ${{ secrets.GITHUB_APP_INSTALLATION_ID_RELEASE_ENGINEER }}
+          GITHUB_APP_PRIVATE_KEY_RELEASE_ENGINEER: ${{ secrets.GITHUB_APP_PRIVATE_KEY_RELEASE_ENGINEER }}
+          GITHUB_WEBHOOK_SECRET_RELEASE_ENGINEER: ${{ secrets.GITHUB_WEBHOOK_SECRET_RELEASE_ENGINEER }}
+          GITHUB_APP_ID_PRODUCT_MANAGER: ${{ secrets.GITHUB_APP_ID_PRODUCT_MANAGER }}
+          GITHUB_APP_INSTALLATION_ID_PRODUCT_MANAGER: ${{ secrets.GITHUB_APP_INSTALLATION_ID_PRODUCT_MANAGER }}
+          GITHUB_APP_PRIVATE_KEY_PRODUCT_MANAGER: ${{ secrets.GITHUB_APP_PRIVATE_KEY_PRODUCT_MANAGER }}
+          GITHUB_WEBHOOK_SECRET_PRODUCT_MANAGER: ${{ secrets.GITHUB_WEBHOOK_SECRET_PRODUCT_MANAGER }}
+          GITHUB_APP_ID_MARKETING_MANAGER: ${{ secrets.GITHUB_APP_ID_MARKETING_MANAGER }}
+          GITHUB_APP_INSTALLATION_ID_MARKETING_MANAGER: ${{ secrets.GITHUB_APP_INSTALLATION_ID_MARKETING_MANAGER }}
+          GITHUB_APP_PRIVATE_KEY_MARKETING_MANAGER: ${{ secrets.GITHUB_APP_PRIVATE_KEY_MARKETING_MANAGER }}
+          GITHUB_WEBHOOK_SECRET_MARKETING_MANAGER: ${{ secrets.GITHUB_WEBHOOK_SECRET_MARKETING_MANAGER }}
+          SLACK_BOT_TOKEN_SOFTWARE_ENGINEER: ${{ secrets.SLACK_BOT_TOKEN_SOFTWARE_ENGINEER }}
+          SLACK_BOT_TOKEN_SUPPORT_ENGINEER: ${{ secrets.SLACK_BOT_TOKEN_SUPPORT_ENGINEER }}
+          SLACK_BOT_TOKEN_RELEASE_ENGINEER: ${{ secrets.SLACK_BOT_TOKEN_RELEASE_ENGINEER }}
+          SLACK_BOT_TOKEN_PRODUCT_MANAGER: ${{ secrets.SLACK_BOT_TOKEN_PRODUCT_MANAGER }}
+          SLACK_BOT_TOKEN_MARKETING_MANAGER: ${{ secrets.SLACK_BOT_TOKEN_MARKETING_MANAGER }}
+          SLACK_ASSISTANT_TOKEN_SOFTWARE_ENGINEER: ${{ secrets.SLACK_ASSISTANT_TOKEN_SOFTWARE_ENGINEER }}
+          SLACK_ASSISTANT_TOKEN_SUPPORT_ENGINEER: ${{ secrets.SLACK_ASSISTANT_TOKEN_SUPPORT_ENGINEER }}
+          SLACK_ASSISTANT_TOKEN_RELEASE_ENGINEER: ${{ secrets.SLACK_ASSISTANT_TOKEN_RELEASE_ENGINEER }}
+          SLACK_ASSISTANT_TOKEN_PRODUCT_MANAGER: ${{ secrets.SLACK_ASSISTANT_TOKEN_PRODUCT_MANAGER }}
+          SLACK_ASSISTANT_TOKEN_MARKETING_MANAGER: ${{ secrets.SLACK_ASSISTANT_TOKEN_MARKETING_MANAGER }}
+          SLACK_SIGNING_SECRET_SOFTWARE_ENGINEER: ${{ secrets.SLACK_SIGNING_SECRET_SOFTWARE_ENGINEER }}
+          SLACK_SIGNING_SECRET_SUPPORT_ENGINEER: ${{ secrets.SLACK_SIGNING_SECRET_SUPPORT_ENGINEER }}
+          SLACK_SIGNING_SECRET_RELEASE_ENGINEER: ${{ secrets.SLACK_SIGNING_SECRET_RELEASE_ENGINEER }}
+          SLACK_SIGNING_SECRET_PRODUCT_MANAGER: ${{ secrets.SLACK_SIGNING_SECRET_PRODUCT_MANAGER }}
+          SLACK_SIGNING_SECRET_MARKETING_MANAGER: ${{ secrets.SLACK_SIGNING_SECRET_MARKETING_MANAGER }}
+          GMAIL_CREDENTIALS_JSON: ${{ secrets.GMAIL_CREDENTIALS_JSON }}
+          GMAIL_TOKEN_JSON: ${{ secrets.GMAIL_TOKEN_JSON }}
         run: |
+          set -euo pipefail
+
           kubectl -n $NAMESPACE delete secret ghcr-pull-secret --ignore-not-found
           kubectl -n $NAMESPACE create secret docker-registry ghcr-pull-secret \
             --docker-server=ghcr.io \
             --docker-username=${{ github.actor }} \
-            --docker-password=${{ secrets.PAT_TOKEN }}
+            --docker-password=$GITHUB_TOKEN
 
-          kubectl -n $NAMESPACE delete secret vibeteam-secrets --ignore-not-found
+          python scripts/render_k8s_role_secrets.py \
+            --namespace "$NAMESPACE" \
+            --vibeteam-env-output /tmp/vibeteam-secrets.env \
+            --github-role-yaml-output /tmp/github-app-role-secrets.yaml
+
           kubectl -n $NAMESPACE create secret generic vibeteam-secrets \
-            --from-literal=SENTRY_AUTH_TOKEN="${{ secrets.SENTRY_AUTH_TOKEN }}" \
-            --from-literal=GITHUB_TOKEN="${{ secrets.PAT_TOKEN }}" \
-            --from-literal=LANGFUSE_PUBLIC_KEY="${{ secrets.LANGFUSE_PUBLIC_KEY }}" \
-            --from-literal=LANGFUSE_SECRET_KEY="${{ secrets.LANGFUSE_SECRET_KEY }}" \
-            --from-literal=LANGFUSE_BASE_URL="https://langfuse.vibebrowser.app" \
-            --from-literal=AZURE_API_KEY="${{ secrets.AZURE_API_KEY }}" \
-            --from-literal=AZURE_API_BASE="${{ secrets.AZURE_API_BASE }}" \
-            --from-literal=AZURE_OPENAI_DEPLOYMENT="${{ secrets.AZURE_OPENAI_DEPLOYMENT }}" \
-            --from-literal=AZURE_API_VERSION="${{ secrets.AZURE_API_VERSION }}" \
-            --from-literal=SLACK_BOT_TOKEN="${{ secrets.SLACK_BOT_TOKEN }}" \
-            --from-literal=SLACK_SIGNING_SECRET="${{ secrets.SLACK_SIGNING_SECRET }}" \
-            --from-literal=SLACK_TRIGGER_SECRET="${{ secrets.SLACK_TRIGGER_SECRET }}" \
-            --from-literal=GITHUB_WEBHOOK_SECRET="${{ secrets.GITHUB_WEBHOOK_SECRET }}" \
-            --from-literal=SENTRY_CLIENT_SECRET="${{ secrets.SENTRY_CLIENT_SECRET }}" \
-            --from-literal=CALLBACK_SECRET="${{ secrets.CALLBACK_SECRET }}"
+            --from-env-file=/tmp/vibeteam-secrets.env \
+            --dry-run=client -o yaml | kubectl apply -f -
 
-          kubectl -n $NAMESPACE delete secret github-app-role-secrets --ignore-not-found
-          kubectl -n $NAMESPACE create secret generic github-app-role-secrets \
-            --from-literal=GITHUB_APP_ID_SOFTWARE_ENGINEER="${{ secrets.GITHUB_APP_ID_SOFTWARE_ENGINEER }}" \
-            --from-literal=GITHUB_APP_INSTALLATION_ID_SOFTWARE_ENGINEER="${{ secrets.GITHUB_APP_INSTALLATION_ID_SOFTWARE_ENGINEER }}" \
-            --from-literal=GITHUB_APP_PRIVATE_KEY_SOFTWARE_ENGINEER="${{ secrets.GITHUB_APP_PRIVATE_KEY_SOFTWARE_ENGINEER }}" \
-            --from-literal=GITHUB_WEBHOOK_SECRET_SOFTWARE_ENGINEER="${{ secrets.GITHUB_WEBHOOK_SECRET_SOFTWARE_ENGINEER }}" \
-            --from-literal=GITHUB_APP_ID_SUPPORT_ENGINEER="${{ secrets.GITHUB_APP_ID_SUPPORT_ENGINEER }}" \
-            --from-literal=GITHUB_APP_INSTALLATION_ID_SUPPORT_ENGINEER="${{ secrets.GITHUB_APP_INSTALLATION_ID_SUPPORT_ENGINEER }}" \
-            --from-literal=GITHUB_APP_PRIVATE_KEY_SUPPORT_ENGINEER="${{ secrets.GITHUB_APP_PRIVATE_KEY_SUPPORT_ENGINEER }}" \
-            --from-literal=GITHUB_WEBHOOK_SECRET_SUPPORT_ENGINEER="${{ secrets.GITHUB_WEBHOOK_SECRET_SUPPORT_ENGINEER }}" \
-            --from-literal=GITHUB_APP_ID_RELEASE_ENGINEER="${{ secrets.GITHUB_APP_ID_RELEASE_ENGINEER }}" \
-            --from-literal=GITHUB_APP_INSTALLATION_ID_RELEASE_ENGINEER="${{ secrets.GITHUB_APP_INSTALLATION_ID_RELEASE_ENGINEER }}" \
-            --from-literal=GITHUB_APP_PRIVATE_KEY_RELEASE_ENGINEER="${{ secrets.GITHUB_APP_PRIVATE_KEY_RELEASE_ENGINEER }}" \
-            --from-literal=GITHUB_WEBHOOK_SECRET_RELEASE_ENGINEER="${{ secrets.GITHUB_WEBHOOK_SECRET_RELEASE_ENGINEER }}" \
-            --from-literal=GITHUB_APP_ID_PRODUCT_MANAGER="${{ secrets.GITHUB_APP_ID_PRODUCT_MANAGER }}" \
-            --from-literal=GITHUB_APP_INSTALLATION_ID_PRODUCT_MANAGER="${{ secrets.GITHUB_APP_INSTALLATION_ID_PRODUCT_MANAGER }}" \
-            --from-literal=GITHUB_APP_PRIVATE_KEY_PRODUCT_MANAGER="${{ secrets.GITHUB_APP_PRIVATE_KEY_PRODUCT_MANAGER }}" \
-            --from-literal=GITHUB_WEBHOOK_SECRET_PRODUCT_MANAGER="${{ secrets.GITHUB_WEBHOOK_SECRET_PRODUCT_MANAGER }}" \
-            --from-literal=GITHUB_APP_ID_MARKETING_MANAGER="${{ secrets.GITHUB_APP_ID_MARKETING_MANAGER }}" \
-            --from-literal=GITHUB_APP_INSTALLATION_ID_MARKETING_MANAGER="${{ secrets.GITHUB_APP_INSTALLATION_ID_MARKETING_MANAGER }}" \
-            --from-literal=GITHUB_APP_PRIVATE_KEY_MARKETING_MANAGER="${{ secrets.GITHUB_APP_PRIVATE_KEY_MARKETING_MANAGER }}" \
-            --from-literal=GITHUB_WEBHOOK_SECRET_MARKETING_MANAGER="${{ secrets.GITHUB_WEBHOOK_SECRET_MARKETING_MANAGER }}"
+          kubectl -n $NAMESPACE apply -f /tmp/github-app-role-secrets.yaml
 
-          if [ -n "${{ secrets.GMAIL_CREDENTIALS_JSON }}" ]; then
+          if [ -n "$GMAIL_CREDENTIALS_JSON" ]; then
             kubectl -n $NAMESPACE delete secret gmail-oauth-secrets --ignore-not-found
-            echo '${{ secrets.GMAIL_CREDENTIALS_JSON }}' > /tmp/gmail-credentials.json
-            echo '${{ secrets.GMAIL_TOKEN_JSON }}' > /tmp/gmail-token.json
+            printf '%s' "$GMAIL_CREDENTIALS_JSON" > /tmp/gmail-credentials.json
+            printf '%s' "$GMAIL_TOKEN_JSON" > /tmp/gmail-token.json
             kubectl -n $NAMESPACE create secret generic gmail-oauth-secrets \
               --from-file=gmail-credentials.json=/tmp/gmail-credentials.json \
               --from-file=gmail-token.json=/tmp/gmail-token.json
-            rm -f /tmp/gmail-credentials.json /tmp/gmail-token.json
           fi
+
+          rm -f \
+            /tmp/vibeteam-secrets.env \
+            /tmp/github-app-role-secrets.yaml \
+            /tmp/gmail-credentials.json \
+            /tmp/gmail-token.json
 
       - name: Update image tags in manifests
         run: |

--- a/agent_service/openhands/support_engineer.py
+++ b/agent_service/openhands/support_engineer.py
@@ -272,6 +272,27 @@ def _extract_user_message(task: str) -> str:
     return task.strip()
 
 
+def _is_knowledgebase_ingestion_task(task: str) -> bool:
+    """Detect eval-style knowledgebase ingestion tasks that require compact acknowledgments."""
+    task_lower = (task or "").lower()
+    mentions_kb = "knowledgebase" in task_lower or "knowledge base" in task_lower
+    references_path = "agents/shared/knowledgebase/inbox/" in task_lower
+    action_words = ("add", "update", "create", "ingest", "rebuild", "index")
+    requests_ingestion = any(word in task_lower for word in action_words)
+    return mentions_kb and references_path and requests_ingestion
+
+
+def _compact_knowledgebase_ingestion_response(task: str, response: str) -> str:
+    """Keep knowledgebase ingestion responses to one concise evidence line."""
+    if not _is_knowledgebase_ingestion_task(task):
+        return response
+    for line in response.splitlines():
+        stripped = line.strip()
+        if stripped:
+            return re.sub(r"\s+", " ", stripped)
+    return response.strip()
+
+
 def _probe_url(url: str, timeout: float = 5.0) -> str:
     if not url:
         return "No URL provided to test."
@@ -1085,6 +1106,8 @@ class OpenHandsSupportEngineer:
                         )
                     except Exception as exc:
                         response = f"Sentry: failed to close issue ({exc}). PR: {pr_url}."
+
+            response = _compact_knowledgebase_ingestion_response(user_message, response)
 
             session.add_message("user", task)
             session.add_message("assistant", response)

--- a/docs/requirements.md
+++ b/docs/requirements.md
@@ -118,6 +118,39 @@ Role-scoped GitHub App credentials are preferred and used to attribute PRs to th
 In Kubernetes, agent pods load these from the `github-app-role-secrets` secret via `envFrom`.
 **Required**: OpenHands/OpenClaw services fail fast if GitHub or Sentry credentials are missing.
 
+For deployment workflows, GitHub App role credentials can be provided as one JSON payload
+secret instead of many individual GitHub Secrets:
+
+- `GITHUB_APP_ROLE_SECRETS_JSON`
+
+Supported JSON formats:
+
+```json
+{
+  "roles": {
+    "software_engineer": {
+      "app_id": "12345",
+      "installation_id": "67890",
+      "private_key": "-----BEGIN RSA PRIVATE KEY-----\n...\n-----END RSA PRIVATE KEY-----",
+      "webhook_secret": "..."
+    }
+  }
+}
+```
+
+or a direct env-key map:
+
+```json
+{
+  "GITHUB_APP_ID_SOFTWARE_ENGINEER": "12345",
+  "GITHUB_APP_INSTALLATION_ID_SOFTWARE_ENGINEER": "67890",
+  "GITHUB_APP_PRIVATE_KEY_SOFTWARE_ENGINEER": "-----BEGIN RSA PRIVATE KEY-----\n...\n-----END RSA PRIVATE KEY-----"
+}
+```
+
+If both JSON and individual vars are provided, JSON values take precedence for deployment
+artifact generation.
+
 Private keys can be supplied as PEM strings with `\n` newlines. For local `.env` usage
 with `export $( < .env )`, replace spaces with underscores:
 `BEGIN_RSA_PRIVATE_KEY` / `END_RSA_PRIVATE_KEY`.
@@ -150,6 +183,41 @@ SLACK_TRIGGER_SECRET=
 Gateway Slack API calls resolve bot tokens per role (`software_engineer`, `support_engineer`,
 `release_engineer`, `product_manager`, `marketing_manager`). If a role-specific token is not set,
 the gateway falls back to `SLACK_BOT_TOKEN`. Incoming Slack signatures are accepted when they match any configured signing secret (default or role-scoped).
+
+For deployment workflows, Slack credentials can also be provided as one JSON payload secret:
+
+- `SLACK_ROLE_SECRETS_JSON`
+
+Supported JSON formats:
+
+```json
+{
+  "default": {
+    "bot_token": "xoxb-...",
+    "assistant_token": "xapp-...",
+    "signing_secret": "...",
+    "trigger_secret": "..."
+  },
+  "support_engineer": {
+    "bot_token": "xoxb-...",
+    "assistant_token": "xapp-...",
+    "signing_secret": "..."
+  }
+}
+```
+
+or a direct env-key map:
+
+```json
+{
+  "SLACK_BOT_TOKEN_SUPPORT_ENGINEER": "xoxb-...",
+  "SLACK_ASSISTANT_TOKEN_SUPPORT_ENGINEER": "xapp-...",
+  "SLACK_SIGNING_SECRET_SUPPORT_ENGINEER": "..."
+}
+```
+
+If both JSON and individual vars are provided, JSON values take precedence for deployment
+artifact generation.
 
 ### Gmail (File-Based Secrets)
 

--- a/docs/slack.md
+++ b/docs/slack.md
@@ -148,6 +148,10 @@ kubectl create secret generic vibeteam-secrets -n vibeteam \
   --dry-run=client -o yaml | kubectl apply -f -
 ```
 
+For GitHub Actions-based deployment, you can store role-scoped Slack credentials as a single
+repository secret (`SLACK_ROLE_SECRETS_JSON`) instead of managing many individual secrets.
+The deploy workflows flatten that JSON into the `vibeteam-secrets` keys above at deploy time.
+
 ## 6. Invite the Bot
 
 After installing the apps, invite the ingress bot and all responder bots to channels

--- a/k8s/overlays/prod/github-app-role-secrets.yaml
+++ b/k8s/overlays/prod/github-app-role-secrets.yaml
@@ -3,9 +3,9 @@
 # DO NOT commit actual secrets - this is a template/placeholder
 #
 # CI generates this secret using:
-#   - GITHUB_APP_ID_<ROLE> from GitHub Secrets
-#   - GITHUB_APP_INSTALLATION_ID_<ROLE> from GitHub Secrets
-#   - GITHUB_APP_PRIVATE_KEY_<ROLE> from GitHub Secrets
+#   - GITHUB_APP_ROLE_SECRETS_JSON (preferred), or
+#   - legacy GITHUB_APP_ID_<ROLE>/GITHUB_APP_INSTALLATION_ID_<ROLE>/
+#     GITHUB_APP_PRIVATE_KEY_<ROLE> GitHub Secrets
 ---
 apiVersion: v1
 kind: Secret

--- a/scripts/check_github_app_permissions.py
+++ b/scripts/check_github_app_permissions.py
@@ -5,13 +5,13 @@ from __future__ import annotations
 
 import argparse
 import os
-import sys
+from collections.abc import Iterable
 from urllib.parse import quote
-from typing import Iterable
 
 import requests
 
 from vibeteam.utils.github_app import get_app_info, get_installation_token, list_installations
+from vibeteam.utils.secret_payloads import flatten_github_role_payload, parse_json_payload
 
 ROLE_SUFFIXES = {
     "software_engineer": "SOFTWARE_ENGINEER",
@@ -36,10 +36,26 @@ def _iter_roles(requested: Iterable[str] | None) -> list[str]:
 
 def _load_credentials(role: str) -> tuple[str | None, str | None, str | None]:
     suffix = ROLE_SUFFIXES[role]
-    return (
+    env_credentials = (
         os.environ.get(f"GITHUB_APP_ID_{suffix}"),
         os.environ.get(f"GITHUB_APP_PRIVATE_KEY_{suffix}"),
         os.environ.get(f"GITHUB_APP_INSTALLATION_ID_{suffix}"),
+    )
+    if all(env_credentials):
+        return env_credentials
+
+    try:
+        payload = parse_json_payload(
+            os.environ.get("GITHUB_APP_ROLE_SECRETS_JSON"),
+            source_name="GITHUB_APP_ROLE_SECRETS_JSON",
+        )
+    except ValueError:
+        payload = {}
+    json_values = flatten_github_role_payload(payload)
+    return (
+        env_credentials[0] or json_values.get(f"GITHUB_APP_ID_{suffix}"),
+        env_credentials[1] or json_values.get(f"GITHUB_APP_PRIVATE_KEY_{suffix}"),
+        env_credentials[2] or json_values.get(f"GITHUB_APP_INSTALLATION_ID_{suffix}"),
     )
 
 
@@ -57,12 +73,22 @@ def _repo_headers(token: str) -> dict[str, str]:
 
 def _resolve_role_assignee(role: str) -> str:
     suffix = ROLE_SUFFIXES[role]
-    return (
+    env_assignee = (
         os.environ.get(f"GITHUB_{suffix}_BOT_ASSIGNEE")
         or os.environ.get(f"GITHUB_APP_BOT_USERNAME_{suffix}")
         or os.environ.get(f"GITHUB_BOT_USERNAME_{suffix}")
         or ""
     ).strip()
+    if env_assignee:
+        return env_assignee
+    try:
+        payload = parse_json_payload(
+            os.environ.get("GITHUB_APP_ROLE_SECRETS_JSON"),
+            source_name="GITHUB_APP_ROLE_SECRETS_JSON",
+        )
+    except ValueError:
+        return ""
+    return (flatten_github_role_payload(payload).get(f"GITHUB_APP_BOT_USERNAME_{suffix}") or "").strip()
 
 
 def _check_assignee_assignable(repo: str, token: str, assignee: str) -> tuple[bool, str]:

--- a/scripts/render_k8s_role_secrets.py
+++ b/scripts/render_k8s_role_secrets.py
@@ -1,0 +1,150 @@
+#!/usr/bin/env python3
+"""Render deploy-time secret files from legacy env vars and JSON payload secrets."""
+
+from __future__ import annotations
+
+import argparse
+import os
+from pathlib import Path
+
+from vibeteam.utils.secret_payloads import (
+    collect_prefixed_env,
+    flatten_github_role_payload,
+    flatten_slack_role_payload,
+    merge_env,
+    parse_json_payload,
+)
+
+VIBETEAM_BASE_KEYS = (
+    "AZURE_API_KEY",
+    "AZURE_API_BASE",
+    "AZURE_OPENAI_DEPLOYMENT",
+    "AZURE_API_VERSION",
+    "LITELLM_MASTER_KEY",
+    "GITHUB_TOKEN",
+    "GITHUB_WEBHOOK_SECRET",
+    "SLACK_BOT_TOKEN",
+    "SLACK_ASSISTANT_TOKEN",
+    "SLACK_SIGNING_SECRET",
+    "SLACK_TRIGGER_SECRET",
+    "SLACK_ASSISTANT_STATUS_TEXT",
+    "SENTRY_AUTH_TOKEN",
+    "SENTRY_CLIENT_SECRET",
+    "LANGFUSE_PUBLIC_KEY",
+    "LANGFUSE_SECRET_KEY",
+    "LANGFUSE_BASE_URL",
+    "DATABASE_URL",
+    "CALLBACK_SECRET",
+)
+
+
+def _render_env_file(data: dict[str, str], output_path: Path) -> None:
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    lines = []
+    for key, value in sorted(data.items()):
+        normalized = value.replace("\r\n", "\\n").replace("\n", "\\n")
+        lines.append(f"{key}={normalized}")
+    output_path.write_text("\n".join(lines) + ("\n" if lines else ""), encoding="utf-8")
+
+
+def _render_secret_yaml(name: str, namespace: str, data: dict[str, str], output_path: Path) -> None:
+    output_path.parent.mkdir(parents=True, exist_ok=True)
+    lines = [
+        "apiVersion: v1",
+        "kind: Secret",
+        "metadata:",
+        f"  name: {name}",
+        f"  namespace: {namespace}",
+        "type: Opaque",
+        "stringData:",
+    ]
+    for key in sorted(data):
+        value = data[key]
+        if "\n" in value:
+            lines.append(f"  {key}: |-")
+            for line in value.splitlines():
+                lines.append(f"    {line}")
+            if value.endswith("\n"):
+                lines.append("    ")
+        else:
+            quoted = value.replace("'", "''")
+            lines.append(f"  {key}: '{quoted}'")
+    output_path.write_text("\n".join(lines) + "\n", encoding="utf-8")
+
+
+def main() -> int:
+    parser = argparse.ArgumentParser(
+        description=(
+            "Generate deploy-time files for vibeteam-secrets (.env format) and "
+            "github-app-role-secrets (YAML) from legacy env vars and JSON secret payloads."
+        )
+    )
+    parser.add_argument(
+        "--namespace",
+        default="vibeteam",
+        help="Kubernetes namespace used in generated YAML (default: vibeteam)",
+    )
+    parser.add_argument(
+        "--vibeteam-env-output",
+        required=True,
+        help="Path to write vibeteam-secrets env file",
+    )
+    parser.add_argument(
+        "--github-role-yaml-output",
+        required=True,
+        help="Path to write github-app-role-secrets YAML manifest",
+    )
+    args = parser.parse_args()
+
+    env = dict(os.environ)
+
+    base_vibeteam = {
+        key: env[key]
+        for key in VIBETEAM_BASE_KEYS
+        if key in env and env[key] != ""
+    }
+    legacy_slack = collect_prefixed_env(
+        env,
+        (
+            "SLACK_BOT_TOKEN_",
+            "SLACK_ASSISTANT_TOKEN_",
+            "SLACK_SIGNING_SECRET_",
+        ),
+    )
+    slack_payload = parse_json_payload(
+        env.get("SLACK_ROLE_SECRETS_JSON"),
+        source_name="SLACK_ROLE_SECRETS_JSON",
+    )
+    json_slack = flatten_slack_role_payload(slack_payload)
+    vibeteam_env = merge_env(base_vibeteam, legacy_slack, json_slack)
+
+    legacy_github = collect_prefixed_env(
+        env,
+        (
+            "GITHUB_APP_ID_",
+            "GITHUB_APP_INSTALLATION_ID_",
+            "GITHUB_APP_PRIVATE_KEY_",
+            "GITHUB_WEBHOOK_SECRET_",
+            "GITHUB_BOT_USERNAME_",
+            "GITHUB_APP_BOT_USERNAME_",
+        ),
+    )
+    github_payload = parse_json_payload(
+        env.get("GITHUB_APP_ROLE_SECRETS_JSON"),
+        source_name="GITHUB_APP_ROLE_SECRETS_JSON",
+    )
+    json_github = flatten_github_role_payload(github_payload)
+    github_role_data = merge_env(legacy_github, json_github)
+
+    _render_env_file(vibeteam_env, Path(args.vibeteam_env_output))
+    _render_secret_yaml(
+        "github-app-role-secrets",
+        args.namespace,
+        github_role_data,
+        Path(args.github_role_yaml_output),
+    )
+    return 0
+
+
+if __name__ == "__main__":
+    raise SystemExit(main())

--- a/tests/test_secret_payloads.py
+++ b/tests/test_secret_payloads.py
@@ -1,0 +1,133 @@
+from __future__ import annotations
+
+import os
+import subprocess
+import sys
+from pathlib import Path
+
+import pytest
+
+from vibeteam.utils.secret_payloads import (
+    flatten_github_role_payload,
+    flatten_slack_role_payload,
+    parse_json_payload,
+)
+
+
+def test_parse_json_payload_rejects_invalid_values() -> None:
+    with pytest.raises(ValueError, match="not valid JSON"):
+        parse_json_payload("{not-json}", source_name="TEST_JSON")
+
+    with pytest.raises(ValueError, match="must be a JSON object"):
+        parse_json_payload('["array"]', source_name="TEST_JSON")
+
+
+def test_flatten_github_role_payload_from_roles_object() -> None:
+    payload = {
+        "roles": {
+            "software_engineer": {
+                "app_id": 123,
+                "installation_id": "456",
+                "private_key": "line1\\nline2",
+                "webhook_secret": "hook-secret",
+                "bot_username": "vibeteam-swe-bot[bot]",
+            },
+            "support": {
+                "appId": "777",
+                "installationId": "888",
+                "privateKey": "pem",
+            },
+        }
+    }
+
+    env = flatten_github_role_payload(payload)
+
+    assert env["GITHUB_APP_ID_SOFTWARE_ENGINEER"] == "123"
+    assert env["GITHUB_APP_INSTALLATION_ID_SOFTWARE_ENGINEER"] == "456"
+    assert env["GITHUB_APP_PRIVATE_KEY_SOFTWARE_ENGINEER"] == "line1\\nline2"
+    assert env["GITHUB_WEBHOOK_SECRET_SOFTWARE_ENGINEER"] == "hook-secret"
+    assert env["GITHUB_APP_BOT_USERNAME_SOFTWARE_ENGINEER"] == "vibeteam-swe-bot[bot]"
+    assert env["GITHUB_APP_ID_SUPPORT_ENGINEER"] == "777"
+    assert env["GITHUB_APP_INSTALLATION_ID_SUPPORT_ENGINEER"] == "888"
+    assert env["GITHUB_APP_PRIVATE_KEY_SUPPORT_ENGINEER"] == "pem"
+
+
+def test_flatten_slack_role_payload_with_default_and_roles() -> None:
+    payload = {
+        "default": {
+            "bot_token": "xoxb-default",
+            "assistant_token": "xapp-default",
+            "signing_secret": "sign-default",
+            "trigger_secret": "trigger-default",
+            "assistant_status_text": "thinking",
+        },
+        "product_manager": {
+            "bot_token": "xoxb-pm",
+            "assistant_token": "xapp-pm",
+            "signing_secret": "sign-pm",
+        },
+    }
+
+    env = flatten_slack_role_payload(payload)
+
+    assert env["SLACK_BOT_TOKEN"] == "xoxb-default"
+    assert env["SLACK_ASSISTANT_TOKEN"] == "xapp-default"
+    assert env["SLACK_SIGNING_SECRET"] == "sign-default"
+    assert env["SLACK_TRIGGER_SECRET"] == "trigger-default"
+    assert env["SLACK_ASSISTANT_STATUS_TEXT"] == "thinking"
+    assert env["SLACK_BOT_TOKEN_PRODUCT_MANAGER"] == "xoxb-pm"
+    assert env["SLACK_ASSISTANT_TOKEN_PRODUCT_MANAGER"] == "xapp-pm"
+    assert env["SLACK_SIGNING_SECRET_PRODUCT_MANAGER"] == "sign-pm"
+
+
+def test_render_k8s_role_secrets_script_merges_json_and_legacy(tmp_path: Path) -> None:
+    vibeteam_env = tmp_path / "vibeteam.env"
+    github_yaml = tmp_path / "github-role.yaml"
+
+    env = os.environ.copy()
+    env.update(
+        {
+            "GITHUB_TOKEN": "gh-token",
+            "SLACK_BOT_TOKEN_SUPPORT_ENGINEER": "legacy-support-token",
+            "SLACK_ROLE_SECRETS_JSON": (
+                '{"support_engineer":{"bot_token":"json-support-token"},'
+                '"default":{"signing_secret":"json-signing"}}'
+            ),
+            "GITHUB_APP_ID_SOFTWARE_ENGINEER": "legacy-app-id",
+            "GITHUB_APP_ROLE_SECRETS_JSON": (
+                '{"roles":{"software_engineer":{"app_id":"json-app-id",'
+                '"installation_id":"101","private_key":"lineA\\\\nlineB",'
+                '"webhook_secret":"json-hook"}}}'
+            ),
+        }
+    )
+
+    subprocess.run(
+        [
+            sys.executable,
+            "scripts/render_k8s_role_secrets.py",
+            "--namespace",
+            "vibeteam",
+            "--vibeteam-env-output",
+            str(vibeteam_env),
+            "--github-role-yaml-output",
+            str(github_yaml),
+        ],
+        cwd=Path(__file__).resolve().parents[1],
+        check=True,
+        env=env,
+    )
+
+    vibeteam_text = vibeteam_env.read_text(encoding="utf-8")
+    github_text = github_yaml.read_text(encoding="utf-8")
+
+    assert "GITHUB_TOKEN=gh-token" in vibeteam_text
+    # JSON payload should override legacy role-scoped value.
+    assert "SLACK_BOT_TOKEN_SUPPORT_ENGINEER=json-support-token" in vibeteam_text
+    assert "SLACK_SIGNING_SECRET=json-signing" in vibeteam_text
+
+    # JSON payload should override legacy app ID and include multiline private key.
+    assert "GITHUB_APP_ID_SOFTWARE_ENGINEER: 'json-app-id'" in github_text
+    assert "GITHUB_APP_INSTALLATION_ID_SOFTWARE_ENGINEER: '101'" in github_text
+    assert "GITHUB_WEBHOOK_SECRET_SOFTWARE_ENGINEER: 'json-hook'" in github_text
+    assert "GITHUB_APP_PRIVATE_KEY_SOFTWARE_ENGINEER: 'lineA\\nlineB'" in github_text

--- a/vibeteam/utils/secret_payloads.py
+++ b/vibeteam/utils/secret_payloads.py
@@ -1,0 +1,207 @@
+"""Helpers for mapping JSON secret payloads to environment-style key/value pairs."""
+
+from __future__ import annotations
+
+import json
+import re
+from collections.abc import Mapping
+from typing import Any
+
+ROLE_SUFFIXES: dict[str, str] = {
+    "software_engineer": "SOFTWARE_ENGINEER",
+    "support_engineer": "SUPPORT_ENGINEER",
+    "release_engineer": "RELEASE_ENGINEER",
+    "product_manager": "PRODUCT_MANAGER",
+    "marketing_manager": "MARKETING_MANAGER",
+}
+
+ROLE_ALIASES: dict[str, str] = {
+    "softwareengineer": "software_engineer",
+    "software_engineer": "software_engineer",
+    "swe": "software_engineer",
+    "supportengineer": "support_engineer",
+    "support_engineer": "support_engineer",
+    "support": "support_engineer",
+    "releaseengineer": "release_engineer",
+    "release_engineer": "release_engineer",
+    "release": "release_engineer",
+    "productmanager": "product_manager",
+    "product_manager": "product_manager",
+    "product": "product_manager",
+    "marketingmanager": "marketing_manager",
+    "marketing_manager": "marketing_manager",
+    "marketing": "marketing_manager",
+}
+
+
+def parse_json_payload(raw: str | None, *, source_name: str) -> dict[str, Any]:
+    """Parse an optional JSON object payload from a secret value."""
+    if not raw or not raw.strip():
+        return {}
+    try:
+        payload = json.loads(raw)
+    except json.JSONDecodeError as exc:  # pragma: no cover - exercised by tests
+        raise ValueError(f"{source_name} is not valid JSON: {exc}") from exc
+    if not isinstance(payload, dict):
+        raise ValueError(f"{source_name} must be a JSON object")
+    return payload
+
+
+def _normalize_role(role: str) -> str | None:
+    normalized = re.sub(r"[^a-z0-9]+", "_", role.strip().lower()).strip("_")
+    if not normalized:
+        return None
+    return ROLE_ALIASES.get(normalized, normalized if normalized in ROLE_SUFFIXES else None)
+
+
+def _string_value(value: Any) -> str | None:
+    if value is None:
+        return None
+    as_text = value if isinstance(value, str) else str(value)
+    return as_text if as_text != "" else None
+
+
+def _first_value(data: Mapping[str, Any], names: list[str]) -> str | None:
+    for name in names:
+        if name in data:
+            value = _string_value(data[name])
+            if value is not None:
+                return value
+    return None
+
+
+def _env_keys(payload: Mapping[str, Any], prefix: str) -> dict[str, str]:
+    env: dict[str, str] = {}
+    for key, value in payload.items():
+        if isinstance(key, str) and key.startswith(prefix):
+            as_text = _string_value(value)
+            if as_text is not None:
+                env[key] = as_text
+    return env
+
+
+def _roles_object(payload: Mapping[str, Any]) -> Mapping[str, Any]:
+    maybe_roles = payload.get("roles")
+    if isinstance(maybe_roles, Mapping):
+        return maybe_roles
+    return payload
+
+
+def flatten_github_role_payload(payload: Mapping[str, Any]) -> dict[str, str]:
+    """Flatten GitHub role payload JSON into env-style key/value pairs."""
+    direct = _env_keys(payload, "GITHUB_")
+    if direct:
+        return direct
+
+    env: dict[str, str] = {}
+    for role_name, role_data in _roles_object(payload).items():
+        if not isinstance(role_name, str) or not isinstance(role_data, Mapping):
+            continue
+        role = _normalize_role(role_name)
+        if role is None:
+            continue
+        suffix = ROLE_SUFFIXES[role]
+        app_id = _first_value(
+            role_data,
+            ["app_id", "appId", "github_app_id", "githubAppId", "id"],
+        )
+        install_id = _first_value(
+            role_data,
+            ["installation_id", "installationId", "github_app_installation_id"],
+        )
+        private_key = _first_value(
+            role_data,
+            ["private_key", "privateKey", "github_app_private_key"],
+        )
+        webhook_secret = _first_value(
+            role_data,
+            ["webhook_secret", "webhookSecret", "github_webhook_secret"],
+        )
+        bot_username = _first_value(
+            role_data,
+            ["bot_username", "botUsername", "github_bot_username"],
+        )
+
+        if app_id is not None:
+            env[f"GITHUB_APP_ID_{suffix}"] = app_id
+        if install_id is not None:
+            env[f"GITHUB_APP_INSTALLATION_ID_{suffix}"] = install_id
+        if private_key is not None:
+            env[f"GITHUB_APP_PRIVATE_KEY_{suffix}"] = private_key
+        if webhook_secret is not None:
+            env[f"GITHUB_WEBHOOK_SECRET_{suffix}"] = webhook_secret
+        if bot_username is not None:
+            env[f"GITHUB_APP_BOT_USERNAME_{suffix}"] = bot_username
+
+    return env
+
+
+def flatten_slack_role_payload(payload: Mapping[str, Any]) -> dict[str, str]:
+    """Flatten Slack role payload JSON into env-style key/value pairs."""
+    direct = _env_keys(payload, "SLACK_")
+    if direct:
+        return direct
+
+    env: dict[str, str] = {}
+    for role_name, role_data in _roles_object(payload).items():
+        if not isinstance(role_name, str) or not isinstance(role_data, Mapping):
+            continue
+
+        role_key = role_name.strip().lower()
+        suffix = None
+        if role_key not in {"default", "global", "fallback"}:
+            normalized_role = _normalize_role(role_name)
+            if normalized_role is None:
+                continue
+            suffix = ROLE_SUFFIXES[normalized_role]
+
+        bot_token = _first_value(role_data, ["bot_token", "botToken", "token"])
+        assistant_token = _first_value(
+            role_data,
+            ["assistant_token", "assistantToken", "status_token"],
+        )
+        signing_secret = _first_value(
+            role_data,
+            ["signing_secret", "signingSecret"],
+        )
+        trigger_secret = _first_value(
+            role_data,
+            ["trigger_secret", "triggerSecret"],
+        )
+        status_text = _first_value(
+            role_data,
+            ["assistant_status_text", "assistantStatusText"],
+        )
+
+        if bot_token is not None:
+            key = "SLACK_BOT_TOKEN" if suffix is None else f"SLACK_BOT_TOKEN_{suffix}"
+            env[key] = bot_token
+        if assistant_token is not None:
+            key = "SLACK_ASSISTANT_TOKEN" if suffix is None else f"SLACK_ASSISTANT_TOKEN_{suffix}"
+            env[key] = assistant_token
+        if signing_secret is not None:
+            key = "SLACK_SIGNING_SECRET" if suffix is None else f"SLACK_SIGNING_SECRET_{suffix}"
+            env[key] = signing_secret
+        if suffix is None and trigger_secret is not None:
+            env["SLACK_TRIGGER_SECRET"] = trigger_secret
+        if suffix is None and status_text is not None:
+            env["SLACK_ASSISTANT_STATUS_TEXT"] = status_text
+
+    return env
+
+
+def collect_prefixed_env(env: Mapping[str, str], prefixes: tuple[str, ...]) -> dict[str, str]:
+    """Collect existing non-empty env vars that start with any prefix."""
+    collected: dict[str, str] = {}
+    for key, value in env.items():
+        if value and key.startswith(prefixes):
+            collected[key] = value
+    return collected
+
+
+def merge_env(*mappings: Mapping[str, str]) -> dict[str, str]:
+    """Merge mappings in order; later values win."""
+    merged: dict[str, str] = {}
+    for mapping in mappings:
+        merged.update(mapping)
+    return merged


### PR DESCRIPTION
## Summary
This PR migrates deploy-time role credential handling to support JSON payload secrets for GitHub Apps and Slack, while preserving fallback support for legacy per-variable secrets.

Closes #361.

## What changed
- Added `vibeteam/utils/secret_payloads.py` to parse and flatten role payload JSON.
- Added `scripts/render_k8s_role_secrets.py` to render:
  - `vibeteam-secrets` env file (for kustomize/secret generation)
  - `github-app-role-secrets` YAML (safe for multiline private keys)
- Updated `.github/workflows/deploy.yml`:
  - uses renderer script
  - supports `GITHUB_APP_ROLE_SECRETS_JSON` and `SLACK_ROLE_SECRETS_JSON`
  - keeps legacy secret fallback behavior
- Updated `.github/workflows/ci-cd.yml` similarly.
- Updated `scripts/check_github_app_permissions.py` to read role creds from JSON payload fallback.
- Updated docs (`docs/requirements.md`, `docs/slack.md`, `.env.example`, `k8s/overlays/prod/github-app-role-secrets.yaml`) with JSON secret guidance.
- Added tests in `tests/test_secret_payloads.py`.

## JSON secrets supported
- `GITHUB_APP_ROLE_SECRETS_JSON`
- `SLACK_ROLE_SECRETS_JSON`

## Validation
- `uv run ruff check scripts/render_k8s_role_secrets.py vibeteam/utils/secret_payloads.py scripts/check_github_app_permissions.py tests/test_secret_payloads.py`
- `uv run python -m pytest tests/test_secret_payloads.py tests/test_slack_role_tokens.py tests/test_webhook_integration.py -v`
  - Result: `70 passed, 2 skipped` (`--run-integration` gated)
