### PR TITLE
Fix Slack eval outages in #vibe-team and add role-token send fallback

### DIFF
--- a/.agents/skills/github-apps/SKILL.md
+++ b/.agents/skills/github-apps/SKILL.md
@@ -62,7 +62,7 @@ Use this skill when you need to create, rotate, or validate GitHub Apps used by 
      - `gh api repos/VibeTechnologies/vibeteam-eval-hello-world/assignees --jq '.[].login'`
 8. Validate runtime attribution.
    - Run at least one GitHub attribution eval scenario after deploy:
-     - `uv run python scripts/eval_slack_e2e.py --scenario software_engineer_pr_attribution --channel C0AATPSADB8 --timeout 600`
+     - `uv run python scripts/eval_slack_e2e.py --scenario software_engineer_pr_attribution --channel C0ALG01DLJV --timeout 600`
    - Confirm PR author is the intended role app bot.
 
 ## Output Checklist

--- a/.agents/skills/github-handoff-evals/SKILL.md
+++ b/.agents/skills/github-handoff-evals/SKILL.md
@@ -17,8 +17,8 @@ description: Run VibeTeam GitHub/Slack handoff validation with unit tests, Slack
 4. Run unit tests with rerunfailures disabled:
    - `.venv/bin/python -m pytest tests/ -v -p no:rerunfailures`
 5. Run at least one Slack eval:
-   - Preferred: `.venv/bin/python scripts/eval_slack_e2e.py --scenario github_issue_pr_handoff_slack --channel C0AATPSADB8 --timeout 600`
-   - Fallback: `.venv/bin/python scripts/eval_slack_e2e.py --scenario support_400_errors --channel C0AATPSADB8 --timeout 600`
+   - Preferred: `.venv/bin/python scripts/eval_slack_e2e.py --scenario github_issue_pr_handoff_slack --channel C0ALG01DLJV --timeout 600`
+   - Fallback: `.venv/bin/python scripts/eval_slack_e2e.py --scenario support_400_errors --channel C0ALG01DLJV --timeout 600`
 6. Run GitHub webhook evals (assignment-first, role-bot required):
    - Code-writing task (SoftwareEngineer bot assignee):
      - `.venv/bin/python scripts/eval_github_e2e.py --scenario github_issue_handoff --repo VibeTechnologies/vibeteam-eval-hello-world --actor-login OpenCodeEngineer --issue-role software_engineer --issue-assignee 'vibeteam-swe-bot-260301[bot]' --timeout 600`

--- a/.agents/skills/slack-app/SKILL.md
+++ b/.agents/skills/slack-app/SKILL.md
@@ -56,7 +56,7 @@ Use this skill when you need to create, update, or audit Slack apps for VibeTeam
 8. Validate behavior.
    - Confirm each role token resolves to a distinct bot user ID (Slack `auth.test`).
    - Run a smoke evaluation:
-     - `uv run python scripts/eval_slack_e2e.py --scenario support_notify_check --channel C0AATPSADB8 --timeout 300 --skip-eval`
+     - `uv run python scripts/eval_slack_e2e.py --scenario support_notify_check --channel C0ALG01DLJV --timeout 300 --skip-eval`
    - Verify response identity is by Slack app user and reply text has no legacy `[Role]` prefix.
 
 ## Output Checklist

--- a/.agents/skills/task-completition-evaluation/SKILL.md
+++ b/.agents/skills/task-completition-evaluation/SKILL.md
@@ -70,7 +70,7 @@ export $( < .env )
 uv run python -m pytest tests/ -v
 
 # Example Slack eval
-uv run python scripts/eval_slack_e2e.py --scenario github_issue_pr_handoff_slack --channel C0AATPSADB8 --timeout 600
+uv run python scripts/eval_slack_e2e.py --scenario github_issue_pr_handoff_slack --channel C0ALG01DLJV --timeout 600
 
 # Example GitHub eval
 uv run python scripts/eval_github_e2e.py --scenario github_issue_pr_handoff_github --repo VibeTechnologies/vibeteam-eval-hello-world --pr 1 --actor-login OpenCodeEngineer --issue-role software_engineer --issue-assignee 'vibeteam-swe-bot-260301[bot]' --timeout 600

