### PR TITLE
Document Slack app setup and add Slack/GitHub app provisioning skills

### DIFF
--- a/.agents/skills/github-apps/SKILL.md
+++ b/.agents/skills/github-apps/SKILL.md
@@ -1,0 +1,75 @@
+---
+name: github-apps
+description: Create and configure role-scoped GitHub Apps for VibeTeam, map credentials to agents placeholders, and validate installation permissions/identity.
+---
+
+# GitHub Apps Provisioning
+
+Use this skill when you need to create, rotate, or validate GitHub Apps used by VibeTeam agents.
+
+## Inputs
+
+- GitHub org/repo targets (typically `VibeTechnologies`)
+- Roles from `agents/agents.yaml`
+- Org admin permissions to create/install GitHub Apps
+- Optional: `gh` auth for secret uploads
+
+## Required References
+
+1. Read `docs/github.md`.
+2. Read `docs/requirements.md` GitHub env naming.
+3. Read `agents/agents.yaml` credential placeholders (`credentials.github_app.*`).
+
+## Workflow
+
+1. Determine app strategy.
+   - Preferred: one GitHub App per role
+   - Roles: `software_engineer`, `support_engineer`, `release_engineer`, `product_manager`, `marketing_manager`
+2. Create each role app.
+   - Name should map clearly to role handle.
+   - Homepage: `https://github.com/VibeTechnologies/VibeTeam`
+   - Repository permissions:
+     - `Contents: Read and write`
+     - `Issues: Read and write`
+     - `Pull requests: Read and write`
+     - `Discussions: Read and write`
+     - `Metadata: Read`
+   - Enable webhook if webhook signature validation is required.
+3. Generate credentials per role app.
+   - App ID
+   - Installation ID (after org install)
+   - Private key PEM
+   - Webhook secret
+   - Bot username (if used in eval/assignment mapping)
+4. Install each app.
+   - Install to org `VibeTechnologies`.
+   - Grant access to required repos (`VibeTeam`, `VibeWebAgent`, `vibeteam-eval-hello-world` at minimum).
+   - Re-approve app permissions after permission changes.
+5. Map credentials to env keys.
+   - `GITHUB_APP_ID_<ROLE>`
+   - `GITHUB_APP_INSTALLATION_ID_<ROLE>`
+   - `GITHUB_APP_PRIVATE_KEY_<ROLE>`
+   - `GITHUB_WEBHOOK_SECRET_<ROLE>`
+   - `GITHUB_APP_BOT_USERNAME_<ROLE>` (when used)
+6. Populate JSON deploy secret.
+   - Start from `config/secrets/github_app_role_secrets.template.json`.
+   - Fill local temp file with role credentials.
+   - Upload:
+     - `gh secret set GITHUB_APP_ROLE_SECRETS_JSON < /tmp/github_app_role_secrets.json`
+7. Validate permissions and assignment readiness.
+   - `uv run python scripts/check_github_app_permissions.py --repo VibeTechnologies/vibeteam-eval-hello-world --require-discussions --require-assignable-assignee`
+   - Verify assignable bot handles:
+     - `gh api repos/VibeTechnologies/vibeteam-eval-hello-world/assignees --jq '.[].login'`
+8. Validate runtime attribution.
+   - Run at least one GitHub attribution eval scenario after deploy:
+     - `uv run python scripts/eval_slack_e2e.py --scenario software_engineer_pr_attribution --channel C0AATPSADB8 --timeout 600`
+   - Confirm PR author is the intended role app bot.
+
+## Output Checklist
+
+- App IDs and Installation IDs per role
+- Installed repository scope
+- Secret/env mapping confirmation
+- Permission check command outputs
+- URL evidence of bot-attributed PR/comment activity
+

