### PR TITLE
chore: ignore local automation/browser artifacts in git status

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -68,3 +68,11 @@ tmp/
 .kube/
 .deepeval/
 results/
+
+# Local automation/browser artifacts
+.codex/
+.tmp-pr*/
+chrome/
+.metrics/
+*.hocr
+tmp-*.png


### PR DESCRIPTION
## Summary
Add explicit `.gitignore` entries for local automation and browser artifacts that frequently pollute workspace status during agent/eval runs.

Closes #363.

## Changes
- Ignore local artifact dirs/files:
  - `.codex/`
  - `.tmp-pr*/`
  - `chrome/`
  - `.metrics/`
  - `*.hocr`
  - `tmp-*.png`

## Why
This prevents accidental inclusion of screenshots, OCR files, temp repos, and local browser payloads in normal code review workflows.

## Validation
- Started with a large dirty workspace and cleaned non-source artifacts.
- Verified branch from `origin/master` only changes `.gitignore`.
- Confirmed current workflow files already include JSON secret ingestion variables and renderer script references (`GITHUB_APP_ROLE_SECRETS_JSON`, `SLACK_ROLE_SECRETS_JSON`, `scripts/render_k8s_role_secrets.py`).