### PR TITLE
docs: add JSON secret templates and GitHub upload commands

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -62,6 +62,8 @@ Thumbs.db
 k8s/overlays/*/.env.secrets
 k8s/overlays/*/github-app-private-key.pem
 k8s/overlays/*/github-app-secret.env
+config/secrets/*.json
+!config/secrets/*.template.json
 # Temporary files
 .tts/
 tmp/

--- a/config/secrets/github_app_role_secrets.template.json
+++ b/config/secrets/github_app_role_secrets.template.json
@@ -1,0 +1,39 @@
+{
+  "roles": {
+    "software_engineer": {
+      "app_id": "12345",
+      "installation_id": "67890",
+      "private_key": "-----BEGIN RSA PRIVATE KEY-----\n...\n-----END RSA PRIVATE KEY-----",
+      "webhook_secret": "replace-with-software-engineer-webhook-secret",
+      "bot_username": "vibeteam-swe-bot-260301[bot]"
+    },
+    "support_engineer": {
+      "app_id": "12345",
+      "installation_id": "67890",
+      "private_key": "-----BEGIN RSA PRIVATE KEY-----\n...\n-----END RSA PRIVATE KEY-----",
+      "webhook_secret": "replace-with-support-engineer-webhook-secret",
+      "bot_username": "vibeteam-support-bot-260301[bot]"
+    },
+    "release_engineer": {
+      "app_id": "12345",
+      "installation_id": "67890",
+      "private_key": "-----BEGIN RSA PRIVATE KEY-----\n...\n-----END RSA PRIVATE KEY-----",
+      "webhook_secret": "replace-with-release-engineer-webhook-secret",
+      "bot_username": "vibeteam-release-bot-260301[bot]"
+    },
+    "product_manager": {
+      "app_id": "12345",
+      "installation_id": "67890",
+      "private_key": "-----BEGIN RSA PRIVATE KEY-----\n...\n-----END RSA PRIVATE KEY-----",
+      "webhook_secret": "replace-with-product-manager-webhook-secret",
+      "bot_username": "vibeteam-pm-bot-260301[bot]"
+    },
+    "marketing_manager": {
+      "app_id": "12345",
+      "installation_id": "67890",
+      "private_key": "-----BEGIN RSA PRIVATE KEY-----\n...\n-----END RSA PRIVATE KEY-----",
+      "webhook_secret": "replace-with-marketing-manager-webhook-secret",
+      "bot_username": "vibeteam-mktg-bot-260301[bot]"
+    }
+  }
+}

--- a/config/secrets/slack_role_secrets.template.json
+++ b/config/secrets/slack_role_secrets.template.json
@@ -1,0 +1,34 @@
+{
+  "default": {
+    "bot_token": "xoxb-fallback-token",
+    "assistant_token": "xapp-fallback-assistant-token",
+    "signing_secret": "replace-with-default-signing-secret",
+    "trigger_secret": "replace-with-trigger-secret",
+    "assistant_status_text": "is thinking..."
+  },
+  "software_engineer": {
+    "bot_token": "xoxb-software-engineer-token",
+    "assistant_token": "xapp-software-engineer-assistant-token",
+    "signing_secret": "replace-with-software-engineer-signing-secret"
+  },
+  "support_engineer": {
+    "bot_token": "xoxb-support-engineer-token",
+    "assistant_token": "xapp-support-engineer-assistant-token",
+    "signing_secret": "replace-with-support-engineer-signing-secret"
+  },
+  "release_engineer": {
+    "bot_token": "xoxb-release-engineer-token",
+    "assistant_token": "xapp-release-engineer-assistant-token",
+    "signing_secret": "replace-with-release-engineer-signing-secret"
+  },
+  "product_manager": {
+    "bot_token": "xoxb-product-manager-token",
+    "assistant_token": "xapp-product-manager-assistant-token",
+    "signing_secret": "replace-with-product-manager-signing-secret"
+  },
+  "marketing_manager": {
+    "bot_token": "xoxb-marketing-manager-token",
+    "assistant_token": "xapp-marketing-manager-assistant-token",
+    "signing_secret": "replace-with-marketing-manager-signing-secret"
+  }
+}

--- a/docs/requirements.md
+++ b/docs/requirements.md
@@ -151,6 +151,16 @@ or a direct env-key map:
 If both JSON and individual vars are provided, JSON values take precedence for deployment
 artifact generation.
 
+Template payload: `config/secrets/github_app_role_secrets.template.json`
+
+Upload this payload into GitHub repository secrets:
+
+```bash
+cp config/secrets/github_app_role_secrets.template.json /tmp/github_app_role_secrets.json
+# edit /tmp/github_app_role_secrets.json with real values
+gh secret set GITHUB_APP_ROLE_SECRETS_JSON < /tmp/github_app_role_secrets.json
+```
+
 Private keys can be supplied as PEM strings with `\n` newlines. For local `.env` usage
 with `export $( < .env )`, replace spaces with underscores:
 `BEGIN_RSA_PRIVATE_KEY` / `END_RSA_PRIVATE_KEY`.
@@ -218,6 +228,16 @@ or a direct env-key map:
 
 If both JSON and individual vars are provided, JSON values take precedence for deployment
 artifact generation.
+
+Template payload: `config/secrets/slack_role_secrets.template.json`
+
+Upload this payload into GitHub repository secrets:
+
+```bash
+cp config/secrets/slack_role_secrets.template.json /tmp/slack_role_secrets.json
+# edit /tmp/slack_role_secrets.json with real values
+gh secret set SLACK_ROLE_SECRETS_JSON < /tmp/slack_role_secrets.json
+```
 
 ### Gmail (File-Based Secrets)
 

--- a/docs/slack.md
+++ b/docs/slack.md
@@ -152,6 +152,15 @@ For GitHub Actions-based deployment, you can store role-scoped Slack credentials
 repository secret (`SLACK_ROLE_SECRETS_JSON`) instead of managing many individual secrets.
 The deploy workflows flatten that JSON into the `vibeteam-secrets` keys above at deploy time.
 
+Use the template at `config/secrets/slack_role_secrets.template.json`, fill in real values
+locally, then upload it as a GitHub repository secret:
+
+```bash
+cp config/secrets/slack_role_secrets.template.json /tmp/slack_role_secrets.json
+# edit /tmp/slack_role_secrets.json
+gh secret set SLACK_ROLE_SECRETS_JSON < /tmp/slack_role_secrets.json
+```
+
 ## 6. Invite the Bot
 
 After installing the apps, invite the ingress bot and all responder bots to channels


### PR DESCRIPTION
## Summary
Add committed JSON template payloads and explicit GitHub Secrets upload commands so role credentials can be maintained as JSON and injected during deployment.

Closes #365.

## Changes
- Added templates:
  - `config/secrets/github_app_role_secrets.template.json`
  - `config/secrets/slack_role_secrets.template.json`
- Updated `.gitignore`:
  - ignore `config/secrets/*.json`
  - allow tracked templates via `!config/secrets/*.template.json`
- Updated docs with concrete `gh secret set ... < file.json` commands:
  - `docs/requirements.md`
  - `docs/slack.md`

## Verification
- Confirmed workflows already consume JSON secrets:
  - `GITHUB_APP_ROLE_SECRETS_JSON`
  - `SLACK_ROLE_SECRETS_JSON`
  - `scripts/render_k8s_role_secrets.py`
- Ran: `uv run python -m pytest tests/test_secret_payloads.py -v` (4 passed).