### PR TITLE
feat: derive role secret mappings from agents.yaml placeholders

### DIFF
--- a/agents/agents.yaml
+++ b/agents/agents.yaml
@@ -4,19 +4,74 @@ agents:
     openclaw_agent_id: product-manager
     slack_handle: ProductManager
     agent_dir: ProductManager
+    credentials:
+      github_app:
+        app_id: "${GITHUB_APP_ID_PRODUCT_MANAGER}"
+        installation_id: "${GITHUB_APP_INSTALLATION_ID_PRODUCT_MANAGER}"
+        private_key: "${GITHUB_APP_PRIVATE_KEY_PRODUCT_MANAGER}"
+        webhook_secret: "${GITHUB_WEBHOOK_SECRET_PRODUCT_MANAGER}"
+        bot_username: "${GITHUB_APP_BOT_USERNAME_PRODUCT_MANAGER}"
+      slack:
+        bot_token: "${SLACK_BOT_TOKEN_PRODUCT_MANAGER}"
+        assistant_token: "${SLACK_ASSISTANT_TOKEN_PRODUCT_MANAGER}"
+        signing_secret: "${SLACK_SIGNING_SECRET_PRODUCT_MANAGER}"
   support_engineer:
     framework: openhands
     slack_handle: SupportEngineer
     agent_dir: SupportEngineer
+    credentials:
+      github_app:
+        app_id: "${GITHUB_APP_ID_SUPPORT_ENGINEER}"
+        installation_id: "${GITHUB_APP_INSTALLATION_ID_SUPPORT_ENGINEER}"
+        private_key: "${GITHUB_APP_PRIVATE_KEY_SUPPORT_ENGINEER}"
+        webhook_secret: "${GITHUB_WEBHOOK_SECRET_SUPPORT_ENGINEER}"
+        bot_username: "${GITHUB_APP_BOT_USERNAME_SUPPORT_ENGINEER}"
+      slack:
+        bot_token: "${SLACK_BOT_TOKEN_SUPPORT_ENGINEER}"
+        assistant_token: "${SLACK_ASSISTANT_TOKEN_SUPPORT_ENGINEER}"
+        signing_secret: "${SLACK_SIGNING_SECRET_SUPPORT_ENGINEER}"
   release_engineer:
     framework: openhands
     slack_handle: ReleaseEngineer
     agent_dir: ReleaseEngineer
+    credentials:
+      github_app:
+        app_id: "${GITHUB_APP_ID_RELEASE_ENGINEER}"
+        installation_id: "${GITHUB_APP_INSTALLATION_ID_RELEASE_ENGINEER}"
+        private_key: "${GITHUB_APP_PRIVATE_KEY_RELEASE_ENGINEER}"
+        webhook_secret: "${GITHUB_WEBHOOK_SECRET_RELEASE_ENGINEER}"
+        bot_username: "${GITHUB_APP_BOT_USERNAME_RELEASE_ENGINEER}"
+      slack:
+        bot_token: "${SLACK_BOT_TOKEN_RELEASE_ENGINEER}"
+        assistant_token: "${SLACK_ASSISTANT_TOKEN_RELEASE_ENGINEER}"
+        signing_secret: "${SLACK_SIGNING_SECRET_RELEASE_ENGINEER}"
   software_engineer:
     framework: openhands
     slack_handle: SoftwareEngineer
     agent_dir: SoftwareEngineer
+    credentials:
+      github_app:
+        app_id: "${GITHUB_APP_ID_SOFTWARE_ENGINEER}"
+        installation_id: "${GITHUB_APP_INSTALLATION_ID_SOFTWARE_ENGINEER}"
+        private_key: "${GITHUB_APP_PRIVATE_KEY_SOFTWARE_ENGINEER}"
+        webhook_secret: "${GITHUB_WEBHOOK_SECRET_SOFTWARE_ENGINEER}"
+        bot_username: "${GITHUB_APP_BOT_USERNAME_SOFTWARE_ENGINEER}"
+      slack:
+        bot_token: "${SLACK_BOT_TOKEN_SOFTWARE_ENGINEER}"
+        assistant_token: "${SLACK_ASSISTANT_TOKEN_SOFTWARE_ENGINEER}"
+        signing_secret: "${SLACK_SIGNING_SECRET_SOFTWARE_ENGINEER}"
   marketing_manager:
     framework: openhands
     slack_handle: MarketingManager
     agent_dir: MarketingManager
