### PR TITLE
Fix k3s Slack eval by seeding kubeconfig in /slack/trigger

### DIFF
--- a/docs/testing.md
+++ b/docs/testing.md
@@ -170,6 +170,10 @@ Slack scenarios are defined in `scripts/eval_slack_e2e.py` (`SCENARIOS`).
 | `release_health_check` | `release_engineer` | Perform production health/readiness checks with evidence-based conclusion. |
 | `release_k3s_configure_then_health` | `release_engineer` | Two-step flow: configure k3s access context first, then investigate `vibe` cluster health in the same thread. |
 
+Implementation note for trigger-driven evals:
+- `release_k3s_configure_then_health` runs through `/slack/trigger` and seeds a validated kubeconfig context via trigger payload (`kubeconfig_yaml`) so the agent receives thread-scoped cluster context without relying on bot-generated Slack file events.
+- Real user flow remains Slack attachment-based (`/slack/events` with uploaded kubeconfig file), as documented in `docs/slack.md`.
+
 Collaboration identity requirement (hard check for `github_issue_pr_handoff_slack`):
 - Required Slack roles must respond (`software_engineer`, `support_engineer`).
 - Each required role must post using its own role-scoped Slack app identity.

--- a/docs/webhook-routing.md
+++ b/docs/webhook-routing.md
@@ -9,7 +9,7 @@ This guide summarizes how external events reach agents. For the canonical routin
 | `/webhook` | GitHub | Issues and PR comments route to SoftwareEngineer by default; role mentions trigger handoffs. |
 | `/webhook/sentry` | Sentry | Routes to SupportEngineer (handoff as needed). |
 | `/slack/events` | Slack | `@VibeTeam` activates a thread; thread replies are auto-routed. See [slack.md](slack.md). |
-| `/slack/trigger` | Slack (eval/tests) | Requires `Authorization: Bearer $SLACK_TRIGGER_SECRET`. |
+| `/slack/trigger` | Slack (eval/tests) | Requires `Authorization: Bearer $SLACK_TRIGGER_SECRET`; supports optional `kubeconfig_yaml` + `kubeconfig_file_name` to seed thread-scoped cluster context for trigger-driven evals. |
 
 ## Routing Rules (Short)
 

--- a/scripts/eval_slack_e2e.py
+++ b/scripts/eval_slack_e2e.py
@@ -81,6 +81,27 @@ except ImportError:
 # Test Scenarios
 # ==============================================================================
 