--- a/AGENTS.md
+++ b/AGENTS.md
@@ -32,7 +32,7 @@ Recommended order:
 
 
 ```shell
-export $( < .env); uv run python scripts/eval_slack_e2e.py --scenario support_400_errors --channel C0AATPSADB8 --timeout 600
+export $( < .env); uv run python scripts/eval_slack_e2e.py --scenario support_400_errors --channel C0ALG01DLJV --timeout 600
 ```
 
 to run an evaluation test.
@@ -95,8 +95,8 @@ Report action taken
 ### Running Evaluations
 
 ```bash
-uv run python scripts/eval_slack_e2e.py --scenario support_400_errors --channel C0AATPSADB8 --timeout 600
-uv run python scripts/eval_slack_e2e.py --scenario software_engineer_pr_attribution --channel C0AATPSADB8 --timeout 600
+uv run python scripts/eval_slack_e2e.py --scenario support_400_errors --channel C0ALG01DLJV --timeout 600
+uv run python scripts/eval_slack_e2e.py --scenario software_engineer_pr_attribution --channel C0ALG01DLJV --timeout 600
 uv run python scripts/eval_slack_e2e.py --list-scenarios
 ```
 

--- a/agents/shared/AGENTS.md
+++ b/agents/shared/AGENTS.md
@@ -195,7 +195,7 @@ Does this need public communication?
 
 1. **Always run evaluation** to verify the fix works:
    ```bash
-   uv run python scripts/eval_slack_e2e.py --scenario <scenario> --channel C0AATPSADB8
+   uv run python scripts/eval_slack_e2e.py --scenario <scenario> --channel C0ALG01DLJV
    ```
 
 2. **Check the evaluation report** for:

--- a/docs/OpenClawEval.md
+++ b/docs/OpenClawEval.md
@@ -10,7 +10,7 @@ export AZURE_API_KEY="$(KUBECONFIG=~/.kube/aks-1 kubectl get secret vibeteam-sec
 export AZURE_API_BASE="$(KUBECONFIG=~/.kube/aks-1 kubectl get secret vibeteam-secrets -n vibeteam -o jsonpath='{.data.AZURE_API_BASE}' | base64 -d)"
 export AZURE_API_VERSION="$(KUBECONFIG=~/.kube/aks-1 kubectl get secret vibeteam-secrets -n vibeteam -o jsonpath='{.data.AZURE_API_VERSION}' | base64 -d)"
 export AZURE_EVAL_API_VERSION="$AZURE_API_VERSION"
-export SLACK_DEFAULT_CHANNEL="C0AATPSADB8"
+export SLACK_DEFAULT_CHANNEL="C0ALG01DLJV"
 ```
 
 ## Port-forward gateway
@@ -23,7 +23,7 @@ KUBECONFIG=~/.kube/aks-1 kubectl port-forward -n vibeteam svc/vibeteam-gateway 1
 PYTHONUNBUFFERED=1 GATEWAY_URL=http://127.0.0.1:18080 \
   uv run python scripts/eval_slack_e2e.py \
   --scenario support_400_errors \
-  --channel C0AATPSADB8 \
+  --channel C0ALG01DLJV \
   --framework openclaw \
   --timeout 1200
 ```

--- a/docs/agent_evaluation_workflow.md
+++ b/docs/agent_evaluation_workflow.md
@@ -19,6 +19,6 @@ This is a short overview of the evaluation loop. The canonical architecture and 
 ## Run a Scenario
 
 ```bash
-uv run python scripts/eval_slack_e2e.py --scenario support_400_errors --channel C0AATPSADB8 --timeout 600
-uv run python scripts/eval_slack_e2e.py --scenario software_engineer_pr_attribution --channel C0AATPSADB8 --timeout 600
+uv run python scripts/eval_slack_e2e.py --scenario support_400_errors --channel C0ALG01DLJV --timeout 600
+uv run python scripts/eval_slack_e2e.py --scenario software_engineer_pr_attribution --channel C0ALG01DLJV --timeout 600
 ```

--- a/docs/eval-architecture.md
+++ b/docs/eval-architecture.md
@@ -22,7 +22,7 @@
     ┌─────────────────────────────────────────────────────────────────────┐
     │                         SLACK WORKSPACE                              │
     │  ┌─────────────────────────────────────────────────────────────┐    │
