### PR TITLE
Remove legacy Slack text prefixes for role apps

### DIFF
--- a/scripts/eval_slack_e2e.py
+++ b/scripts/eval_slack_e2e.py
@@ -1432,6 +1432,24 @@ def _build_role_display() -> dict[str, str]:
 ROLE_DISPLAY = _build_role_display()
 
 
+# Role-scoped Slack bot user IDs (user_id -> role), resolved from env tokens.
+@lru_cache(maxsize=1)
+def _load_role_bot_user_ids() -> dict[str, str]:
+    mapping: dict[str, str] = {}
+    for role in sorted(r for r in ROLE_DISPLAY if r != "user"):
+        token = os.environ.get(f"SLACK_BOT_TOKEN_{role.upper()}", "").strip()
+        if not token:
+            continue
+        try:
+            connector = SlackConnector(token=token)
+            user_id = connector.bot_user_id
+            if user_id:
+                mapping[user_id] = role
+        except Exception as exc:
+            print(f"WARNING: Failed to resolve Slack bot user ID for role '{role}': {exc}")
+    return mapping
+
+
 # ==============================================================================
 # Azure OpenAI Model for DeepEval
 # ==============================================================================
@@ -1553,21 +1571,28 @@ def _is_placeholder(text: str) -> bool:
 
     Placeholder patterns posted by the gateway while agent is working:
     - "Thinking..." messages: ":hourglass_flowing_sand: [Role] Thinking..."