+_EVAL_MINIMAL_KUBECONFIG = """\
+apiVersion: v1
+kind: Config
+clusters:
+  - name: eval-k3s
+    cluster:
+      server: https://127.0.0.1:6443
+      insecure-skip-tls-verify: true
+contexts:
+  - name: eval-k3s-context
+    context:
+      cluster: eval-k3s
+      user: eval-user
+current-context: eval-k3s-context
+users:
+  - name: eval-user
+    user:
+      token: eval-token
+"""
+
+
 SCENARIOS = {
     "support_400_errors": {
         "name": "Support Engineer - API 400 Errors Investigation",
@@ -1421,9 +1442,15 @@ SCENARIOS = {
             "@ReleaseEngineer configure k3s cluster access from the kubeconfig I attached and "
             "confirm you can use it for this thread."
         ),
+        # For trigger-based evals we inject kubeconfig context directly in the
+        # initial /slack/trigger payload to emulate an attached kubeconfig.
+        "trigger_kubeconfig_yaml": _EVAL_MINIMAL_KUBECONFIG,
+        "trigger_kubeconfig_file_name": "eval-k3s-kubeconfig.yaml",
         "follow_up_messages": [
             "@ReleaseEngineer now investigate vibe cluster health and provide a concise status summary."
         ],
+        # Avoid posting eval-owned follow-up text as a bot message in-thread.
+        "post_follow_up_messages": False,
         "follow_up_delay_seconds": 8,
         "expected_agent": "release_engineer",
         "evaluation_criteria": {
@@ -2723,6 +2750,15 @@ async def run_evaluation(
                         trigger_payload["framework"] = framework
                     if use_async:
                         trigger_payload["use_async"] = True
+                    if (
+                        step_name == "Initial message"
+                        and isinstance(scenario.get("trigger_kubeconfig_yaml"), str)
+                        and scenario.get("trigger_kubeconfig_yaml", "").strip()
+                    ):
+                        trigger_payload["kubeconfig_yaml"] = scenario["trigger_kubeconfig_yaml"]
+                        trigger_payload["kubeconfig_file_name"] = str(
+                            scenario.get("trigger_kubeconfig_file_name", "uploaded-kubeconfig.yaml")
+                        )
 
                     response = await client.post(
                         trigger_url,
@@ -2755,19 +2791,23 @@ async def run_evaluation(
         await _trigger_gateway_message(user_message, "Initial message")
 
         follow_up_messages = scenario.get("follow_up_messages", [])
+        post_follow_up_messages = bool(scenario.get("post_follow_up_messages", True))
         follow_up_delay_seconds = int(scenario.get("follow_up_delay_seconds", 8))
         if follow_up_messages:
             for idx, follow_up in enumerate(follow_up_messages, start=1):
-                print(f"\n>>> Step 1c.{idx}: Posting follow-up message")
-                follow_up_posted = ROLE_PATTERN.sub("", follow_up).strip()
-                if not follow_up_posted:
-                    follow_up_posted = f"Evaluation follow-up #{idx}"
-                await _slack_call(
-                    slack.post_message,
-                    channel=channel,
-                    text=follow_up_posted,
-                    thread_ts=thread_ts,
-                )
+                if post_follow_up_messages:
+                    print(f"\n>>> Step 1c.{idx}: Posting follow-up message")
+                    follow_up_posted = ROLE_PATTERN.sub("", follow_up).strip()
+                    if not follow_up_posted:
+                        follow_up_posted = f"Evaluation follow-up #{idx}"
+                    await _slack_call(
+                        slack.post_message,
+                        channel=channel,
+                        text=follow_up_posted,
+                        thread_ts=thread_ts,
+                    )
+                else:
+                    print(f"\n>>> Step 1c.{idx}: Skipping follow-up post (trigger-only mode)")
                 if follow_up_delay_seconds > 0:
                     await asyncio.sleep(follow_up_delay_seconds)
 

--- a/tests/test_eval_rescore.py
+++ b/tests/test_eval_rescore.py
@@ -575,6 +575,66 @@ class TestScenarios:
         expected_roles = {"user", *{entry.role for entry in list_agents()}}
         assert set(ROLE_DISPLAY.keys()) == expected_roles
 
+    def test_release_k3s_scenario_has_inline_kubeconfig_context(self):
+        """release_k3s scenario should provide trigger kubeconfig context for eval flow."""
+        scenario = SCENARIOS["release_k3s_configure_then_health"]
+        assert isinstance(scenario.get("trigger_kubeconfig_yaml"), str)
+        assert scenario["trigger_kubeconfig_yaml"].strip()
+        assert scenario.get("trigger_kubeconfig_file_name") == "eval-k3s-kubeconfig.yaml"
+        assert scenario.get("post_follow_up_messages") is False
+
+    @pytest.mark.asyncio
+    async def test_release_k3s_trigger_payload_and_followup_posting(self, monkeypatch):
+        """Initial trigger should include kubeconfig; follow-up trigger should not."""
+        monkeypatch.setenv("SLACK_BOT_TOKEN", "xoxb-test-token")
+        monkeypatch.setenv("SLACK_TRIGGER_SECRET", "test-secret")
+
+        mock_slack = MagicMock()
+        mock_slack.post_message.return_value = make_slack_message(
+            ts="100.000", text="configure k3s", is_bot=False
+        )
+        mock_slack.get_thread_replies.return_value = [
+            make_slack_message(
+                ts="100.000",
+                text="configure k3s",
+                is_bot=False,
+                thread_ts="100.000",
+                channel="C_TEST",
+            )
+        ]
+
+        with (
+            patch("scripts.eval_slack_e2e.SlackConnector", return_value=mock_slack),
+            patch("scripts.eval_slack_e2e.httpx.AsyncClient") as mock_httpx_cls,
+            patch("scripts.eval_slack_e2e.asyncio.sleep", new_callable=AsyncMock),
+        ):
+            mock_client = AsyncMock()
+            mock_response = MagicMock()
+            mock_response.status_code = 200
+            mock_response.json.return_value = {"roles": ["release_engineer"], "mode": "sync"}
+            mock_client.post.return_value = mock_response
+            mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+            mock_client.__aexit__ = AsyncMock(return_value=None)
+            mock_httpx_cls.return_value = mock_client
+
+            await run_evaluation(
+                scenario_name="release_k3s_configure_then_health",
+                channel="C_TEST",
+                wait_timeout=0,
+                poll_interval=1,
+                skip_eval=True,
+            )
+
+        # Initial user message only; follow-up should be trigger-only for this scenario.
+        mock_slack.post_message.assert_called_once()
+        assert mock_client.post.call_count == 2
+
+        initial_trigger_payload = mock_client.post.call_args_list[0].kwargs["json"]
+        follow_up_trigger_payload = mock_client.post.call_args_list[1].kwargs["json"]
+        assert "kubeconfig_yaml" in initial_trigger_payload
+        assert initial_trigger_payload["kubeconfig_file_name"] == "eval-k3s-kubeconfig.yaml"
+        assert "kubeconfig_yaml" not in follow_up_trigger_payload
+
 
 class TestPerScenarioTimeout:
     """Tests for per-scenario timeout override functionality."""

--- a/tests/test_gateway_trigger.py
+++ b/tests/test_gateway_trigger.py
@@ -43,6 +43,26 @@ VALID_PAYLOAD = {
 
 AUTH_HEADERS = {"Authorization": "Bearer test-secret"}
 
+VALID_KUBECONFIG = """\
+apiVersion: v1
+kind: Config
+clusters:
+  - name: eval
+    cluster:
+      server: https://127.0.0.1:6443
+      insecure-skip-tls-verify: true
+contexts:
+  - name: eval-context
+    context:
+      cluster: eval
+      user: eval-user
+current-context: eval-context
+users:
+  - name: eval-user
+    user:
+      token: eval-token
+"""
+
 
 class TestTriggerAuth:
     """Test /slack/trigger authentication."""
@@ -178,6 +198,50 @@ class TestTriggerValidation:
         roles = response.json()["roles"]
         assert "support_engineer" in roles
         assert "release_engineer" in roles
+
+    def test_inline_kubeconfig_requires_thread_ts(self, client: TestClient):
+        """Inline kubeconfig payload requires thread_ts for thread-scoped storage."""
+        payload = {
+            "channel": "C0AATPSADB8",
+            "text": "@ReleaseEngineer configure cluster access",
+            "kubeconfig_yaml": VALID_KUBECONFIG,
+        }
+        with patch("vibeteam.gateway.routes.slack.config") as mock_config:
+            mock_config.SLACK_TRIGGER_SECRET = "test-secret"
+            response = client.post("/slack/trigger", json=payload, headers=AUTH_HEADERS)
+        assert response.status_code == 400
+        assert "thread_ts is required" in response.json()["detail"]
+
+    def test_inline_kubeconfig_rejects_invalid_yaml(self, client: TestClient):
+        """Inline kubeconfig payload must be valid kubeconfig YAML."""
+        payload = {
+            "channel": "C0AATPSADB8",
+            "thread_ts": "1234567890.123456",
+            "text": "@ReleaseEngineer configure cluster access",
+            "kubeconfig_yaml": "not-a-kubeconfig",
+        }
+        with patch("vibeteam.gateway.routes.slack.config") as mock_config:
+            mock_config.SLACK_TRIGGER_SECRET = "test-secret"
+            response = client.post("/slack/trigger", json=payload, headers=AUTH_HEADERS)
+        assert response.status_code == 400
+        assert "invalid kubeconfig_yaml" in response.json()["detail"]
+
+    def test_inline_kubeconfig_sets_thread_context(self, client: TestClient):
+        """Valid inline kubeconfig payload stores trigger thread context."""
+        payload = {
+            "channel": "C0AATPSADB8",
+            "thread_ts": "1234567890.123456",
+            "text": "@ReleaseEngineer configure cluster access",
+            "kubeconfig_yaml": VALID_KUBECONFIG,
+            "kubeconfig_file_name": "eval-kubeconfig.yaml",
+        }
+        with patch("vibeteam.gateway.routes.slack.config") as mock_config:
+            mock_config.SLACK_TRIGGER_SECRET = "test-secret"
+            mock_config.SLACK_BOT_TOKEN = "xoxb-test"
+            response = client.post("/slack/trigger", json=payload, headers=AUTH_HEADERS)
+        assert response.status_code == 200
+        data = response.json()
+        assert data["kubeconfig_context_stored"] is True
 
 
 class TestTriggerRateLimit:

--- a/vibeteam/gateway/routes/slack.py
+++ b/vibeteam/gateway/routes/slack.py
@@ -2586,7 +2586,9 @@ async def trigger_agent_for_slack(
         "text": "@SupportEngineer please investigate the issue",
         "user_id": "eval_script",
         "framework": "openclaw",
-        "use_async": false
+        "use_async": false,
+        "kubeconfig_yaml": "apiVersion: v1 ...",
+        "kubeconfig_file_name": "uploaded-kubeconfig.yaml"
     }
 
     Fields:
@@ -2599,6 +2601,10 @@ async def trigger_agent_for_slack(
       (POST /run/async → agent processes → POST /callback/agent) instead of the
       synchronous path. Useful for testing the full async lifecycle including
       CALLBACK_SECRET verification.
+    - kubeconfig_yaml (optional): Inline kubeconfig YAML used to seed
+      thread-scoped kubeconfig context for this trigger.
+    - kubeconfig_file_name (optional): Source filename label for the inline
+      kubeconfig context (default: "uploaded-kubeconfig.yaml").
     """
     # Rate limiting
     if not _trigger_rate_limiter.allow():
@@ -2632,11 +2638,29 @@ async def trigger_agent_for_slack(
     user_id = body.get("user_id", "trigger_api")
     use_async = body.get("use_async", False)
     framework = body.get("framework")
+    kubeconfig_yaml = body.get("kubeconfig_yaml")
+    kubeconfig_file_name = str(body.get("kubeconfig_file_name", "uploaded-kubeconfig.yaml"))
 
     if not channel:
         raise HTTPException(status_code=400, detail="channel is required")
     if not text:
         raise HTTPException(status_code=400, detail="text is required")
+
+    kubeconfig_context_stored = False
+    if isinstance(kubeconfig_yaml, str) and kubeconfig_yaml.strip():
+        if not thread_ts:
+            raise HTTPException(
+                status_code=400,
+                detail="thread_ts is required when kubeconfig_yaml is provided",
+            )
+        try:
+            kube_context = _validate_and_normalize_kubeconfig(kubeconfig_yaml)
+        except ValueError as exc:
+            raise HTTPException(status_code=400, detail=f"invalid kubeconfig_yaml: {exc}") from exc
+        kube_context["file_name"] = kubeconfig_file_name
+        kube_context["source"] = "slack_trigger"
+        _store_thread_kubeconfig_context(channel, thread_ts, kube_context)
+        kubeconfig_context_stored = True
 
     # Check for role mentions
     message_router = get_message_router()
@@ -2671,4 +2695,5 @@ async def trigger_agent_for_slack(
         "thread_ts": thread_ts,
         "roles": role_mentions,
         "mode": mode,
+        "kubeconfig_context_stored": kubeconfig_context_stored,
     }


### PR DESCRIPTION
Closes #381

## Summary
- add optional `kubeconfig_yaml` + `kubeconfig_file_name` support to `/slack/trigger`
- validate and store thread-scoped kubeconfig context before routing
- update `release_k3s_configure_then_health` eval scenario to inject minimal kubeconfig via trigger payload
- switch scenario follow-up to trigger-only mode (no eval bot follow-up message posted to thread)
- add unit tests for trigger kubeconfig validation/storage and eval trigger payload behavior
- document trigger-eval kubeconfig context behavior in testing/routing docs

## Why
Trigger-based evals bypass normal Slack event attachment payloads, so the k3s scenario previously claimed an attachment but never actually supplied kubeconfig context.

## Validation
- `uv run python -m pytest tests/test_gateway_trigger.py tests/test_eval_rescore.py -q`