### PR TITLE
fix(k8s): prevent gmail-processor crash on .secrets fallback path

### DIFF
--- a/k8s/base/gmail-processor.yaml
+++ b/k8s/base/gmail-processor.yaml
@@ -78,6 +78,9 @@ spec:
           volumeMounts:
             - name: gmail-writable
               mountPath: /gmail
+            # Keep script fallback paths writable even when ESCALATION_DIR is not resolved.
+            - name: app-secrets-writable
+              mountPath: /app/.secrets
           resources:
             requests:
               cpu: 50m
@@ -91,5 +94,7 @@ spec:
             secretName: gmail-oauth-secret
             optional: false
         - name: gmail-writable
+          emptyDir: {}
+        - name: app-secrets-writable
           emptyDir: {}
       restartPolicy: Always


### PR DESCRIPTION
## Summary
- add a writable `emptyDir` mount at `/app/.secrets` for `gmail-processor`
- preserve existing `/gmail` writable mount and `ESCALATION_DIR` env
- ensure fallback directory creation in `scripts/process_emails.py` cannot crash pod startup

Closes #371

## Validation
- `uv run python -m pytest tests/test_gmail_processor.py -v`
- `kubectl apply -k k8s/overlays/dev`
- `kubectl rollout status` for affected deployments
- `kubectl get pods,svc,ingress -n vibeteam`
- `uv run python scripts/eval_slack_e2e.py --scenario support_notify_check --channel C0AATPSADB8 --timeout 600`