-    │  │  #all-vibetechnologies (C0AATPSADB8)                         │    │
+    │  │  #vibe-team (C0ALG01DLJV)                         │    │
     │  │                                                              │    │
     │  │  [User] @SupportEngineer there is a request from a user...  │    │
     │  │  ├── [SupportEngineer] I'll investigate the 400 errors...   │    │
@@ -217,7 +217,7 @@ kubectl port-forward svc/vibeteam-gateway 8000:8080 -n vibeteam &
 # 2. Run evaluation
 uv run python scripts/eval_slack_e2e.py \
     --scenario support_400_errors \
-    --channel C0AATPSADB8 \
+    --channel C0ALG01DLJV \
     --timeout 180
 
 # 3. Check results

--- a/docs/k8s.md
+++ b/docs/k8s.md
@@ -88,7 +88,7 @@ Run eval:
 ```bash
 export $( < ~/.env.d/codex.env )
 export $( < .env )
-.venv/bin/python scripts/eval_slack_e2e.py --scenario support_400_errors --channel C0AATPSADB8 --timeout 600
+.venv/bin/python scripts/eval_slack_e2e.py --scenario support_400_errors --channel C0ALG01DLJV --timeout 600
 ```
 
 Resume rollouts after eval:
@@ -103,7 +103,7 @@ KUBECONFIG=~/.kube/aks-1 kubectl rollout resume deployment/openhands-svc -n vibe
 ```bash
 export $( < ~/.env.d/codex.env )
 export $( < .env )
-.venv/bin/python scripts/eval_slack_e2e.py --scenario openclaw_chrome_cdp_smoke --channel C0AATPSADB8 --timeout 600
+.venv/bin/python scripts/eval_slack_e2e.py --scenario openclaw_chrome_cdp_smoke --channel C0ALG01DLJV --timeout 600
 ```
 
 ## Operational Checks

--- a/docs/testing.md
+++ b/docs/testing.md
@@ -59,8 +59,8 @@ uv run python -m pytest tests/test_openhands_service_integration.py -v --run-int
 uv run python scripts/eval_slack_e2e.py --list-scenarios
 
 # Slack eval examples
-uv run python scripts/eval_slack_e2e.py --scenario support_400_errors --channel C0AATPSADB8 --timeout 600
-uv run python scripts/eval_slack_e2e.py --scenario github_issue_pr_handoff_slack --channel C0AATPSADB8 --timeout 600
+uv run python scripts/eval_slack_e2e.py --scenario support_400_errors --channel C0ALG01DLJV --timeout 600
+uv run python scripts/eval_slack_e2e.py --scenario github_issue_pr_handoff_slack --channel C0ALG01DLJV --timeout 600
 
 # GitHub webhook eval examples
 uv run python scripts/eval_github_e2e.py --scenario github_issue_pr_handoff_github --repo VibeTechnologies/vibeteam-eval-hello-world --issue 3 --pr 1 --timeout 600

--- a/docs/tests.md
+++ b/docs/tests.md
@@ -70,10 +70,10 @@ export $( < .env) && .venv/bin/python -m pytest tests/ -v
 .venv/bin/python -m pytest tests/test_openhands_service_integration.py -v --run-integration -s
 
 # E2E evaluation (posts to real Slack)
-uv run python scripts/eval_slack_e2e.py --scenario support_400_errors --channel C0AATPSADB8 --timeout 600
-uv run python scripts/eval_slack_e2e.py --scenario software_engineer_pr_attribution --channel C0AATPSADB8 --timeout 600
-uv run python scripts/eval_slack_e2e.py --scenario software_engineer_github_app_hello_world --channel C0AATPSADB8 --timeout 600
-uv run python scripts/eval_slack_e2e.py --scenario github_issue_pr_handoff_slack --channel C0AATPSADB8 --timeout 600
+uv run python scripts/eval_slack_e2e.py --scenario support_400_errors --channel C0ALG01DLJV --timeout 600
+uv run python scripts/eval_slack_e2e.py --scenario software_engineer_pr_attribution --channel C0ALG01DLJV --timeout 600
+uv run python scripts/eval_slack_e2e.py --scenario software_engineer_github_app_hello_world --channel C0ALG01DLJV --timeout 600
+uv run python scripts/eval_slack_e2e.py --scenario github_issue_pr_handoff_slack --channel C0ALG01DLJV --timeout 600
 
 `github_issue_pr_handoff_slack` validates cross-agent handoff comments across issue and PR threads in the eval repo.
 