+    credentials:
+      github_app:
+        app_id: "${GITHUB_APP_ID_MARKETING_MANAGER}"
+        installation_id: "${GITHUB_APP_INSTALLATION_ID_MARKETING_MANAGER}"
+        private_key: "${GITHUB_APP_PRIVATE_KEY_MARKETING_MANAGER}"
+        webhook_secret: "${GITHUB_WEBHOOK_SECRET_MARKETING_MANAGER}"
+        bot_username: "${GITHUB_APP_BOT_USERNAME_MARKETING_MANAGER}"
+      slack:
+        bot_token: "${SLACK_BOT_TOKEN_MARKETING_MANAGER}"
+        assistant_token: "${SLACK_ASSISTANT_TOKEN_MARKETING_MANAGER}"
+        signing_secret: "${SLACK_SIGNING_SECRET_MARKETING_MANAGER}"

--- a/docs/design.md
+++ b/docs/design.md
@@ -59,7 +59,8 @@
 
 - The gateway resolves which framework to use per role using `agents/agents.yaml`.
 - `agents/agents.yaml` is the single source of truth for role → framework mapping, Slack handle,
-  and agent directory references (AGENTS.md resolves from the directory).
+  agent directory references (AGENTS.md resolves from the directory), and role credential
+  placeholder references for Slack and GitHub App env keys.
 - Example:
 
 The gateway does not prefetch or inject monitoring context; it only routes messages.

--- a/docs/github.md
+++ b/docs/github.md
@@ -135,6 +135,9 @@ GITHUB_APP_PRIVATE_KEY_MARKETING_MANAGER
 GITHUB_WEBHOOK_SECRET_MARKETING_MANAGER
 ```
 
+Role-scoped key names are derived from `agents/agents.yaml` credential placeholders so the
+mapping is maintained in one place.
+
 ### Private Key Formatting
 
 For local `.env` usage with `export $( < .env )`, replace spaces with underscores:

--- a/docs/requirements.md
+++ b/docs/requirements.md
@@ -35,9 +35,20 @@ agents:
     framework: openhands
     slack_handle: SoftwareEngineer
     agent_dir: agents/SoftwareEngineer
+    credentials:
+      github_app:
+        app_id: "${GITHUB_APP_ID_SOFTWARE_ENGINEER}"
+        installation_id: "${GITHUB_APP_INSTALLATION_ID_SOFTWARE_ENGINEER}"
+        private_key: "${GITHUB_APP_PRIVATE_KEY_SOFTWARE_ENGINEER}"
+        webhook_secret: "${GITHUB_WEBHOOK_SECRET_SOFTWARE_ENGINEER}"
+      slack:
+        bot_token: "${SLACK_BOT_TOKEN_SOFTWARE_ENGINEER}"
+        assistant_token: "${SLACK_ASSISTANT_TOKEN_SOFTWARE_ENGINEER}"
+        signing_secret: "${SLACK_SIGNING_SECRET_SOFTWARE_ENGINEER}"
 ```
 
 The gateway only routes messages; it does not prefetch or inject monitoring context.
+`agents/agents.yaml` stores only placeholder references for role credentials, never secret values.
 
 ## Browser Automation
 
@@ -150,6 +161,8 @@ or a direct env-key map:
 
 If both JSON and individual vars are provided, JSON values take precedence for deployment
 artifact generation.
+Deployment rendering resolves role-scoped env keys from the placeholders defined in
+`agents/agents.yaml`, keeping role credential key naming in one place.
 
 Template payload: `config/secrets/github_app_role_secrets.template.json`
 
@@ -228,6 +241,8 @@ or a direct env-key map:
 
 If both JSON and individual vars are provided, JSON values take precedence for deployment
 artifact generation.
+Deployment rendering resolves role-scoped env keys from the placeholders defined in
+`agents/agents.yaml`, keeping role credential key naming in one place.
 
 Template payload: `config/secrets/slack_role_secrets.template.json`
 

--- a/docs/slack.md
+++ b/docs/slack.md
@@ -151,6 +151,8 @@ kubectl create secret generic vibeteam-secrets -n vibeteam \
 For GitHub Actions-based deployment, you can store role-scoped Slack credentials as a single
 repository secret (`SLACK_ROLE_SECRETS_JSON`) instead of managing many individual secrets.
 The deploy workflows flatten that JSON into the `vibeteam-secrets` keys above at deploy time.
+Role-scoped key names are derived from `agents/agents.yaml` credential placeholders so the
+mapping is maintained in one place.
 
 Use the template at `config/secrets/slack_role_secrets.template.json`, fill in real values
 locally, then upload it as a GitHub repository secret:

