### PR TITLE
fix(dev): align gateway/openclaw AGENTS_CONFIG_PATH with git-sync

### DIFF
--- a/k8s/overlays/dev/gateway-patch.yaml
+++ b/k8s/overlays/dev/gateway-patch.yaml
@@ -32,6 +32,10 @@ spec:
           env:
             - name: PYTHONPATH
               value: "/code/current"
+            - name: AGENTS_DIR
+              value: "/code/current/agents"
+            - name: AGENTS_CONFIG_PATH
+              value: "/code/current/agents/agents.yaml"
           volumeMounts:
             - name: code
               mountPath: /code

--- a/k8s/overlays/dev/openclaw-svc-patch.yaml
+++ b/k8s/overlays/dev/openclaw-svc-patch.yaml
@@ -31,6 +31,10 @@ spec:
           env:
             - name: PYTHONPATH
               value: "/code/current"
+            - name: AGENTS_DIR
+              value: "/code/current/agents"
+            - name: AGENTS_CONFIG_PATH
+              value: "/code/current/agents/agents.yaml"
           volumeMounts:
             - name: code
               mountPath: /code


### PR DESCRIPTION
## Summary
- fix dev gateway patch to read agents config from git-sync path (`/code/current/agents/agents.yaml`)
- fix dev openclaw patch to read agents config from git-sync path (`/code/current/agents/agents.yaml`)
- keep `AGENTS_DIR` aligned to `/code/current/agents`

Closes #369

## Why
Dev deployments run code from `/code/current` via git-sync, but these services still referenced `/app/agents/agents.yaml`, which can be stale and bypass recent `agents.yaml` updates.

## Validation
- `kubectl kustomize k8s/overlays/dev | rg "AGENTS_CONFIG_PATH|AGENTS_DIR|/code/current/agents"`