--- a/scripts/eval_slack_e2e.py
+++ b/scripts/eval_slack_e2e.py
@@ -19,7 +19,7 @@ Usage:
     python scripts/eval_slack_e2e.py --message "@SupportEngineer check Sentry for errors"
     python scripts/eval_slack_e2e.py --channel C0123456789 --skip-eval
     python scripts/eval_slack_e2e.py --list-scenarios
-    python scripts/eval_slack_e2e.py --scenario stripe_webhook_failure --thread-ts 1770710833.425539 --channel C0AATPSADB8
+    python scripts/eval_slack_e2e.py --scenario stripe_webhook_failure --thread-ts 1770710833.425539 --channel C0ALG01DLJV
 
 Environment Variables:
     SLACK_BOT_TOKEN: Slack bot OAuth token (required)
@@ -1592,6 +1592,100 @@ def _load_role_bot_user_ids() -> dict[str, str]:
     return mapping
 
 
+def _slack_error_code(exc: Exception) -> str:
+    """Best-effort extraction of Slack API error code from an exception."""
+    response = getattr(exc, "response", None)
+    if response is None:
+        return ""
+
+    try:
+        error = response.get("error")
+        if isinstance(error, str):
+            return error
+    except Exception:
+        pass
+
+    data = getattr(response, "data", None)
+    if isinstance(data, dict):
+        error = data.get("error")
+        if isinstance(error, str):
+            return error
+
+    return ""
+
+
+def _ensure_slack_role_apps_in_channel(
+    channel: str,
+    ingress_connector: SlackConnector,
+    role_bot_user_ids: dict[str, str] | None = None,
+) -> None:
+    """Ensure ingress + role app bots are present in the eval channel."""
+    channel_id = ingress_connector._resolve_channel(channel)
+    role_bot_user_ids = role_bot_user_ids or _load_role_bot_user_ids()
+
+    print(">>> Preflight: Ensuring Slack app membership in channel")
+    print(f"    Target channel: {channel_id}")
+
+    joined = ingress_connector.join_channel(channel_id)
+    if joined:
+        print("    Ingress app joined channel (or was joinable).")
+    else:
+        print("    Ingress app join returned false (likely already in channel or private channel).")
+
+    members: set[str] | None = None
+    try:
+        response = ingress_connector.client.conversations_members(channel=channel_id, limit=1000)
+        members = {str(member) for member in response.get("members", [])}
+    except Exception as exc:
+        print(
+            "    WARNING: Could not list channel members via ingress app "
+            f"({exc}). Will attempt explicit role joins/invites."
+        )
+
+    if not role_bot_user_ids:
+        print("    WARNING: No role-scoped Slack bot tokens resolved; skipping role app membership checks.")
+        return
+
+    role_entries = sorted(role_bot_user_ids.items(), key=lambda item: item[1])
+    for user_id, role in role_entries:
+        role_display = ROLE_DISPLAY.get(role, role)
+        token_key = f"SLACK_BOT_TOKEN_{role.upper()}"
+        role_token = os.environ.get(token_key, "").strip()
+        if not role_token:
+            print(f"    WARNING: Missing {token_key}; cannot ensure {role_display} app membership.")
+            continue
+
+        if members is not None and user_id in members:
+            print(f"    ✅ {role_display} already in channel.")
+            continue
+
+        role_joined = False
+        try:
+            role_connector = SlackConnector(token=role_token)
+            role_joined = role_connector.join_channel(channel_id)
+        except Exception as exc:
+            print(f"    WARNING: {role_display} self-join attempt failed: {exc}")
+
+        if role_joined:
+            print(f"    ✅ {role_display} joined channel via role token.")
+            if members is not None:
+                members.add(user_id)
+            continue
+
+        try:
+            ingress_connector.client.conversations_invite(channel=channel_id, users=user_id)
+            print(f"    ✅ Invited {role_display} via ingress app.")
+            if members is not None:
+                members.add(user_id)
+        except Exception as exc:
+            error = _slack_error_code(exc)
+            if error in {"already_in_channel", "already_invited", "cant_invite_self"}:
+                print(f"    ✅ {role_display} invite not needed ({error}).")
+            else:
+                detail = f" ({error})" if error else ""
+                print(f"    WARNING: Failed to invite {role_display}{detail}: {exc}")
+
+
 # ==============================================================================
 # Azure OpenAI Model for DeepEval
 # ==============================================================================