--- a/.agents/skills/slack-app/SKILL.md
+++ b/.agents/skills/slack-app/SKILL.md
@@ -1,0 +1,68 @@
+---
+name: slack-app
+description: Create and configure VibeTeam Slack apps (one ingress app plus role-scoped responder apps), wire role tokens/secrets, and validate routing/identity behavior.
+---
+
+# Slack App Provisioning
+
+Use this skill when you need to create, update, or audit Slack apps for VibeTeam.
+
+## Inputs
+
+- Target environment host (for example `https://webhook.team.vibebrowser.app`)
+- Slack workspace with admin access
+- Roles from `agents/agents.yaml`
+- Optional: `gh` auth for uploading JSON secrets
+
+## Required References
+
+1. Read `docs/slack.md`.
+2. Read `docs/requirements.md` Slack env naming.
+3. Read `agents/agents.yaml` for role handles and credential placeholders.
+
+## Workflow
+
+1. Build the app inventory.
+   - Ingress app: `VibeTeam`
+   - Role apps: `SoftwareEngineer`, `SupportEngineer`, `ReleaseEngineer`, `ProductManager`, `MarketingManager`
+2. Configure ingress app.
+   - Use `templates/slack-app/manifest.yaml`.
+   - Set Event Subscriptions request URL to `<gateway>/slack/events`.
+   - Ensure ingress bot events: `app_mention`, `message.channels`, `message.groups`, `message.im`.
+3. Configure each role app.
+   - App/bot display name must match the role handle.
+   - Keep Event Subscriptions disabled for role apps.
+   - Add required scopes: `chat:write`, `reactions:write`, `channels:history`, `groups:history`, `im:history`, `users:read`.
+   - Add `assistant:write` when role-specific assistant status is required.
+4. Install/Reinstall all apps.
+   - Reinstall after any scope changes.
+5. Invite apps to channels.
+   - `/invite @VibeTeam`
+   - `/invite @SoftwareEngineer @SupportEngineer @ReleaseEngineer @ProductManager @MarketingManager`
+6. Map credentials to env keys.
+   - Ingress fallback:
+     - `SLACK_BOT_TOKEN`, `SLACK_ASSISTANT_TOKEN`, `SLACK_SIGNING_SECRET`
+   - Role-scoped:
+     - `SLACK_BOT_TOKEN_<ROLE>`
+     - `SLACK_ASSISTANT_TOKEN_<ROLE>`
+     - `SLACK_SIGNING_SECRET_<ROLE>`
+   - Shared trigger secret:
+     - `SLACK_TRIGGER_SECRET`
+7. Populate JSON deploy secret.
+   - Start from `config/secrets/slack_role_secrets.template.json`.
+   - Store real values in a local temp file only.
+   - Upload to GitHub Secret:
+     - `gh secret set SLACK_ROLE_SECRETS_JSON < /tmp/slack_role_secrets.json`
+8. Validate behavior.
+   - Confirm each role token resolves to a distinct bot user ID (Slack `auth.test`).
+   - Run a smoke evaluation:
+     - `uv run python scripts/eval_slack_e2e.py --scenario support_notify_check --channel C0AATPSADB8 --timeout 300 --skip-eval`
+   - Verify response identity is by Slack app user and reply text has no legacy `[Role]` prefix.
+
+## Output Checklist
+
+- App IDs for ingress + each role app
+- Bot user IDs for each role token
+- Confirmed env/secret key mapping
+- Slack thread URL for smoke test evidence
+

--- a/docs/slack.md
+++ b/docs/slack.md
@@ -28,67 +28,115 @@ Current deployment policy:
   `SLACK_BOT_TOKEN_<ROLE>` and `SLACK_ASSISTANT_TOKEN_<ROLE>`.
 - If a role-scoped token is missing, gateway falls back to global
   `SLACK_BOT_TOKEN` / `SLACK_ASSISTANT_TOKEN`.
+- Response attribution is by Slack app identity, not text prefixing.
+  Gateway responses should be plain text (no legacy `[Role]` message prefix).
 
-## 1. Create the Slack App
+## 1. App Inventory (Ingress + Role Apps)
 
