### PR TITLE
fix(slack): route direct role-bot mentions in channel messages

### DIFF
--- a/tests/test_async_callback.py
+++ b/tests/test_async_callback.py
@@ -859,6 +859,7 @@ class TestSlackEventsPassMessageTs:
         text: str = "help me",
         channel_type: str | None = None,
         is_bot: bool = False,
+        include_thread: bool = True,
     ) -> dict[str, Any]:
         """Build a minimal Slack event payload."""
         event: dict[str, Any] = {
@@ -867,8 +868,9 @@ class TestSlackEventsPassMessageTs:
             "user": "U_TEST",
             "channel": "C_TEST",
             "ts": "1234567890.123456",
-            "thread_ts": "1234567890.000000",
         }
+        if include_thread:
+            event["thread_ts"] = "1234567890.000000"
         if channel_type:
             event["channel_type"] = channel_type
         if is_bot:
@@ -949,6 +951,80 @@ class TestSlackEventsPassMessageTs:
 
             mock_run.assert_called_once()
             assert mock_run.call_args.kwargs.get("message_ts") == "1234567890.123456"
+
+    def test_channel_role_bot_mention_routes_without_ingress_mention(self, test_client):
+        """Direct role-bot user mention in channel should route even without @VibeTeam."""
+        payload = self._make_slack_event(
+            "message",
+            text="<@U_SUPPORT_BOT> please investigate sentry issue",
+            channel_type="channel",
+            include_thread=False,
+        )
+
+        with (
+            patch(
+                "vibeteam.gateway.routes.slack.add_reaction",
+                new_callable=AsyncMock,
+            ) as mock_add,
+            patch(
+                "vibeteam.gateway.routes.slack._extract_roles_from_slack_user_mentions",
+                new_callable=AsyncMock,
+                return_value=["support_engineer"],
+            ),
+            patch(
+                "vibeteam.gateway.routes.slack._mentions_ingress_bot",
+                new_callable=AsyncMock,
+                return_value=False,
+            ),
+            patch(
+                "vibeteam.gateway.routes.slack.run_agent_for_slack",
+                new_callable=AsyncMock,
+            ) as mock_run,
+        ):
+            asyncio.run(_process_slack_event(payload))
+
+            mock_add.assert_any_call("C_TEST", "1234567890.123456", "eyes")
+            mock_add.assert_any_call("C_TEST", "1234567890.123456", "thinking_face")
+            mock_run.assert_called_once()
+            routed_text = mock_run.call_args.args[0]
+            assert "@SupportEngineer" in routed_text
+            assert mock_run.call_args.kwargs.get("message_ts") == "1234567890.123456"
+
+    def test_channel_role_bot_mention_skips_when_ingress_mentioned(self, test_client):
+        """If ingress bot is mentioned, app_mention path should handle to avoid duplicates."""
+        payload = self._make_slack_event(
+            "message",
+            text="<@U_INGRESS> <@U_SUPPORT_BOT> please investigate sentry issue",
+            channel_type="channel",
+            include_thread=False,
+        )
+
+        with (
+            patch(
+                "vibeteam.gateway.routes.slack.add_reaction",
+                new_callable=AsyncMock,
+            ) as mock_add,
+            patch(
+                "vibeteam.gateway.routes.slack._extract_roles_from_slack_user_mentions",
+                new_callable=AsyncMock,
+                return_value=["support_engineer"],
+            ),
+            patch(
+                "vibeteam.gateway.routes.slack._mentions_ingress_bot",
+                new_callable=AsyncMock,
+                return_value=True,
+            ),
+            patch(
+                "vibeteam.gateway.routes.slack.run_agent_for_slack",
+                new_callable=AsyncMock,
+            ) as mock_run,
+        ):
+            asyncio.run(_process_slack_event(payload))
+
+            mock_add.assert_any_call("C_TEST", "1234567890.123456", "eyes")
+            thinking_calls = [c for c in mock_add.call_args_list if c.args[2] == "thinking_face"]
+            assert not thinking_calls
+            mock_run.assert_not_called()
 
 
 # ==============================================================================

--- a/vibeteam/gateway/routes/slack.py
+++ b/vibeteam/gateway/routes/slack.py
@@ -399,6 +399,49 @@ def _collect_slack_bot_tokens() -> list[str]:
     return ordered
 
 