--- a/scripts/check_github_app_permissions.py
+++ b/scripts/check_github_app_permissions.py
@@ -10,32 +10,38 @@ from urllib.parse import quote
 
 import requests
 
+from vibeteam.agents_config import get_role_secret_suffixes
 from vibeteam.utils.github_app import get_app_info, get_installation_token, list_installations
-from vibeteam.utils.secret_payloads import flatten_github_role_payload, parse_json_payload
-
-ROLE_SUFFIXES = {
-    "software_engineer": "SOFTWARE_ENGINEER",
-    "support_engineer": "SUPPORT_ENGINEER",
-    "release_engineer": "RELEASE_ENGINEER",
-    "product_manager": "PRODUCT_MANAGER",
-    "marketing_manager": "MARKETING_MANAGER",
-}
+from vibeteam.utils.secret_payloads import (
+    ROLE_SUFFIXES as DEFAULT_ROLE_SUFFIXES,
+    flatten_github_role_payload,
+    parse_json_payload,
+)
 DEFAULT_REPO = os.environ.get("GITHUB_TEST_REPO", "VibeTechnologies/vibeteam-eval-hello-world")
 
 
+def _role_suffixes() -> dict[str, str]:
+    configured = get_role_secret_suffixes()
+    if configured:
+        return configured
+    return dict(DEFAULT_ROLE_SUFFIXES)
+
+
 def _iter_roles(requested: Iterable[str] | None) -> list[str]:
+    role_suffixes = _role_suffixes()
     if not requested:
-        return list(ROLE_SUFFIXES.keys())
+        return list(role_suffixes.keys())
     normalized = []
     for role in requested:
         role_key = role.strip().lower()
-        if role_key in ROLE_SUFFIXES:
+        if role_key in role_suffixes:
             normalized.append(role_key)
     return normalized
 
 
 def _load_credentials(role: str) -> tuple[str | None, str | None, str | None]:
-    suffix = ROLE_SUFFIXES[role]
+    role_suffixes = _role_suffixes()
+    suffix = role_suffixes[role]
     env_credentials = (
         os.environ.get(f"GITHUB_APP_ID_{suffix}"),
         os.environ.get(f"GITHUB_APP_PRIVATE_KEY_{suffix}"),
@@ -51,7 +57,7 @@ def _load_credentials(role: str) -> tuple[str | None, str | None, str | None]:
         )
     except ValueError:
         payload = {}