-1. Go to [api.slack.com/apps](https://api.slack.com/apps) and create a new app
-2. Choose **From a manifest** and paste the contents of [`templates/slack-app/manifest.yaml`](../templates/slack-app/manifest.yaml)
-3. Update the `request_url` values to point to your gateway's public URL
+Create **six** Slack apps total for one workspace:
 
-Alternatively, create the app manually following the sections below.
+| App Type | Slack Display Name | Purpose | Inbound Events |
+|---------|---------------------|---------|----------------|
+| Ingress | `VibeTeam` | Receives Slack events and routes work | **Required** (`/slack/events`) |
+| Role responder | `SoftwareEngineer` | Posts as SWE role identity | Not required |
+| Role responder | `SupportEngineer` | Posts as Support role identity | Not required |
+| Role responder | `ReleaseEngineer` | Posts as Release role identity | Not required |
+| Role responder | `ProductManager` | Posts as PM role identity | Not required |
+| Role responder | `MarketingManager` | Posts as Marketing role identity | Not required |
 
-If the app already exists, open the app directly:
+Use the same role handles as `agents/agents.yaml` (`slack_handle`) so mention parsing and identity mapping stay consistent.
+
+## 2. Create and Configure the Apps
+
+### 2.1 Create the ingress app (`VibeTeam`)
+
+1. Go to [api.slack.com/apps](https://api.slack.com/apps).
+2. Create app **From a manifest**.
+3. Use [`templates/slack-app/manifest.yaml`](../templates/slack-app/manifest.yaml).
+4. Set request URLs to your gateway host (typically `https://webhook.team.vibebrowser.app`).
+5. Install/Reinstall the app to workspace after any scope/event change.
+
+If already created, open directly:
 
 ```
 https://api.slack.com/apps/A0AAZGWEAVA
 ```
 
-## 2. OAuth Scopes
+### 2.2 Create the five role responder apps
 
-Under **OAuth & Permissions**, add these **Bot Token Scopes**:
+For each role app (`SoftwareEngineer`, `SupportEngineer`, `ReleaseEngineer`, `ProductManager`, `MarketingManager`):
+
+1. Create app **From scratch**.
+2. App name and bot display name: exactly the role handle (for example `SupportEngineer`).
+3. Add OAuth bot scopes from the responder scope set in section 3.
+4. Keep **Event Subscriptions disabled** (responder apps do not receive inbound webhooks).
+5. Install app to workspace and copy:
+   - bot token (`xoxb-...`)
+   - assistant token (`xapp-...`) if `assistant:write` is enabled
+   - signing secret (only needed if you choose to validate with role-specific secrets)
+6. Invite each role app to channels where it should post responses.
+
+## 3. OAuth Scopes
+
+### 3.1 Ingress app (`VibeTeam`) scopes
+
+Under **OAuth & Permissions**, configure these **Bot Token Scopes**:
 
 | Scope | Required For |
 |-------|-------------|
-| `assistant:write` | Showing assistant thread status (typing indicator) |
+| `assistant:write` | Assistant thread status (typing indicator) |
 | `app_mentions:read` | Receiving `@VibeTeam` mentions |
-| `channels:history` | Reading messages in public channels (needed for `message.channels` event + `conversations.replies` API for thread participation check) |
-| `channels:read` | Listing public channels |
-| `chat:write` | Posting agent responses |
-| `groups:history` | Reading messages in private channels (needed for `message.groups` event) |
-| `groups:read` | Listing private channels |
+| `channels:history` | Thread follow-up handling in public channels |
+| `channels:read` | Listing/reading public channel metadata |
+| `chat:write` | Posting responses |
+| `groups:history` | Thread follow-up handling in private channels |
+| `groups:read` | Listing/reading private channel metadata |
 | `im:history` | Reading direct messages |
 | `im:read` | Listing DM conversations |
-| `im:write` | Sending DMs to users |
-| `users:read` | Resolving user IDs to display names |
+| `im:write` | Sending DMs |
+| `reactions:write` | Adding/removing `:eyes:` and `:thinking_face:` reactions |
+| `users:read` | Resolving user IDs/mentions |
 
-After adding scopes, install or reinstall the app to the workspace to generate the bot token.
+### 3.2 Role responder app scopes
 
-Quick path to the scopes page:
+Use this responder scope baseline:
 
-```
-https://api.slack.com/apps/A0AAZGWEAVA/oauth
-```
+| Scope | Why |
+|-------|-----|
+| `assistant:write` | Optional per-role assistant status |
+| `chat:write` | Posting role-attributed responses |
+| `reactions:write` | Role-attributed reaction lifecycle |
+| `channels:history` | Thread participation and replies |
+| `groups:history` | Thread participation in private channels |
+| `im:history` | DM thread participation checks |
+| `users:read` | Mention/user mapping support |
 
-If `assistant:write` does not appear, enable **Agents & AI Apps** for the app and refresh the scopes list, then reinstall the app.
+`channels:read`, `groups:read`, `im:read`, and `im:write` are optional unless you need role apps to perform those operations directly.
 
-## 3. Event Subscriptions
+After scope updates, always **Reinstall to Workspace** so tokens include new permissions.
+If `assistant:write` is missing, enable **Agents & AI Apps**, refresh, then reinstall.
 
-Under **Event Subscriptions**, enable events and set the request URL to:
+## 4. Event Subscriptions
+
+Configure inbound events on the **ingress app only**:
+
+1. Enable Event Subscriptions.
+2. Request URL:
 
 ```
 https://<your-gateway-host>/slack/events
 ```
 
-Slack will send a verification challenge to this URL. The gateway responds to it automatically.
+Slack will send a verification challenge to this URL. The gateway responds automatically.
 
-Subscribe to these **bot events**:
+Subscribe to these ingress bot events:
 
 | Event | Purpose |
 |-------|---------|
-| `app_mention` | Triggers when a user mentions `@VibeTeam` in a channel. This is the primary entry point for agent interactions. |
-| `message.channels` | Delivers all messages in public channels the bot is in. Required for thread follow-ups -- without this, the gateway cannot receive thread replies that don't explicitly `@VibeTeam`. |
-| `message.groups` | Same as above but for private channels. |
-| `message.im` | Delivers direct messages to the bot. |
+| `app_mention` | Primary entry point (`@VibeTeam ...`) |
+| `message.channels` | Thread follow-ups in public channels |
+| `message.groups` | Thread follow-ups in private channels |
+| `message.im` | Direct messages to ingress app |
 
 ### Why `message.channels` is required
 
@@ -98,7 +146,7 @@ For follow-up messages like `@SupportEngineer what did you find?`, the user does
 
 With `message.channels` enabled, the gateway receives all channel messages and uses the thread participation handler to detect whether the bot previously replied in the thread. If it did, the message is routed to the appropriate agent.
 
-## 4. Interactivity (Optional)
+## 5. Interactivity (Optional)
 
 If you want interactive components (buttons, modals), enable interactivity and set the request URL to:
 
@@ -106,7 +154,7 @@ If you want interactive components (buttons, modals), enable interactivity and s
 https://<your-gateway-host>/slack/interactive
 ```
 
-## 5. Environment Variables
+## 6. Environment Variables
 
 The gateway requires these environment variables for Slack integration:
 
@@ -163,7 +211,7 @@ cp config/secrets/slack_role_secrets.template.json /tmp/slack_role_secrets.json
 gh secret set SLACK_ROLE_SECRETS_JSON < /tmp/slack_role_secrets.json
 ```
 
-## 6. Invite the Bot
+## 7. Invite the Bot
 
 After installing the apps, invite the ingress bot and all responder bots to channels
 where they should post:

--- a/templates/slack-app/manifest.yaml
+++ b/templates/slack-app/manifest.yaml
@@ -29,6 +29,7 @@ oauth_config:
       - im:history
       - im:read
       - im:write
+      - reactions:write
       - users:read
 
 settings:


### PR DESCRIPTION
## Summary
- expanded `docs/slack.md` with a concrete six-app provisioning runbook (ingress + 5 role apps)
- added explicit scope guidance for ingress vs responder apps and documented identity-based attribution (no legacy `[Role]` prefixes)
- added reusable skill `.agents/skills/slack-app/SKILL.md` for creating/configuring Slack apps and secrets mapping
- added reusable skill `.agents/skills/github-apps/SKILL.md` for creating/configuring GitHub Apps and role-secret mapping
- updated `templates/slack-app/manifest.yaml` to include `reactions:write` scope to match gateway reaction behavior and docs

## Issue
Closes #377

## Validation
- `export $( < ~/.env.d/codex.env ); export $( < .env ); uv run python -m pytest tests/test_secret_payloads.py -v`
- Result: `6 passed`