-    - Progress updates: "_[Role] Step N (Xs): summary_" (italicized)
+      and role-prefix-free variants (e.g., ":hourglass_flowing_sand: Thinking...")
+    - Progress updates: "_[Role] Step N (Xs): summary_" (legacy) or
+      "_Step N (Xs): summary_" (role-prefix-free)
     - Timeout notices: ":hourglass: ..."
     """
-    import re
-
     stripped = text.strip()
-    # Progress updates are posted as italicized messages: _[Role] Step N ..._
-    if stripped.startswith("_[") and stripped.endswith("_"):
+
+    # Progress updates are posted as italicized messages:
+    #   _[Role] Step N (45s): summary_   (legacy)
+    #   _Step N (45s): summary_          (current)
+    progress_re = re.compile(r"^_(?:\[[^\]]+\]\s*)?Step\s+\d+\s+\([^)]*\):\s+.+_$")
+    if progress_re.match(stripped):
         return True
+
     # Thinking placeholders
     if "Thinking..." in stripped and len(stripped) < 200:
         return True
+
     # Very short messages that look like status updates
-    if re.match(r"^:[\w_]+:\s*\[[\w]+\]\s*(Thinking|Processing|Working)", stripped):
+    if re.match(r"^:[\w_]+:\s*(?:\[[\w:.\-]+\]\s*)?(Thinking|Processing|Working)\b", stripped):
         return True
+
     return False
 
 
@@ -2521,6 +2546,7 @@ async def run_evaluation(
         raise ValueError("SLACK_BOT_TOKEN environment variable not set")
 
     slack = SlackConnector(token=slack_token)
+    role_bot_user_ids = _load_role_bot_user_ids()
 
     async def _slack_call(fn: Any, *args: Any, timeout: float = 30.0, **kwargs: Any) -> Any:
         """Run a Slack API call in a thread with a timeout to avoid hangs."""
@@ -2547,6 +2573,68 @@ async def run_evaluation(
     print()
 
     user_message = scenario["message"]
+
+    def _extract_agent_prefix(text: str) -> str:
+        """Extract the agent name from a legacy bot prefix like '[SupportEngineer]'."""
+        m = re.match(r"_?\[([A-Za-z][\w.\-]*)\]", text.strip())
+        return m.group(1) if m else ""
+
+    def _display_to_role(display: str) -> str:
+        """Convert display name like 'SupportEngineer' to role key 'support_engineer'."""
+        if not display:
+            return ""
+        lowered = display.strip().lower()
+        for role in ROLE_DISPLAY:
+            if role.lower() == lowered:
+                return role
+        for role, disp in ROLE_DISPLAY.items():
+            if disp.lower() == lowered:
+                return role
+        return ""
+
+    def _parse_role_mentions_loose(text: str) -> list[str]:
+        """Parse role mentions, including bare role names in handoff phrasing."""
+        explicit = parse_role_mentions(text)
+        if explicit:
+            return explicit
+        # Remove leading agent prefix like "[SupportEngineer]" from legacy messages.
+        clean = re.sub(r"_?\[[A-Za-z]+\]\s*", "", text.strip())
+        names_pattern = "|".join(re.escape(v) for v in ROLE_DISPLAY.values())
+        if not names_pattern:
+            return []
+        pattern = re.compile(rf"(?i)(?<![@/])\b({names_pattern})\b")
+        display_to_role = {v.lower(): k for k, v in ROLE_DISPLAY.items()}
+        roles: list[str] = []
+        for match in pattern.findall(clean):
+            role = display_to_role.get(match.lower())
+            if role and role not in roles:
+                roles.append(role)
+        return roles
+
+    def _role_from_reply(reply: SlackMessage) -> str:
+        """Resolve role from Slack app identity, fallback to legacy text prefix."""
+        if reply.user in role_bot_user_ids:
+            return role_bot_user_ids[reply.user]
+        prefix_display = _extract_agent_prefix(reply.text)
+        if prefix_display:
+            prefix_role = _display_to_role(prefix_display)
+            if prefix_role:
+                return prefix_role
+        return "bot"
+
+    def _has_non_self_handoff(text: str, source_role: str = "") -> bool:
+        """True if text mentions a role other than the current agent."""
+        targets = _parse_role_mentions_loose(text)
+        if not targets:
+            return False
+        if source_role == "bot":
+            source_role = ""
+        if not source_role:
+            source_role = _display_to_role(_extract_agent_prefix(text))
+        # If we can't identify the source role, treat any mention as a handoff.
+        if not source_role:
+            return True
+        return any(t != source_role for t in targets)
 
     if existing_thread_ts:
         # ── Re-score mode: skip Steps 1, 1b, 2 ──────────────────────────
@@ -2645,7 +2733,7 @@ async def run_evaluation(
         # Track substantive responses per agent role for handoff completion.
         # When a handoff is detected, we need a substantive response from the
         # handoff *target* agent, not just the original agent.
-        handoff_source_agent = ""  # e.g. "SupportEngineer" — the agent that initiated handoff
+        handoff_source_role = ""  # e.g. "support_engineer" — the handoff initiator role
         handoff_target_responded = False  # True once the handoff target posts a real response
 
         def _content_fingerprint(replies: list) -> str:
@@ -2654,58 +2742,6 @@ async def run_evaluation(
 
             content = "|".join(r.text for r in replies)
             return hashlib.md5(content.encode()).hexdigest()
-
-        def _extract_agent_prefix(text: str) -> str:
-            """Extract the agent name from a bot message prefix like '[SupportEngineer]'.
-
-            Works for both substantive messages ('[Agent] ...') and progress
-            messages ('_[Agent] Step N ..._').
-            """
-            import re
-
-            # Match [AgentName] at start, optionally preceded by _ (italic progress)
-            m = re.match(r"_?\[([A-Za-z]+)\]", text.strip())
-            return m.group(1) if m else ""
-
-        def _display_to_role(display: str) -> str:
-            """Convert display name like 'SupportEngineer' to role key 'support_engineer'."""
-            if not display:
-                return ""
-            lowered = display.strip().lower()
-            for role, disp in ROLE_DISPLAY.items():
-                if disp.lower() == lowered:
-                    return role
-            return ""
-
-        def _parse_role_mentions_loose(text: str) -> list[str]:
-            """Parse role mentions, including bare role names in handoff phrasing."""
-            explicit = parse_role_mentions(text)
-            if explicit:
-                return explicit
-            # Remove leading agent prefix like "[SupportEngineer]"
-            clean = re.sub(r"_?\[[A-Za-z]+\]\s*", "", text.strip())
-            names_pattern = "|".join(re.escape(v) for v in ROLE_DISPLAY.values())
-            if not names_pattern:
-                return []
-            pattern = re.compile(rf"(?i)(?<![@/])\b({names_pattern})\b")
-            display_to_role = {v.lower(): k for k, v in ROLE_DISPLAY.items()}
-            roles: list[str] = []
-            for match in pattern.findall(clean):
-                role = display_to_role.get(match.lower())
-                if role and role not in roles:
-                    roles.append(role)
-            return roles
-
-        def _has_non_self_handoff(text: str) -> bool:
-            """True if text mentions a role other than the current agent."""
-            targets = _parse_role_mentions_loose(text)
-            if not targets:
-                return False
-            source_role = _display_to_role(_extract_agent_prefix(text))
-            # If we can't identify the source role, treat any mention as a handoff
-            if not source_role:
-                return True
-            return any(t != source_role for t in targets)
 
         while True:
             await asyncio.sleep(poll_interval)
@@ -2734,14 +2770,15 @@ async def run_evaluation(
                 bot_messages = [r for r in replies if r.is_bot and r.ts != thread_ts]
                 if bot_messages:
                     latest_bot_msg = bot_messages[-1]
-                    has_handoff = _has_non_self_handoff(latest_bot_msg.text)
+                    latest_role = _role_from_reply(latest_bot_msg)
+                    has_handoff = _has_non_self_handoff(latest_bot_msg.text, latest_role)
                     if has_handoff and not scenario.get("skip_handoff", False):
                         print("    Handoff detected in response! Waiting for next agent...")
                         pending_handoff = True
                         effective_timeout = time.time() - start_time + handoff_timeout_extension
                         # Track which agent initiated the handoff so we can
                         # distinguish its messages from the handoff target's
-                        handoff_source_agent = _extract_agent_prefix(latest_bot_msg.text)
+                        handoff_source_role = latest_role
                         handoff_target_responded = False
                         continue
                     else:
@@ -2754,12 +2791,18 @@ async def run_evaluation(
                                 m for m in bot_messages if not _is_placeholder(m.text)
                             ]
                             for msg in new_substantive:
-                                agent = _extract_agent_prefix(msg.text)
-                                if agent and agent != handoff_source_agent:
+                                agent_role = _role_from_reply(msg)
+                                if (
+                                    agent_role
+                                    and agent_role != "bot"
+                                    and agent_role != handoff_source_role
+                                ):
                                     handoff_target_responded = True
                                     pending_handoff = False
+                                    agent_display = ROLE_DISPLAY.get(agent_role, agent_role)
                                     print(
-                                        f"    Handoff target [{agent}] posted substantive response."
+                                        f"    Handoff target [{agent_display}] posted substantive "
+                                        "response."
                                     )
                                     break
                             # If still only progress from target, keep waiting
@@ -2804,7 +2847,8 @@ async def run_evaluation(
                             continue
 
                     latest_bot_msg = bot_messages[-1]
-                    has_handoff = _has_non_self_handoff(latest_bot_msg.text)
+                    latest_role = _role_from_reply(latest_bot_msg)
+                    has_handoff = _has_non_self_handoff(latest_bot_msg.text, latest_role)
                     if not has_handoff or scenario.get("skip_handoff", False):
                         print(
                             f"    Conversation stable for {int(time_since_last)}s, "
@@ -2843,22 +2887,21 @@ async def run_evaluation(
         if reply.ts == thread_ts:
             continue  # Skip original message
 
-        # Detect agent role from message prefix like "[SupportEngineer]"
-        text = reply.text
         role = "bot"
+        if reply.user in role_bot_user_ids:
+            role = role_bot_user_ids[reply.user]
+        else:
+            # Legacy fallback for old threads that still used [Role] prefixes.
+            text_prefix = _extract_agent_prefix(reply.text)
+            if text_prefix:
+                prefix_role = _display_to_role(text_prefix)
+                if prefix_role:
+                    role = prefix_role
 
+        text = reply.text
         if text.startswith("["):
             bracket_end = text.find("]")
             if bracket_end > 0:
-                role_name = text[1:bracket_end].lower().replace(" ", "_")
-                if role_name in ROLE_DISPLAY.values() or role_name.replace("_", "") in [
-                    r.lower().replace("_", "") for r in ROLE_DISPLAY.keys()
-                ]:
-                    # Normalize role name
-                    for key, display in ROLE_DISPLAY.items():
-                        if display.lower() == role_name or key == role_name:
-                            role = key
-                            break
                 text = text[bracket_end + 1 :].strip()
 
         conversation.append((role, text))

--- a/tests/test_async_callback.py
+++ b/tests/test_async_callback.py
@@ -284,7 +284,7 @@ class TestCallbackEndpoint:
             # Verify message posted to thread
             mock_send.assert_called_once()
             sent_text = mock_send.call_args[0][1]
-            assert "[SupportEngineer]" in sent_text
+            assert "[SupportEngineer]" not in sent_text
             assert "I investigated the issue" in sent_text
 
     def test_callback_failure_posts_error(self, test_client):
@@ -580,11 +580,13 @@ class TestCallbackEndpoint:
 
             # First message should have role prefix
             first_text = mock_send.call_args_list[0][0][1]
-            assert "[SupportEngineer]" in first_text
+            assert "[SupportEngineer]" not in first_text
+            assert first_text
 
-            # Second message should have continuation prefix
+            # Second message should be plain chunk text as well
             second_text = mock_send.call_args_list[1][0][1]
-            assert "(cont.)" in second_text
+            assert "(cont.)" not in second_text
+            assert second_text
 
     def test_callback_rejects_invalid_secret(self, test_client):
         """Callback with wrong secret is rejected when CALLBACK_SECRET is set."""
@@ -952,6 +954,37 @@ class TestSlackEventsPassMessageTs:
             mock_run.assert_called_once()
             assert mock_run.call_args.kwargs.get("message_ts") == "1234567890.123456"
 
+    def test_self_bot_message_with_role_mention_is_ignored(self, test_client):
+        """Self-posted bot messages are ignored to avoid duplicate handoff processing."""
+        payload = self._make_slack_event(
+            "message", text="@SupportEngineer please investigate", is_bot=True
+        )
+        payload["event"]["user"] = "U_SUPPORT_BOT"
+
+        with (
+            patch(
+                "vibeteam.gateway.routes.slack.add_reaction",
+                new_callable=AsyncMock,
+            ) as mock_add,
+            patch(
+                "vibeteam.gateway.routes.slack._our_bot_user_ids",
+                new_callable=AsyncMock,
+                return_value={"U_SUPPORT_BOT"},
+            ),
+            patch(
+                "vibeteam.gateway.routes.slack.run_agent_for_slack",
+                new_callable=AsyncMock,
+            ) as mock_run,
+        ):
+            result = asyncio.run(_process_slack_event(payload))
+
+            assert result["status"] == "ignored"
+            assert result["reason"] == "self_bot_handoff_already_handled"
+            mock_add.assert_any_call("C_TEST", "1234567890.123456", "eyes")
+            thinking_calls = [c for c in mock_add.call_args_list if c.args[2] == "thinking_face"]
+            assert not thinking_calls
+            mock_run.assert_not_called()
+
     def test_channel_role_bot_mention_routes_without_ingress_mention(self, test_client):
         """Direct role-bot user mention in channel should route even without @VibeTeam."""
         payload = self._make_slack_event(
@@ -1275,7 +1308,7 @@ class TestCallbackTimeout:
             # Verify timeout message posted with partial response
             mock_send.assert_called_once()
             sent_text = mock_send.call_args[0][1]
-            assert "[SupportEngineer]" in sent_text
+            assert "[SupportEngineer]" not in sent_text
             assert ":hourglass:" in sent_text
             assert "ran out of time" in sent_text
 

--- a/vibeteam/gateway/routes/slack.py
+++ b/vibeteam/gateway/routes/slack.py
@@ -223,7 +223,7 @@ def split_long_message(text: str, max_chunk_size: int = 2900) -> list[str]:
 
     Args:
         text: The text to split
-        max_chunk_size: Maximum size of each chunk (default 2900 to leave room for prefix)
+        max_chunk_size: Maximum size of each chunk (default 2900)
 
     Returns:
         List of text chunks
@@ -414,6 +414,16 @@ async def _role_bot_user_ids() -> dict[str, str]:
         if user_id:
             user_id_to_role[user_id] = role
     return user_id_to_role
+
+
+async def _our_bot_user_ids() -> set[str]:
+    """Collect Slack user IDs for ingress + role-scoped bot tokens."""
+    bot_ids: set[str] = set()
+    for token in _collect_slack_bot_tokens():
+        user_id = await get_bot_user_id(token=token)
+        if user_id:
+            bot_ids.add(user_id)
+    return bot_ids
 
 
 async def _extract_roles_from_slack_user_mentions(text: str) -> list[str]:
@@ -744,11 +754,7 @@ async def bot_participated_in_thread(channel: str, thread_ts: str) -> bool:
     tokens = _collect_slack_bot_tokens()
     if not tokens:
         return False
-    bot_ids: set[str] = set()
-    for token in tokens:
-        bot_id = await get_bot_user_id(token=token)
-        if bot_id:
-            bot_ids.add(bot_id)
+    bot_ids = await _our_bot_user_ids()
     if not bot_ids:
         return False
 
@@ -1427,9 +1433,7 @@ async def _submit_agent_async(
         await remove_reaction(channel, message_ts, "thinking_face", role=role)
         await clear_thread_status(channel, status_thread_ts, role=role)
         await add_reaction(channel, message_ts, "x", role=role)
-        error_text = (
-            f"[{display_name}] Sorry, I couldn't reach the agent service: {result['error']}"
-        )
+        error_text = f"Sorry, I couldn't reach the agent service: {result['error']}"
         await send_slack_message(channel, error_text, thread_ts, role=role)
         logger.error(f"[ASYNC] Failed to submit task for {role}: {result['error']}")
     else:
@@ -1585,7 +1589,7 @@ async def _run_agent_and_respond(
         logger.info(f"[TIMING] Agent {role} completed in {agent_duration:.1f}s")
 
         if "error" in result:
-            error_text = f"[{display_name}] Sorry, I encountered an error: {result['error']}"
+            error_text = f"Sorry, I encountered an error: {result['error']}"
             if message_ts:
                 await remove_reaction(channel, message_ts, "thinking_face", role=role)
                 await add_reaction(channel, message_ts, "x", role=role)
@@ -1598,24 +1602,13 @@ async def _run_agent_and_respond(
                 await remove_reaction(channel, message_ts, "thinking_face", role=role)
                 await add_reaction(channel, message_ts, "white_check_mark", role=role)
 
-            # Build display prefix with model info if available
-            model_name = result.get("model", "")
-            if model_name:
-                agent_prefix = f"[{display_name}:{model_name}]"
-            else:
-                agent_prefix = f"[{display_name}]"
-
             # Split long responses into multiple messages instead of truncating
             # This preserves handoff mentions that might be at the end
             chunks = split_long_message(response)
 
             # Send each chunk as a separate message
-            for i, chunk in enumerate(chunks):
-                if i == 0:
-                    formatted_chunk = f"{agent_prefix} {chunk}"
-                else:
-                    formatted_chunk = f"{agent_prefix} (cont.) {chunk}"
-                await send_slack_message(channel, formatted_chunk, thread_ts, role=role)
+            for chunk in chunks:
+                await send_slack_message(channel, chunk, thread_ts, role=role)
 
             # Check for handoffs in the response and execute them synchronously
             handoff_roles = _parse_handoff_roles(response, role)
@@ -1680,9 +1673,7 @@ async def _run_agent_and_respond(
 
     except Exception as e:
         logger.exception(f"Failed to run agent for Slack: {e}")
-        error_text = (
-            f"[{display_name}] Sorry, I encountered an unexpected error. Please try again later."
-        )
+        error_text = "Sorry, I encountered an unexpected error. Please try again later."
         if message_ts:
             await remove_reaction(channel, message_ts, "thinking_face", role=role)
             await add_reaction(channel, message_ts, "x", role=role)
@@ -1762,7 +1753,7 @@ async def handle_agent_callback(request: Request) -> dict[str, Any]:
             "Sorry, I ran out of time working on this task. "
             "Please try again or break the request into smaller steps."
         )
-        timeout_text = f"[{display_name}] :hourglass: {timeout_response}"
+        timeout_text = f":hourglass: {timeout_response}"
         await send_slack_message(channel, timeout_text, thread_ts, role=role)
         return {"status": "ok", "job_id": job_id, "outcome": "timeout_posted"}
 
@@ -1771,7 +1762,7 @@ async def handle_agent_callback(request: Request) -> dict[str, Any]:
         if message_ts:
             await add_reaction(channel, message_ts, "x", role=role)
         error_msg = error or "Unknown error"
-        error_text = f"[{display_name}] Sorry, I encountered an error: {error_msg}"
+        error_text = f"Sorry, I encountered an error: {error_msg}"
         await send_slack_message(channel, error_text, thread_ts, role=role)
         return {"status": "ok", "job_id": job_id, "outcome": "error_posted"}
 
@@ -1781,23 +1772,11 @@ async def handle_agent_callback(request: Request) -> dict[str, Any]:
 
     response = response_text or "I completed the task but have no output to share."
 
-    # Build display prefix with model info if available
-    result_metadata = payload.get("metadata", {})
-    model_name = result_metadata.get("model", "")
-    if model_name:
-        agent_prefix = f"[{display_name}:{model_name}]"
-    else:
-        agent_prefix = f"[{display_name}]"
-
     # Split long responses into multiple messages
     chunks = split_long_message(response)
 
-    for i, chunk in enumerate(chunks):
-        if i == 0:
-            formatted_chunk = f"{agent_prefix} {chunk}"
-        else:
-            formatted_chunk = f"{agent_prefix} (cont.) {chunk}"
-        await send_slack_message(channel, formatted_chunk, thread_ts, role=role)
+    for chunk in chunks:
+        await send_slack_message(channel, chunk, thread_ts, role=role)
 
     # Check for handoffs in the response
     message_router = get_message_router()
@@ -1882,7 +1861,6 @@ async def handle_agent_progress(request: Request) -> dict[str, Any]:
     channel = meta.get("channel", "")
     thread_ts = meta.get("thread_ts")
     role = meta.get("role")
-    display_name = meta.get("display_name", meta.get("role", "Agent"))
 
     if not channel or not step_summary:
         return {"status": "ignored", "reason": "missing channel or step_summary"}
@@ -1899,7 +1877,7 @@ async def handle_agent_progress(request: Request) -> dict[str, Any]:
     time_str = f"{mins}m{secs:02d}s" if mins > 0 else f"{secs}s"
 
     # Post progress as a subtle update
-    progress_text = f"_[{display_name}] Step {step_number} ({time_str}): {step_summary}_"
+    progress_text = f"_Step {step_number} ({time_str}): {step_summary}_"
     await send_slack_message(channel, progress_text, thread_ts, role=role)
 
     logger.info(
@@ -2119,23 +2097,18 @@ async def _process_slack_event(payload: dict[str, Any]) -> dict[str, Any]:
             thread_ts = event.get("thread_ts") or message_ts
             bot_id = event.get("bot_id", "")
 
-            # Check if this message was posted by our own bot (self-posted handoff).
-            # Our bot's messages from the callback handler contain a "[RoleName]" prefix.
-            # The callback handler already processes handoffs in the response, so
-            # re-processing here would cause duplicate agent executions.
+            # Check if this message was posted by one of our own Slack apps.
+            # Callback handlers already submit handoffs, so re-processing our own
+            # thread replies here would cause duplicate agent executions.
             is_self_bot_message = False
-            if text:
-                # Our callback handler formats messages as "[DisplayName] ..." or
-                # "[DisplayName:model] ...". If the message starts with this pattern
-                # and is in a thread, it's a response we posted — not a new request.
-                import re as _re
-
-                self_bot_pattern = _re.match(r"^\[[\w:.\-]+\]\s", text)
-                if self_bot_pattern and thread_ts and thread_ts != message_ts:
+            message_user = event.get("user", "")
+            if message_user and thread_ts and thread_ts != message_ts:
+                own_bot_user_ids = await _our_bot_user_ids()
+                if message_user in own_bot_user_ids:
                     is_self_bot_message = True
                     logger.info(
-                        f"Skipping self-posted bot message with role mention "
-                        f"(handoff already handled by callback): {text[:80]}..."
+                        "Skipping self-posted bot message from known VibeTeam bot "
+                        f"user_id={message_user}: {text[:80]}..."
                     )
 
             if is_self_bot_message:


### PR DESCRIPTION
## Summary
- remove legacy `[Role]` / `[Role:model]` prefix formatting from sync + async Slack responses
- remove `[Role]` from progress and timeout/error user-visible messages
- switch self-bot duplicate suppression to bot user-id identity checks instead of text-prefix pattern matching
- update eval parsing to attribute messages by role-app Slack user IDs with legacy prefix fallback
- update callback and slack event tests for prefix-free output

## Issue
- Closes #375

## Testing
- `export $( < ~/.env.d/codex.env ); export $( < .env ); uv run python -m pytest tests/test_async_callback.py tests/test_eval_rescore.py -v`
- `export $( < ~/.env.d/codex.env ); export $( < .env ); uv run python scripts/eval_slack_e2e.py --scenario support_notify_check --channel C0AATPSADB8 --timeout 600`
  - Slack thread: https://slack.com/app_redirect?channel=C0AATPSADB8&thread_ts=1773159457.506149