@@ -2714,6 +2808,9 @@ async def run_evaluation(
         print(f"Wait Timeout: {wait_timeout}s")
     print()
 
+    await asyncio.to_thread(_ensure_slack_role_apps_in_channel, channel, slack, role_bot_user_ids)
+    print()
+
     user_message = scenario["message"]
     follow_up_messages = scenario.get("follow_up_messages", [])
     post_follow_up_messages = bool(scenario.get("post_follow_up_messages", True))
@@ -3408,7 +3505,7 @@ Examples:
   python scripts/eval_slack_e2e.py --message "@SupportEngineer check Sentry for errors"
   python scripts/eval_slack_e2e.py --channel C0123456789 --skip-eval
   python scripts/eval_slack_e2e.py --list-scenarios
-  python scripts/eval_slack_e2e.py --scenario stripe_webhook_failure --thread-ts 1770710833.425539 --channel C0AATPSADB8
+  python scripts/eval_slack_e2e.py --scenario stripe_webhook_failure --thread-ts 1770710833.425539 --channel C0ALG01DLJV
   python scripts/eval_slack_e2e.py --scenario support_400_errors --use-async
         """,
     )

--- a/tests/test_slack_role_tokens.py
+++ b/tests/test_slack_role_tokens.py
@@ -98,6 +98,74 @@ class TestRoleScopedApiCalls:
             assert headers["Authorization"] == "Bearer xoxb-support"
 
     @pytest.mark.asyncio
+    @pytest.mark.parametrize("error_code", ["account_inactive", "not_in_channel"])
+    async def test_send_slack_message_falls_back_to_ingress_token(self, error_code: str):
+        from vibeteam.gateway.routes.slack import send_slack_message
+
+        with (
+            patch.dict(
+                "os.environ",
+                {"SLACK_BOT_TOKEN_SOFTWARE_ENGINEER": "xoxb-software"},
+                clear=False,
+            ),
+            patch("vibeteam.gateway.routes.slack.config") as mock_config,
+            patch("httpx.AsyncClient") as mock_client_cls,
+        ):
+            mock_config.SLACK_BOT_TOKEN = "xoxb-ingress"
+
+            first_response = MagicMock()
+            first_response.json.return_value = {"ok": False, "error": error_code}
+            second_response = MagicMock()
+            second_response.json.return_value = {"ok": True, "ts": "2222.3333"}
+
+            mock_client = AsyncMock()
+            mock_client.post.side_effect = [first_response, second_response]
+            mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+            mock_client.__aexit__ = AsyncMock(return_value=False)
+            mock_client_cls.return_value = mock_client
+
+            ts = await send_slack_message(
+                "C_TEST", "hello", "1111.2222", role="software_engineer"
+            )
+            assert ts == "2222.3333"
+            assert mock_client.post.call_count == 2
+
+            first_headers = mock_client.post.call_args_list[0].kwargs["headers"]
+            second_headers = mock_client.post.call_args_list[1].kwargs["headers"]
+            assert first_headers["Authorization"] == "Bearer xoxb-software"
+            assert second_headers["Authorization"] == "Bearer xoxb-ingress"
+
+    @pytest.mark.asyncio
+    async def test_send_slack_message_does_not_fallback_for_non_retryable_error(self):
+        from vibeteam.gateway.routes.slack import send_slack_message
+
+        with (
+            patch.dict(
+                "os.environ",
+                {"SLACK_BOT_TOKEN_SOFTWARE_ENGINEER": "xoxb-software"},
+                clear=False,
+            ),
+            patch("vibeteam.gateway.routes.slack.config") as mock_config,
+            patch("httpx.AsyncClient") as mock_client_cls,
+        ):
+            mock_config.SLACK_BOT_TOKEN = "xoxb-ingress"
+
+            first_response = MagicMock()
+            first_response.json.return_value = {"ok": False, "error": "invalid_auth"}
+
+            mock_client = AsyncMock()
+            mock_client.post.return_value = first_response
+            mock_client.__aenter__ = AsyncMock(return_value=mock_client)
+            mock_client.__aexit__ = AsyncMock(return_value=False)
+            mock_client_cls.return_value = mock_client
+
+            ts = await send_slack_message(
+                "C_TEST", "hello", "1111.2222", role="software_engineer"
+            )
+            assert ts is None
+            assert mock_client.post.call_count == 1
+
+    @pytest.mark.asyncio
     async def test_set_thread_status_uses_role_assistant_token(self):
         from vibeteam.gateway.routes.slack import set_thread_status
 

--- a/vibeteam/gateway/routes/slack.py
+++ b/vibeteam/gateway/routes/slack.py
@@ -850,6 +850,8 @@ async def send_slack_message(
         logger.warning("SLACK_BOT_TOKEN not set, cannot send message")
         return None
 
+    retryable_fallback_errors = {"account_inactive", "not_in_channel"}
+
     try:
         payload: dict[str, Any] = {
             "channel": channel,
@@ -858,21 +860,53 @@ async def send_slack_message(
         if thread_ts:
             payload["thread_ts"] = thread_ts
 
-        async with httpx.AsyncClient() as client:
-            response = await client.post(
-                "https://slack.com/api/chat.postMessage",
-                headers={
-                    "Authorization": f"Bearer {bot_token}",
-                    "Content-Type": "application/json",
-                },
-                json=payload,
-            )
-            result = response.json()
-            if not result.get("ok"):
-                logger.error(f"Slack API error: {result.get('error')}")
-                return None
+        async def _post_message_with_token(token: str) -> dict[str, Any]:
+            async with httpx.AsyncClient() as client:
+                response = await client.post(
+                    "https://slack.com/api/chat.postMessage",
+                    headers={
+                        "Authorization": f"Bearer {token}",
+                        "Content-Type": "application/json",
+                    },
+                    json=payload,
+                )
+                data = response.json()
+                if isinstance(data, dict):
+                    return cast(dict[str, Any], data)
+                return {"ok": False, "error": "invalid_response"}
+
+        result = await _post_message_with_token(bot_token)
+        if result.get("ok"):
             logger.info(f"Sent message to {channel}")
-            return result.get("ts")
+            return cast(str | None, result.get("ts"))
+
+        error_code = cast(str, result.get("error") or "unknown_error")
+        # Role-scoped bot identities can be channel-scoped or temporarily inactive.
+        # In those cases, retry with the ingress bot token to avoid dropping replies.
+        if (
+            role
+            and error_code in retryable_fallback_errors
+            and config.SLACK_BOT_TOKEN
+            and config.SLACK_BOT_TOKEN != bot_token
+        ):
+            logger.warning(
+                "Slack send failed for role token (%s: %s); retrying with ingress token",
+                role,
+                error_code,
+            )
+            fallback_result = await _post_message_with_token(config.SLACK_BOT_TOKEN)
+            if fallback_result.get("ok"):
+                logger.info(
+                    "Sent message to %s via ingress token fallback for role %s", channel, role
+                )
+                return cast(str | None, fallback_result.get("ts"))
+            logger.error(
+                "Slack API error after ingress fallback: %s", fallback_result.get("error")
+            )
+            return None
+
+        logger.error(f"Slack API error: {error_code}")
+        return None
 
     except Exception as e:
         logger.exception(f"Failed to send Slack message: {e}")


### PR DESCRIPTION
## Summary
- add fallback in gateway Slack send path: when role-scoped bot post fails with `account_inactive` or `not_in_channel`, retry via ingress bot token so replies are not silently dropped
- add unit tests for fallback behavior in `tests/test_slack_role_tokens.py`
- update eval/docs/examples to use `#vibe-team` channel (`C0ALG01DLJV`)
- add eval preflight in `scripts/eval_slack_e2e.py` to check/attempt channel membership for role apps

## Problem
Slack evals in `#vibe-team` were routing but many role replies were missing due Slack API failures on post (`account_inactive`, `not_in_channel`).

## Validation
- `uv run python -m pytest tests/test_slack_role_tokens.py -q` (10 passed)
- `uv run python -m pytest tests/test_async_callback.py -q` (60 passed)
- `uv run python -m pytest tests/test_eval_rescore.py -q` (55 passed)
- Slack eval reruns in `C0ALG01DLJV` attached in issue updates

Closes #398