+async def _role_bot_user_ids() -> dict[str, str]:
+    """Map Slack user IDs to roles for role-scoped bot tokens.
+
+    Uses only role-scoped bot tokens to avoid conflating ingress token identity
+    with role bot identities when global fallback is configured.
+    """
+    user_id_to_role: dict[str, str] = {}
+    for role in sorted(set(ROLE_MENTION_MAP.values())):
+        token = _get_role_scoped_env("SLACK_BOT_TOKEN", role)
+        if not token:
+            continue
+        user_id = await get_bot_user_id(token=token)
+        if user_id:
+            user_id_to_role[user_id] = role
+    return user_id_to_role
+
+
+async def _extract_roles_from_slack_user_mentions(text: str) -> list[str]:
+    """Extract roles referenced via Slack user mention syntax (<@U...>)."""
+    if not text:
+        return []
+
+    user_mentions = re.findall(r"<@([A-Z0-9]+)>", text)
+    if not user_mentions:
+        return []
+
+    user_id_to_role = await _role_bot_user_ids()
+    roles: list[str] = []
+    for user_id in user_mentions:
+        role = user_id_to_role.get(user_id)
+        if role and role not in roles:
+            roles.append(role)
+    return roles
+
+
+async def _mentions_ingress_bot(text: str) -> bool:
+    """Return True when message explicitly mentions ingress bot (<@U...>)."""
+    ingress_user_id = await get_bot_user_id()
+    if not ingress_user_id:
+        return False
+    return f"<@{ingress_user_id}>" in (text or "")
+
+
 async def send_slack_message(
     channel: str,
     text: str,
@@ -1957,6 +2000,48 @@ async def _process_slack_event(payload: dict[str, Any]) -> dict[str, Any]:
             await run_agent_for_slack(text, channel, thread_ts, user_id, message_ts=message_ts)
 
             return {"status": "accepted", "event": "message.im"}
+
+        # Handle direct role mentions in channel messages even without ingress
+        # app mention (e.g., "<@U_SUPPORT_BOT> please investigate").
+        if event_type == "message" and not is_bot_message and event.get("channel_type") != "im":
+            user_id = event.get("user", "")
+            channel = event.get("channel", "")
+            text = event.get("text", "")
+            message_ts = event.get("ts", "")
+            thread_ts = event.get("thread_ts") or message_ts
+
+            message_router = get_message_router()
+            parsed_role_mentions = message_router.parse_role_mentions(text)
+            user_mention_roles = await _extract_roles_from_slack_user_mentions(text)
+            explicit_roles: list[str] = []
+            for role in [*parsed_role_mentions, *user_mention_roles]:
+                if role not in explicit_roles:
+                    explicit_roles.append(role)
+
+            # If ingress app is explicitly mentioned, app_mention flow already handles
+            # the message and this branch would duplicate processing.
+            ingress_mentioned = await _mentions_ingress_bot(text)
+
+            if explicit_roles and not ingress_mentioned:
+                if message_ts:
+                    await add_reaction(channel, message_ts, "thinking_face")
+
+                routed_text = text
+                for role in explicit_roles:
+                    display_name = get_slack_handle(role) or get_display_name(cast(AgentRole, role))
+                    token = f"@{display_name}"
+                    if token.lower() not in routed_text.lower():
+                        routed_text = f"{token} {routed_text}".strip()
+
+                await run_agent_for_slack(
+                    routed_text,
+                    channel,
+                    thread_ts,
+                    user_id,
+                    message_ts=message_ts,
+                )
+
+                return {"status": "accepted", "event": "message.channel_role_mention"}
 
         # Handle thread replies in threads where the bot has participated.
         # When VibeTeam participates in a thread (via app_mention or trigger),


### PR DESCRIPTION
## Summary
- add Slack `<@U...>` mention -> role mapping using role-scoped bot tokens
- process non-bot channel messages that mention role bot users even without `@VibeTeam`
- skip this branch when ingress bot is mentioned to avoid duplicate processing with `app_mention`
- add coverage in `tests/test_async_callback.py`

Closes #373

## Validation
- `uv run python -m pytest tests/test_async_callback.py -v`
- verified regression case from channel `C0AATPSADB8` message shape (`<@U_ROLE_BOT> ...`) now routes through event handler path