### PR TITLE
Inject stored kubeconfig context in /slack/trigger routing

### DIFF
--- a/tests/test_gateway_trigger.py
+++ b/tests/test_gateway_trigger.py
@@ -243,6 +243,28 @@ class TestTriggerValidation:
         data = response.json()
         assert data["kubeconfig_context_stored"] is True
 
+    def test_inline_kubeconfig_is_injected_into_trigger_text(
+        self, client: TestClient, _patch_run_agent
+    ):
+        """Trigger path should inject stored kubeconfig context into routed text."""
+        payload = {
+            "channel": "C0AATPSADB8",
+            "thread_ts": "1234567890.123456",
+            "text": "@ReleaseEngineer investigate vibe cluster health",
+            "kubeconfig_yaml": VALID_KUBECONFIG,
+            "kubeconfig_file_name": "eval-kubeconfig.yaml",
+        }
+        with patch("vibeteam.gateway.routes.slack.config") as mock_config:
+            mock_config.SLACK_TRIGGER_SECRET = "test-secret"
+            mock_config.SLACK_BOT_TOKEN = "xoxb-test"
+            response = client.post("/slack/trigger", json=payload, headers=AUTH_HEADERS)
+
+        assert response.status_code == 200
+        _patch_run_agent.assert_called_once()
+        routed_text = _patch_run_agent.call_args.args[0]
+        assert "Attached Kubeconfig Context" in routed_text
+        assert "eval-kubeconfig.yaml" in routed_text
+
 
 class TestTriggerRateLimit:
     """Test /slack/trigger rate limiting."""

--- a/vibeteam/gateway/routes/slack.py
+++ b/vibeteam/gateway/routes/slack.py
@@ -2672,6 +2672,10 @@ async def trigger_agent_for_slack(
             detail="text must contain @RoleName mention (e.g., @SupportEngineer)",
         )
 
+    routed_text = _inject_thread_kubeconfig_context(text, channel, thread_ts)
+    if not routed_text:
+        raise HTTPException(status_code=400, detail="text is required")
+
     mode = "async" if use_async else "sync"
     logger.info(f"Trigger API: routing to {role_mentions} in {channel} (mode={mode})")
 
@@ -2680,7 +2684,7 @@ async def trigger_agent_for_slack(
     # use_async=False (default) uses the synchronous path
     asyncio.create_task(
         run_agent_for_slack(
-            text,
+            routed_text,
             channel,
             thread_ts,
             user_id,


### PR DESCRIPTION
Closes #383

## Summary
- apply `_inject_thread_kubeconfig_context(...)` in `/slack/trigger` before invoking `run_agent_for_slack`
- keep validation error when trigger text is empty after processing
- add test asserting inline trigger kubeconfig is actually injected into routed text

## Validation
- `uv run python -m pytest tests/test_gateway_trigger.py tests/test_eval_rescore.py -q`