-    json_values = flatten_github_role_payload(payload)
+    json_values = flatten_github_role_payload(payload, role_suffixes=role_suffixes)
     return (
         env_credentials[0] or json_values.get(f"GITHUB_APP_ID_{suffix}"),
         env_credentials[1] or json_values.get(f"GITHUB_APP_PRIVATE_KEY_{suffix}"),
@@ -72,7 +78,8 @@ def _repo_headers(token: str) -> dict[str, str]:
 
 
 def _resolve_role_assignee(role: str) -> str:
-    suffix = ROLE_SUFFIXES[role]
+    role_suffixes = _role_suffixes()
+    suffix = role_suffixes[role]
     env_assignee = (
         os.environ.get(f"GITHUB_{suffix}_BOT_ASSIGNEE")
         or os.environ.get(f"GITHUB_APP_BOT_USERNAME_{suffix}")
@@ -88,7 +95,12 @@ def _resolve_role_assignee(role: str) -> str:
         )
     except ValueError:
         return ""
-    return (flatten_github_role_payload(payload).get(f"GITHUB_APP_BOT_USERNAME_{suffix}") or "").strip()
+    return (
+        flatten_github_role_payload(payload, role_suffixes=role_suffixes).get(
+            f"GITHUB_APP_BOT_USERNAME_{suffix}"
+        )
+        or ""
+    ).strip()
 
 
 def _check_assignee_assignable(repo: str, token: str, assignee: str) -> tuple[bool, str]:

--- a/scripts/render_k8s_role_secrets.py
+++ b/scripts/render_k8s_role_secrets.py
@@ -7,6 +7,7 @@ import argparse
 import os
 from pathlib import Path
 
+from vibeteam.agents_config import get_role_secret_suffixes, list_role_secret_env_vars
 from vibeteam.utils.secret_payloads import (
     collect_prefixed_env,
     flatten_github_role_payload,
@@ -97,43 +98,74 @@ def main() -> int:
     args = parser.parse_args()
 
     env = dict(os.environ)
+    role_scoped_env_keys = list_role_secret_env_vars()
+    role_suffixes = get_role_secret_suffixes()
+    for suffix in role_suffixes.values():
+        role_scoped_env_keys.add(f"GITHUB_BOT_USERNAME_{suffix}")
 
     base_vibeteam = {
         key: env[key]
         for key in VIBETEAM_BASE_KEYS
         if key in env and env[key] != ""
     }
-    legacy_slack = collect_prefixed_env(
-        env,
-        (
-            "SLACK_BOT_TOKEN_",
-            "SLACK_ASSISTANT_TOKEN_",
-            "SLACK_SIGNING_SECRET_",
-        ),
-    )
+    if role_scoped_env_keys:
+        legacy_slack = {
+            key: env[key]
+            for key in role_scoped_env_keys
+            if key.startswith(("SLACK_BOT_TOKEN_", "SLACK_ASSISTANT_TOKEN_", "SLACK_SIGNING_SECRET_"))
+            and key in env
+            and env[key] != ""
+        }
+    else:
+        legacy_slack = collect_prefixed_env(
+            env,
+            (
+                "SLACK_BOT_TOKEN_",
+                "SLACK_ASSISTANT_TOKEN_",
+                "SLACK_SIGNING_SECRET_",
+            ),
+        )
     slack_payload = parse_json_payload(
         env.get("SLACK_ROLE_SECRETS_JSON"),
         source_name="SLACK_ROLE_SECRETS_JSON",
     )
-    json_slack = flatten_slack_role_payload(slack_payload)
+    json_slack = flatten_slack_role_payload(slack_payload, role_suffixes=role_suffixes)
     vibeteam_env = merge_env(base_vibeteam, legacy_slack, json_slack)
 
-    legacy_github = collect_prefixed_env(
-        env,
-        (
-            "GITHUB_APP_ID_",
-            "GITHUB_APP_INSTALLATION_ID_",
-            "GITHUB_APP_PRIVATE_KEY_",
-            "GITHUB_WEBHOOK_SECRET_",
-            "GITHUB_BOT_USERNAME_",
-            "GITHUB_APP_BOT_USERNAME_",
-        ),
-    )
+    if role_scoped_env_keys:
+        legacy_github = {
+            key: env[key]
+            for key in role_scoped_env_keys
+            if key.startswith(
+                (
+                    "GITHUB_APP_ID_",
+                    "GITHUB_APP_INSTALLATION_ID_",
+                    "GITHUB_APP_PRIVATE_KEY_",
+                    "GITHUB_WEBHOOK_SECRET_",
+                    "GITHUB_BOT_USERNAME_",
+                    "GITHUB_APP_BOT_USERNAME_",
+                )
+            )
+            and key in env
+            and env[key] != ""
+        }
+    else:
+        legacy_github = collect_prefixed_env(
+            env,
+            (
+                "GITHUB_APP_ID_",
+                "GITHUB_APP_INSTALLATION_ID_",
+                "GITHUB_APP_PRIVATE_KEY_",
+                "GITHUB_WEBHOOK_SECRET_",
+                "GITHUB_BOT_USERNAME_",
+                "GITHUB_APP_BOT_USERNAME_",
+            ),
+        )
     github_payload = parse_json_payload(
         env.get("GITHUB_APP_ROLE_SECRETS_JSON"),
         source_name="GITHUB_APP_ROLE_SECRETS_JSON",
     )
-    json_github = flatten_github_role_payload(github_payload)
+    json_github = flatten_github_role_payload(github_payload, role_suffixes=role_suffixes)
     github_role_data = merge_env(legacy_github, json_github)
 
     _render_env_file(vibeteam_env, Path(args.vibeteam_env_output))

--- a/tests/test_agents_config.py
+++ b/tests/test_agents_config.py
@@ -1,5 +1,6 @@
 from __future__ import annotations
 
+from pathlib import Path
 from unittest.mock import patch
 
 from vibeteam import agents_config
@@ -31,3 +32,43 @@ def test_normalize_framework_name_maps_legacy_frameworks():
 def test_resolve_framework_applies_alias_to_framework_override():
     framework = agents_config.resolve_framework(None, "crewai", "openclaw")
     assert framework == "openhands"
+
+
+def test_secret_placeholders_are_loaded_from_agents_yaml(tmp_path: Path):
+    config = tmp_path / "agents.yaml"
+    config.write_text(
+        """
+agents:
+  software_engineer:
+    framework: openhands
+    slack_handle: SoftwareEngineer
+    credentials:
+      github_app:
+        app_id: "${GITHUB_APP_ID_SWE_CUSTOM}"
+        installation_id: "${GITHUB_APP_INSTALLATION_ID_SWE_CUSTOM}"
+        private_key: "${GITHUB_APP_PRIVATE_KEY_SWE_CUSTOM}"
+      slack:
+        bot_token: "${SLACK_BOT_TOKEN_SWE_CUSTOM}"
+        assistant_token: "${SLACK_ASSISTANT_TOKEN_SWE_CUSTOM}"
+""".strip()
+        + "\n",
+        encoding="utf-8",
+    )
+
+    agents_config._get_agents_map.cache_clear()
+    with patch.object(agents_config, "AGENTS_CONFIG_PATH", str(config)):
+        placeholders = agents_config.get_role_secret_placeholders("software_engineer")
+        suffixes = agents_config.get_role_secret_suffixes()
+        env_vars = agents_config.list_role_secret_env_vars()
+    agents_config._get_agents_map.cache_clear()
+
+    assert placeholders["github.app_id"] == "GITHUB_APP_ID_SWE_CUSTOM"
+    assert placeholders["github.installation_id"] == "GITHUB_APP_INSTALLATION_ID_SWE_CUSTOM"
+    assert placeholders["github.private_key"] == "GITHUB_APP_PRIVATE_KEY_SWE_CUSTOM"
+    # Missing placeholder falls back to conventional naming.
+    assert placeholders["github.webhook_secret"] == "GITHUB_WEBHOOK_SECRET_SOFTWARE_ENGINEER"
+    assert placeholders["slack.bot_token"] == "SLACK_BOT_TOKEN_SWE_CUSTOM"
+    assert placeholders["slack.assistant_token"] == "SLACK_ASSISTANT_TOKEN_SWE_CUSTOM"
+    assert placeholders["slack.signing_secret"] == "SLACK_SIGNING_SECRET_SOFTWARE_ENGINEER"
+    assert suffixes["software_engineer"] == "SWE_CUSTOM"
+    assert "GITHUB_APP_PRIVATE_KEY_SWE_CUSTOM" in env_vars

--- a/tests/test_secret_payloads.py
+++ b/tests/test_secret_payloads.py
@@ -80,6 +80,20 @@ def test_flatten_slack_role_payload_with_default_and_roles() -> None:
     assert env["SLACK_SIGNING_SECRET_PRODUCT_MANAGER"] == "sign-pm"
 
 
+def test_flatten_payloads_honor_custom_role_suffixes() -> None:
+    github = flatten_github_role_payload(
+        {"roles": {"support_engineer": {"app_id": "101"}}},
+        role_suffixes={"support_engineer": "SUP_CUSTOM"},
+    )
+    slack = flatten_slack_role_payload(
+        {"support_engineer": {"bot_token": "xoxb-custom"}},
+        role_suffixes={"support_engineer": "SUP_CUSTOM"},
+    )
+
+    assert github["GITHUB_APP_ID_SUP_CUSTOM"] == "101"
+    assert slack["SLACK_BOT_TOKEN_SUP_CUSTOM"] == "xoxb-custom"
+
+
 def test_render_k8s_role_secrets_script_merges_json_and_legacy(tmp_path: Path) -> None:
     vibeteam_env = tmp_path / "vibeteam.env"
     github_yaml = tmp_path / "github-role.yaml"
@@ -94,6 +108,7 @@ def test_render_k8s_role_secrets_script_merges_json_and_legacy(tmp_path: Path) -
                 '"default":{"signing_secret":"json-signing"}}'
             ),
             "GITHUB_APP_ID_SOFTWARE_ENGINEER": "legacy-app-id",
+            "GITHUB_BOT_USERNAME_SOFTWARE_ENGINEER": "legacy-bot-user",
             "GITHUB_APP_ROLE_SECRETS_JSON": (
                 '{"roles":{"software_engineer":{"app_id":"json-app-id",'
                 '"installation_id":"101","private_key":"lineA\\\\nlineB",'
@@ -131,3 +146,66 @@ def test_render_k8s_role_secrets_script_merges_json_and_legacy(tmp_path: Path) -
     assert "GITHUB_APP_INSTALLATION_ID_SOFTWARE_ENGINEER: '101'" in github_text
     assert "GITHUB_WEBHOOK_SECRET_SOFTWARE_ENGINEER: 'json-hook'" in github_text
     assert "GITHUB_APP_PRIVATE_KEY_SOFTWARE_ENGINEER: 'lineA\\nlineB'" in github_text
+    # Legacy env aliases still flow through rendered role secret output.
+    assert "GITHUB_BOT_USERNAME_SOFTWARE_ENGINEER: 'legacy-bot-user'" in github_text
+
+
+def test_render_script_uses_agents_yaml_placeholders_for_role_suffixes(tmp_path: Path) -> None:
+    vibeteam_env = tmp_path / "vibeteam.env"
+    github_yaml = tmp_path / "github-role.yaml"
+    custom_agents = tmp_path / "agents.yaml"
+    custom_agents.write_text(
+        """
+agents:
+  support_engineer:
+    framework: openhands
+    slack_handle: SupportEngineer
+    credentials:
+      github_app:
+        app_id: "${GITHUB_APP_ID_SUP_CUSTOM}"
+        installation_id: "${GITHUB_APP_INSTALLATION_ID_SUP_CUSTOM}"
+        private_key: "${GITHUB_APP_PRIVATE_KEY_SUP_CUSTOM}"
+        webhook_secret: "${GITHUB_WEBHOOK_SECRET_SUP_CUSTOM}"
+      slack:
+        bot_token: "${SLACK_BOT_TOKEN_SUP_CUSTOM}"
+        assistant_token: "${SLACK_ASSISTANT_TOKEN_SUP_CUSTOM}"
+        signing_secret: "${SLACK_SIGNING_SECRET_SUP_CUSTOM}"
+""".strip()
+        + "\n",
+        encoding="utf-8",
+    )
+
+    env = os.environ.copy()
+    env.update(
+        {
+            "AGENTS_CONFIG_PATH": str(custom_agents),
+            "SLACK_BOT_TOKEN_SUP_CUSTOM": "legacy-custom-token",
+            "SLACK_BOT_TOKEN_SUPPORT_ENGINEER": "legacy-standard-token",
+            "SLACK_ROLE_SECRETS_JSON": '{"support_engineer":{"bot_token":"json-custom-token"}}',
+            "GITHUB_APP_ID_SUP_CUSTOM": "legacy-app-id",
+            "GITHUB_APP_ROLE_SECRETS_JSON": '{"roles":{"support_engineer":{"app_id":"json-app-id"}}}',
+        }
+    )
+
+    subprocess.run(
+        [
+            sys.executable,
+            "scripts/render_k8s_role_secrets.py",
+            "--namespace",
+            "vibeteam",
+            "--vibeteam-env-output",
+            str(vibeteam_env),
+            "--github-role-yaml-output",
+            str(github_yaml),
+        ],
+        cwd=Path(__file__).resolve().parents[1],
+        check=True,
+        env=env,
+    )
+
+    vibeteam_text = vibeteam_env.read_text(encoding="utf-8")
+    github_text = github_yaml.read_text(encoding="utf-8")
+
+    assert "SLACK_BOT_TOKEN_SUP_CUSTOM=json-custom-token" in vibeteam_text
+    assert "SLACK_BOT_TOKEN_SUPPORT_ENGINEER=legacy-standard-token" not in vibeteam_text
+    assert "GITHUB_APP_ID_SUP_CUSTOM: 'json-app-id'" in github_text

--- a/vibeteam/agents_config.py
+++ b/vibeteam/agents_config.py
@@ -8,6 +8,7 @@ resolution for services that need to respect agents/agents.yaml configuration.
 from __future__ import annotations
 
 import os
+import re
 from dataclasses import dataclass
 from functools import lru_cache
 from pathlib import Path
@@ -33,6 +34,21 @@ AGENTS_CONFIG_PATH = os.environ.get("AGENTS_CONFIG_PATH", "agents/agents.yaml")
 FRAMEWORK_ALIASES = {
     "autogen": "openhands",
     "crewai": "openhands",
+}
+PLACEHOLDER_PATTERN = re.compile(r"^\$\{([A-Z0-9_]+)\}$")
+
+GITHUB_PLACEHOLDER_KEYS = {
+    "app_id": "GITHUB_APP_ID",
+    "installation_id": "GITHUB_APP_INSTALLATION_ID",
+    "private_key": "GITHUB_APP_PRIVATE_KEY",
+    "webhook_secret": "GITHUB_WEBHOOK_SECRET",
+    "bot_username": "GITHUB_APP_BOT_USERNAME",
+}
+
+SLACK_PLACEHOLDER_KEYS = {
+    "bot_token": "SLACK_BOT_TOKEN",
+    "assistant_token": "SLACK_ASSISTANT_TOKEN",
+    "signing_secret": "SLACK_SIGNING_SECRET",
 }
 
 
@@ -61,6 +77,17 @@ def _get_agents_config_path() -> Path:
 
 def _get_agents_config_dir() -> Path:
     return _get_agents_config_path().parent
+
+
+def _placeholder_env_name(value: Any) -> str | None:
+    if not isinstance(value, str):
+        return None
+    match = PLACEHOLDER_PATTERN.match(value.strip())
+    return match.group(1) if match else None
+
+
+def _default_role_suffix(role: str) -> str:
+    return re.sub(r"[^A-Z0-9]+", "_", role.strip().upper()).strip("_")
 
 
 def _load_agents_config() -> dict[str, Any]:
@@ -192,6 +219,71 @@ def list_agents() -> list[AgentEntry]:
     return entries
 
 
+def get_role_secret_placeholders(role: str | None) -> dict[str, str]:
+    """Return env-var names referenced by role credential placeholders in agents.yaml.
+
+    Placeholders are expected as strings in `${ENV_VAR_NAME}` form under:
+      agents.<role>.credentials.github_app.<field>
+      agents.<role>.credentials.slack.<field>
+
+    Missing placeholders are filled with conventional defaults derived from role name.
+    """
+    if not role:
+        return {}
+
+    agents = _get_agents_map()
+    raw = agents.get(role, {})
+    if not isinstance(raw, dict):
+        raw = {}
+
+    credentials = raw.get("credentials", {})
+    if not isinstance(credentials, dict):
+        credentials = {}
+    github = credentials.get("github_app", {})
+    slack = credentials.get("slack", {})
+    if not isinstance(github, dict):
+        github = {}
+    if not isinstance(slack, dict):
+        slack = {}
+
+    suffix = _default_role_suffix(role)
+    resolved: dict[str, str] = {}
+
+    for key, prefix in GITHUB_PLACEHOLDER_KEYS.items():
+        env_name = _placeholder_env_name(github.get(key)) or f"{prefix}_{suffix}"
+        resolved[f"github.{key}"] = env_name
+
+    for key, prefix in SLACK_PLACEHOLDER_KEYS.items():
+        env_name = _placeholder_env_name(slack.get(key)) or f"{prefix}_{suffix}"
+        resolved[f"slack.{key}"] = env_name
+
+    return resolved
+
+
+def get_role_secret_suffixes() -> dict[str, str]:
+    """Return role -> env suffix inferred from agents.yaml github app placeholders."""
+    suffixes: dict[str, str] = {}
+    for role in _get_agents_map().keys():
+        placeholders = get_role_secret_placeholders(role)
+        app_id_key = placeholders.get("github.app_id", "")
+        prefix = "GITHUB_APP_ID_"
+        if app_id_key.startswith(prefix):
+            suffix = app_id_key[len(prefix) :]
+            if suffix:
+                suffixes[role] = suffix
+                continue
+        suffixes[role] = _default_role_suffix(role)
+    return suffixes
+
+
+def list_role_secret_env_vars() -> set[str]:
+    """Return all role-scoped env var names referenced by agents.yaml placeholders."""
+    env_vars: set[str] = set()
+    for role in _get_agents_map().keys():
+        env_vars.update(get_role_secret_placeholders(role).values())
+    return env_vars
+
+
 __all__ = [
     "AgentEntry",
     "get_agent_entry",
@@ -202,4 +294,7 @@ __all__ = [
     "get_agent_dir",
     "get_prompt_path",
     "list_agents",
+    "get_role_secret_placeholders",
+    "get_role_secret_suffixes",
+    "list_role_secret_env_vars",
 ]

--- a/vibeteam/utils/secret_payloads.py
+++ b/vibeteam/utils/secret_payloads.py
@@ -34,6 +34,27 @@ ROLE_ALIASES: dict[str, str] = {
 }
 
 
+def _resolve_role_maps(
+    role_suffixes: Mapping[str, str] | None,
+) -> tuple[dict[str, str], dict[str, str]]:
+    suffixes = dict(ROLE_SUFFIXES)
+    if role_suffixes:
+        for role, suffix in role_suffixes.items():
+            if not isinstance(role, str) or not isinstance(suffix, str):
+                continue
+            role_key = re.sub(r"[^a-z0-9]+", "_", role.strip().lower()).strip("_")
+            suffix_value = suffix.strip().upper()
+            if role_key and suffix_value:
+                suffixes[role_key] = suffix_value
+
+    aliases = dict(ROLE_ALIASES)
+    for role in suffixes:
+        compact = role.replace("_", "")
+        aliases.setdefault(role, role)
+        aliases.setdefault(compact, role)
+    return suffixes, aliases
+
+
 def parse_json_payload(raw: str | None, *, source_name: str) -> dict[str, Any]:
     """Parse an optional JSON object payload from a secret value."""
     if not raw or not raw.strip():
@@ -47,11 +68,16 @@ def parse_json_payload(raw: str | None, *, source_name: str) -> dict[str, Any]:
     return payload
 
 
-def _normalize_role(role: str) -> str | None:
+def _normalize_role(
+    role: str,
+    *,
+    suffixes: Mapping[str, str],
+    aliases: Mapping[str, str],
+) -> str | None:
     normalized = re.sub(r"[^a-z0-9]+", "_", role.strip().lower()).strip("_")
     if not normalized:
         return None
-    return ROLE_ALIASES.get(normalized, normalized if normalized in ROLE_SUFFIXES else None)
+    return aliases.get(normalized, normalized if normalized in suffixes else None)
 
 
 def _string_value(value: Any) -> str | None:
@@ -87,8 +113,13 @@ def _roles_object(payload: Mapping[str, Any]) -> Mapping[str, Any]:
     return payload
 
 
-def flatten_github_role_payload(payload: Mapping[str, Any]) -> dict[str, str]:
+def flatten_github_role_payload(
+    payload: Mapping[str, Any],
+    *,
+    role_suffixes: Mapping[str, str] | None = None,
+) -> dict[str, str]:
     """Flatten GitHub role payload JSON into env-style key/value pairs."""
+    suffixes, aliases = _resolve_role_maps(role_suffixes)
     direct = _env_keys(payload, "GITHUB_")
     if direct:
         return direct
@@ -97,10 +128,10 @@ def flatten_github_role_payload(payload: Mapping[str, Any]) -> dict[str, str]:
     for role_name, role_data in _roles_object(payload).items():
         if not isinstance(role_name, str) or not isinstance(role_data, Mapping):
             continue
-        role = _normalize_role(role_name)
+        role = _normalize_role(role_name, suffixes=suffixes, aliases=aliases)
         if role is None:
             continue
-        suffix = ROLE_SUFFIXES[role]
+        suffix = suffixes[role]
         app_id = _first_value(
             role_data,
             ["app_id", "appId", "github_app_id", "githubAppId", "id"],
@@ -136,8 +167,13 @@ def flatten_github_role_payload(payload: Mapping[str, Any]) -> dict[str, str]:
     return env
 
 
-def flatten_slack_role_payload(payload: Mapping[str, Any]) -> dict[str, str]:
+def flatten_slack_role_payload(
+    payload: Mapping[str, Any],
+    *,
+    role_suffixes: Mapping[str, str] | None = None,
+) -> dict[str, str]:
     """Flatten Slack role payload JSON into env-style key/value pairs."""
+    suffixes, aliases = _resolve_role_maps(role_suffixes)
     direct = _env_keys(payload, "SLACK_")
     if direct:
         return direct
@@ -150,10 +186,10 @@ def flatten_slack_role_payload(payload: Mapping[str, Any]) -> dict[str, str]:
         role_key = role_name.strip().lower()
         suffix = None
         if role_key not in {"default", "global", "fallback"}:
-            normalized_role = _normalize_role(role_name)
+            normalized_role = _normalize_role(role_name, suffixes=suffixes, aliases=aliases)
             if normalized_role is None:
                 continue
-            suffix = ROLE_SUFFIXES[normalized_role]
+            suffix = suffixes[normalized_role]
 
         bot_token = _first_value(role_data, ["bot_token", "botToken", "token"])
         assistant_token = _first_value(


### PR DESCRIPTION
## Summary
- add per-role Slack and GitHub App credential placeholders to `agents/agents.yaml`
- derive role suffix/env-key mappings from `agents.yaml` in config helpers
- render deploy-time role secrets using placeholder-derived keys (with JSON payload precedence)
- keep legacy compatibility including `GITHUB_BOT_USERNAME_<ROLE>`
- update docs and tests

Closes #367

## Docs referenced
- docs/requirements.md
- docs/design.md
- docs/testing.md
- docs/slack.md
- docs/github.md
- docs/webhook-routing.md

## Validation
- `uv run python -m pytest tests/test_agents_config.py tests/test_secret_payloads.py tests/test_slack_role_tokens.py tests/test_agent_github_app_tokens.py -v`
  - Result: 22 passed
